### PR TITLE
TLS support with both `rustls` and `native-tls`

### DIFF
--- a/examples/protocol_test/Cargo.toml
+++ b/examples/protocol_test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe2o3-amqp = { version = "0.0.3", path = "../../fe2o3-amqp" }
+fe2o3-amqp = { version = "0.0.4", path = "../../fe2o3-amqp" }
 tokio = { version = "1.11.0", features = ["net", "macros", "rt-multi-thread", "time"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.9"

--- a/examples/protocol_test/Cargo.toml
+++ b/examples/protocol_test/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe2o3-amqp = {version = "0.0.3", path = "../../fe2o3-amqp"}
+fe2o3-amqp = { version = "0.0.3", path = "../../fe2o3-amqp" }
 tokio = { version = "1.11.0", features = ["net", "macros", "rt-multi-thread", "time"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.9"
-tokio-rustls = "0.23"
+tokio-native-tls = "0.3.0"
+native-tls = "0.2.8"

--- a/examples/protocol_test/src/bin/sender.rs
+++ b/examples/protocol_test/src/bin/sender.rs
@@ -13,10 +13,6 @@ use fe2o3_amqp::types::definitions::SenderSettleMode;
 use fe2o3_amqp::types::messaging::message::BodySection;
 use fe2o3_amqp::types::messaging::Message;
 use tokio::net::TcpStream;
-use tokio_rustls::TlsConnector;
-use tokio_rustls::rustls::ClientConfig;
-use tokio_rustls::rustls::RootCertStore;
-use tokio_rustls::rustls::ServerName;
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 
@@ -38,13 +34,14 @@ async fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    let stream = TcpStream::connect("localhost:5671").await.unwrap();
-    let config = ClientConfig::builder()
-        .with_safe_defaults()
-        .with_root_certificates(RootCertStore::empty())
-        .with_no_client_auth();
-    let connector = TlsConnector::from(Arc::new(config));
-    let domain = ServerName::try_from("localhost").unwrap();
+    let addr = "localhost:5671";
+    let domain = "localhost";
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let connector = native_tls::TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+    let connector = tokio_native_tls::TlsConnector::from(connector);
     let tls_stream = connector.connect(domain, stream).await.unwrap();
 
     // let mut connection = Connection::open("connection-1", "amqp://guest:guest@localhost:5671")

--- a/examples/protocol_test/src/bin/sender.rs
+++ b/examples/protocol_test/src/bin/sender.rs
@@ -49,6 +49,7 @@ async fn main() {
     //     .unwrap();
     let mut connection = Connection::builder()
         .container_id("connection-1")
+        .scheme("amqp")
         .max_frame_size(1000)
         .channel_max(9)
         .idle_time_out(50_000 as u32)

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -14,10 +14,10 @@ readme = "Readme.md"
 
 [features]
 
-default = []
+default = ["rustls"]
 
 rustls = ["tokio-rustls", "librustls", "webpki-roots"]
-native-tls = ["tokio-native-tls"]
+native-tls = ["tokio-native-tls", "libnative-tls"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
@@ -48,6 +48,7 @@ tracing = "0.1"
 
 # Optional deps
 tokio-rustls = { version = "0.23", optional = true }
-tokio-native-tls = { version = "0.3", optional = true }
 librustls = { package = "rustls", version = "0.20", optional = true }
 webpki-roots = { version = "0.22.2", optional = true }
+tokio-native-tls = { version = "0.3", optional = true }
+libnative-tls = { package = "native-tls", version = "0.2.8", optional = true }

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -12,6 +12,13 @@ readme = "Readme.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+
+default = []
+
+rustls = ["tokio-rustls", "librustls", "webpki-roots"]
+native-tls = ["tokio-native-tls"]
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-test = { version = "0.4" }
@@ -36,7 +43,11 @@ slab = "0.4"
 tokio-stream = { version = "0.1", features = ["time"] }
 async-trait = "0.1"
 crossbeam = "0.8"
-tokio-rustls = "0.23"
-rustls = "0.20"
 serde_bytes = "0.11"
 tracing = "0.1"
+
+# Optional deps
+tokio-rustls = { version = "0.23", optional = true }
+tokio-native-tls = { version = "0.3", optional = true }
+librustls = { package = "rustls", version = "0.20", optional = true }
+webpki-roots = { version = "0.22.2", optional = true }

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -791,6 +791,12 @@ impl<'a> Builder<'a, WithContainerId, tokio_rustls::TlsConnector> {
     }
 
     /// Open with an IO that implements `AsyncRead` and `AsyncWrite`
+    /// 
+    /// # TLS
+    /// 
+    /// If the `scheme` field is `"amqps"`, the builder will attempt to start with
+    /// exchanging TLS protocol header and establish TLS stream using the user-supplied 
+    /// `tokio_rustls::TlsConnector`.
     pub async fn open_with_stream<Io>(
         self,
         stream: Io,
@@ -899,6 +905,12 @@ impl<'a> Builder<'a, WithContainerId, tokio_native_tls::TlsConnector> {
     }
 
     /// Open with an IO that implements `AsyncRead` and `AsyncWrite`
+    /// 
+    /// # TLS
+    /// 
+    /// If the `scheme` field is `"amqps"`, the builder will attempt to start with
+    /// exchanging TLS protocol header and establish TLS stream using the user-supplied 
+    /// `tokio_rustls::TlsConnector`.
     pub async fn open_with_stream<Io>(
         self,
         stream: Io,

--- a/fe2o3-amqp/src/connection/error.rs
+++ b/fe2o3-amqp/src/connection/error.rs
@@ -120,9 +120,9 @@ pub enum OpenError {
     #[error("Invalid domain")]
     InvalidDomain,
 
-    // /// Missing client config for TLS connection
-    // #[error("TLS client config is not found")]
-    // TlsClientConfigNotFound,
+    /// Missing client config for TLS connection
+    #[error("TLS connector is not found")]
+    TlsConnectorNotFound,
 
     /// Scheme is invalid or not found
     #[error(r#"Invalid scheme. Only "amqp" and "amqps" are supported."#)]

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -187,9 +187,6 @@ impl ConnectionHandle {
 /// ## TLS
 ///
 /// TLS is supported with `rustls` by setting the url scheme to `"amqps"`. 
-/// The user must use the builder to supply a custom `ClientConfig` for the TLS connection. 
-/// If there is no custom `ClientConfig`, the TLS handshake will use the the following
-/// config.
 /// 
 /// ```rust, ignore
 /// ClientConfig::builder()
@@ -210,7 +207,6 @@ impl ConnectionHandle {
 /// // Set custom `ClientConfig`
 /// let connection = Connection::builder()
 ///     .container_id("connection-1")
-///     .client_config(config)
 ///     .open("amqps://localhost:5672")
 ///     .await.unwrap();
 /// ```

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -267,7 +267,7 @@ pub struct Connection {
 /* ------------------------------- Public API ------------------------------- */
 impl Connection {
     /// Creates a Builder for [`Connection`]
-    pub fn builder<'a>() -> builder::Builder<'a, WithoutContainerId> {
+    pub fn builder<'a>() -> builder::Builder<'a, WithoutContainerId, ()> {
         builder::Builder::new()
     }
 

--- a/fe2o3-amqp/src/transport/mod.rs
+++ b/fe2o3-amqp/src/transport/mod.rs
@@ -316,7 +316,7 @@ where
     ProtocolHeader::try_from(buf)
         .map_err(|buf| NegotiationError::Io(std::io::Error::new(
             std::io::ErrorKind::Other,
-            "Invalid protocol header",
+            format!("Invalid protocol header {:?}", buf),
         )))
 }
 

--- a/fe2o3-amqp/src/transport/protocol_header.rs
+++ b/fe2o3-amqp/src/transport/protocol_header.rs
@@ -50,6 +50,15 @@ impl ProtocolHeader {
         }
     }
 
+    /// Returns whether the protocol id is AMQP
+    pub fn is_amqp(&self) -> bool {
+        match self.id {
+            ProtocolId::Amqp => true,
+            ProtocolId::Tls => false,
+            ProtocolId::Sasl => false,
+        }
+    }
+
     /// Creates a TLS protocol header
     pub fn tls() -> Self {
         Self {
@@ -58,11 +67,29 @@ impl ProtocolHeader {
         }
     }
 
+    /// Returns whether the protocol id is TLS
+    pub fn is_tls(&self) -> bool {
+        match self.id {
+            ProtocolId::Amqp => false,
+            ProtocolId::Tls => true,
+            ProtocolId::Sasl => false,
+        }
+    }
+
     /// Creates a SASL protocol header
     pub fn sasl() -> Self {
         Self {
             id: ProtocolId::Sasl,
             ..Default::default()
+        }
+    }
+
+    /// Returns whether the protocol id is SASL
+    pub fn is_sasl(&self) -> bool {
+        match self.id {
+            ProtocolId::Amqp => false,
+            ProtocolId::Tls => false,
+            ProtocolId::Sasl => true,
         }
     }
 }


### PR DESCRIPTION
1. TLS is only supported if either `"rustls"` or `"native-tls"` feature is enabled.
2. Default `TlsConnector` will depend on the the particular feature enabled.
3. `Connection`'s `Builder`'s `client_config` field is now replaced with `tls_connector` which allows user to supply custom `TlsConnector` for TLS handshake.