### PR TITLE
Reduce look-ups needed for incoming session frames and link frames

### DIFF
--- a/examples/protocol_test/Cargo.toml
+++ b/examples/protocol_test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe2o3-amqp = { version = "0.0.9", path = "../../fe2o3-amqp", features = ["acceptor", "transaction"] }
+fe2o3-amqp = { version = "0.0.10", path = "../../fe2o3-amqp", features = ["acceptor", "transaction"] }
 tokio = { version = "1.11.0", features = ["net", "macros", "rt-multi-thread", "time"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.9"

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -17,15 +17,15 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+# default = []
 
-# dev defaults
-# default = [
-#     "acceptor",
-#     "rustls",
-#     "native-tls",
-#     "transaction",
-# ]
+## dev defaults
+default = [
+    "acceptor",
+    "rustls",
+    "native-tls",
+    "transaction",
+]
 
 
 transaction = ["fe2o3-amqp-types/transaction"]

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -69,3 +69,4 @@ librustls = { package = "rustls", version = "0.20", optional = true }
 webpki-roots = { version = "0.22.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 libnative-tls = { package = "native-tls", version = "0.2.8", optional = true }
+crossbeam = "0.8.1"

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -69,4 +69,3 @@ librustls = { package = "rustls", version = "0.20", optional = true }
 webpki-roots = { version = "0.22.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 libnative-tls = { package = "native-tls", version = "0.2.8", optional = true }
-crossbeam = "0.8.1"

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"
@@ -17,15 +17,15 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-# default = []
+default = []
 
 ## dev defaults
-default = [
-    "acceptor",
-    "rustls",
-    "native-tls",
-    "transaction",
-]
+# default = [
+#     "acceptor",
+#     "rustls",
+#     "native-tls",
+#     "transaction",
+# ]
 
 
 transaction = ["fe2o3-amqp-types/transaction"]

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.10
+
+1. Reduced lookups needed for incoming session frames and link frames
+
 ## 0.0.9
 
 1. Implemented client side transaction

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -22,7 +22,7 @@ use crate::{
         self, engine::ConnectionEngine, ConnectionHandle, Error, OpenError,
         DEFAULT_CONTROL_CHAN_BUF,
     },
-    endpoint::{self, OutgoingChannel, IncomingChannel},
+    endpoint::{self, IncomingChannel, OutgoingChannel},
     frames::{
         amqp::{self, Frame},
         sasl,
@@ -582,12 +582,20 @@ impl endpoint::Connection for ListenerConnection {
     }
 
     #[inline]
-    async fn on_incoming_open(&mut self, channel: IncomingChannel, open: Open) -> Result<(), Self::Error> {
+    async fn on_incoming_open(
+        &mut self,
+        channel: IncomingChannel,
+        open: Open,
+    ) -> Result<(), Self::Error> {
         self.connection.on_incoming_open(channel, open).await
     }
 
     #[inline]
-    async fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error> {
+    async fn on_incoming_begin(
+        &mut self,
+        channel: IncomingChannel,
+        begin: Begin,
+    ) -> Result<(), Self::Error> {
         // This should remain mostly the same
         match self.connection.on_incoming_begin_inner(channel, &begin)? {
             Some(relay) => {
@@ -608,7 +616,10 @@ impl endpoint::Connection for ListenerConnection {
                 // remotely initiated session
 
                 // Here we will send the begin frame out to get processed
-                let incoming_session = IncomingSession { channel: channel.0, begin };
+                let incoming_session = IncomingSession {
+                    channel: channel.0,
+                    begin,
+                };
                 self.session_listener
                     .send(incoming_session)
                     .await
@@ -625,12 +636,20 @@ impl endpoint::Connection for ListenerConnection {
     }
 
     #[inline]
-    async fn on_incoming_end(&mut self, channel: IncomingChannel, end: End) -> Result<(), Self::Error> {
+    async fn on_incoming_end(
+        &mut self,
+        channel: IncomingChannel,
+        end: End,
+    ) -> Result<(), Self::Error> {
         self.connection.on_incoming_end(channel, end).await
     }
 
     #[inline]
-    async fn on_incoming_close(&mut self, channel: IncomingChannel, close: Close) -> Result<(), Self::Error> {
+    async fn on_incoming_close(
+        &mut self,
+        channel: IncomingChannel,
+        close: Close,
+    ) -> Result<(), Self::Error> {
         self.connection.on_incoming_close(channel, close).await
     }
 

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -22,7 +22,7 @@ use crate::{
         self, engine::ConnectionEngine, ConnectionHandle, Error, OpenError,
         DEFAULT_CONTROL_CHAN_BUF,
     },
-    endpoint,
+    endpoint::{self, OutgoingChannel, IncomingChannel},
     frames::{
         amqp::{self, Frame},
         sasl,
@@ -572,28 +572,28 @@ impl endpoint::Connection for ListenerConnection {
     fn allocate_session(
         &mut self,
         tx: mpsc::Sender<crate::session::frame::SessionIncomingItem>,
-    ) -> Result<(u16, crate::connection::engine::SessionId), Self::AllocError> {
+    ) -> Result<OutgoingChannel, Self::AllocError> {
         self.connection.allocate_session(tx)
     }
 
     #[inline]
-    fn deallocate_session(&mut self, session_id: usize) {
-        self.connection.deallocate_session(session_id)
+    fn deallocate_session(&mut self, outgoing_channel: OutgoingChannel) {
+        self.connection.deallocate_session(outgoing_channel)
     }
 
     #[inline]
-    async fn on_incoming_open(&mut self, channel: u16, open: Open) -> Result<(), Self::Error> {
+    async fn on_incoming_open(&mut self, channel: IncomingChannel, open: Open) -> Result<(), Self::Error> {
         self.connection.on_incoming_open(channel, open).await
     }
 
     #[inline]
-    async fn on_incoming_begin(&mut self, channel: u16, begin: Begin) -> Result<(), Self::Error> {
+    async fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error> {
         // This should remain mostly the same
         match self.connection.on_incoming_begin_inner(channel, &begin)? {
-            Some(session_id) => {
+            Some(relay) => {
                 // forward begin to session
                 let sframe = SessionFrame::new(channel, SessionFrameBody::Begin(begin));
-                self.connection.send_to_session(session_id, sframe).await?;
+                relay.send(sframe).await?;
             }
             None => {
                 // If a session is locally initiated, the remote-channel MUST NOT be set. When an endpoint responds
@@ -608,7 +608,7 @@ impl endpoint::Connection for ListenerConnection {
                 // remotely initiated session
 
                 // Here we will send the begin frame out to get processed
-                let incoming_session = IncomingSession { channel, begin };
+                let incoming_session = IncomingSession { channel: channel.0, begin };
                 self.session_listener
                     .send(incoming_session)
                     .await
@@ -625,12 +625,12 @@ impl endpoint::Connection for ListenerConnection {
     }
 
     #[inline]
-    async fn on_incoming_end(&mut self, channel: u16, end: End) -> Result<(), Self::Error> {
+    async fn on_incoming_end(&mut self, channel: IncomingChannel, end: End) -> Result<(), Self::Error> {
         self.connection.on_incoming_end(channel, end).await
     }
 
     #[inline]
-    async fn on_incoming_close(&mut self, channel: u16, close: Close) -> Result<(), Self::Error> {
+    async fn on_incoming_close(&mut self, channel: IncomingChannel, close: Close) -> Result<(), Self::Error> {
         self.connection.on_incoming_close(channel, close).await
     }
 
@@ -659,14 +659,14 @@ impl endpoint::Connection for ListenerConnection {
     #[inline]
     fn on_outgoing_begin(
         &mut self,
-        outgoing_channel: u16,
+        outgoing_channel: OutgoingChannel,
         begin: Begin,
     ) -> Result<amqp::Frame, Self::Error> {
         if let Some(remote_channel) = begin.remote_channel {
-            let session_id = self
+            let relay = self
                 .connection
                 .session_by_outgoing_channel
-                .get(&outgoing_channel)
+                .get(outgoing_channel.0 as usize)
                 .ok_or_else(|| {
                     Error::amqp_error(
                         AmqpError::InternalError,
@@ -676,7 +676,7 @@ impl endpoint::Connection for ListenerConnection {
 
             self.connection
                 .session_by_incoming_channel
-                .insert(remote_channel, *session_id);
+                .insert(IncomingChannel(remote_channel), relay.clone());
         }
 
         self.connection.on_outgoing_begin(outgoing_channel, begin)
@@ -685,7 +685,7 @@ impl endpoint::Connection for ListenerConnection {
     #[inline]
     fn on_outgoing_end(
         &mut self,
-        channel: u16,
+        channel: OutgoingChannel,
         end: fe2o3_amqp_types::performatives::End,
     ) -> Result<amqp::Frame, Self::Error> {
         self.connection.on_outgoing_end(channel, end)
@@ -694,16 +694,16 @@ impl endpoint::Connection for ListenerConnection {
     #[inline]
     fn session_tx_by_incoming_channel(
         &mut self,
-        channel: u16,
-    ) -> Option<&mut mpsc::Sender<crate::session::frame::SessionIncomingItem>> {
+        channel: IncomingChannel,
+    ) -> Option<&mpsc::Sender<crate::session::frame::SessionIncomingItem>> {
         self.connection.session_tx_by_incoming_channel(channel)
     }
 
     #[inline]
     fn session_tx_by_outgoing_channel(
         &mut self,
-        channel: u16,
-    ) -> Option<&mut mpsc::Sender<crate::session::frame::SessionIncomingItem>> {
+        channel: OutgoingChannel,
+    ) -> Option<&mpsc::Sender<crate::session::frame::SessionIncomingItem>> {
         self.connection.session_tx_by_outgoing_channel(channel)
     }
 }

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -19,7 +19,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
 
 use crate::{
-    endpoint::LinkAttach,
+    endpoint::{LinkAttach, InputHandle},
     link::{
         self,
         delivery::UnsettledMessage,
@@ -266,7 +266,7 @@ impl LinkAcceptor {
         };
 
         // Allocate link in session
-        let input_handle = remote_attach.handle.clone();
+        let input_handle = InputHandle::from(remote_attach.handle.clone());
         let output_handle = super::session::allocate_incoming_link(
             &mut session.control,
             remote_attach.name.clone(),
@@ -374,7 +374,7 @@ impl LinkAcceptor {
         };
 
         // Allocate link in session
-        let input_handle = remote_attach.handle.clone();
+        let input_handle = InputHandle::from(remote_attach.handle.clone());
         let output_handle = super::session::allocate_incoming_link(
             &mut session.control,
             remote_attach.name.clone(),

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -27,7 +27,7 @@ use crate::{
         role,
         sender::SenderInner,
         state::{LinkFlowState, LinkFlowStateInner, LinkState},
-        AttachError, LinkFrame, LinkHandle, LinkIncomingItem, ReceiverFlowState, SenderFlowState,
+        AttachError, LinkFrame, LinkRelay, LinkIncomingItem, ReceiverFlowState, SenderFlowState,
     },
     util::{Consumer, Initialized, Producer},
     Receiver, Sender,
@@ -256,7 +256,7 @@ impl LinkAcceptor {
         // Comparing unsettled should be taken care of in `on_incoming_attach`
         let unsettled = Arc::new(RwLock::new(BTreeMap::new()));
         // let state_code = Arc::new(AtomicU8::new(0));
-        let link_handle = LinkHandle::Receiver {
+        let link_handle = LinkRelay::Receiver {
             tx: incoming_tx,
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),
@@ -365,7 +365,7 @@ impl LinkAcceptor {
 
         let unsettled = Arc::new(RwLock::new(BTreeMap::new()));
         // let state_code = Arc::new(AtomicU8::new(0));
-        let link_handle = LinkHandle::Sender {
+        let link_handle = LinkRelay::Sender {
             tx: incoming_tx,
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -19,7 +19,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
 
 use crate::{
-    endpoint::{LinkAttach, InputHandle},
+    endpoint::{InputHandle, LinkAttach},
     link::{
         self,
         delivery::UnsettledMessage,
@@ -27,7 +27,7 @@ use crate::{
         role,
         sender::SenderInner,
         state::{LinkFlowState, LinkFlowStateInner, LinkState},
-        AttachError, LinkFrame, LinkRelay, LinkIncomingItem, ReceiverFlowState, SenderFlowState,
+        AttachError, LinkFrame, LinkIncomingItem, LinkRelay, ReceiverFlowState, SenderFlowState,
     },
     util::{Consumer, Initialized, Producer},
     Receiver, Sender,
@@ -258,6 +258,7 @@ impl LinkAcceptor {
         // let state_code = Arc::new(AtomicU8::new(0));
         let link_handle = LinkRelay::Receiver {
             tx: incoming_tx,
+            output_handle: (),
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),
             receiver_settle_mode: rcv_settle_mode.clone(),
@@ -367,6 +368,7 @@ impl LinkAcceptor {
         // let state_code = Arc::new(AtomicU8::new(0));
         let link_handle = LinkRelay::Sender {
             tx: incoming_tx,
+            output_handle: (),
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),
             receiver_settle_mode: remote_attach.rcv_settle_mode.clone(),

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -8,7 +8,7 @@ use std::io;
 
 use async_trait::async_trait;
 use fe2o3_amqp_types::{
-    definitions::{self, AmqpError, Handle, SessionError},
+    definitions::{self, AmqpError, SessionError},
     performatives::{Attach, Begin, Detach, Disposition, End, Flow, Transfer},
     states::SessionState,
 };
@@ -19,7 +19,9 @@ use tracing::instrument;
 
 use crate::{
     control::{ConnectionControl, SessionControl},
-    endpoint::{self, LinkFlow, Session, OutgoingChannel, InputHandle, OutputHandle, IncomingChannel},
+    endpoint::{
+        self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle, Session,
+    },
     link::{LinkFrame, LinkRelay},
     session::{
         self,
@@ -48,7 +50,7 @@ impl ListenerSessionHandle {
 pub(crate) async fn allocate_incoming_link(
     control: &mut mpsc::Sender<SessionControl>,
     link_name: String,
-    link_handle: LinkRelay,
+    link_relay: LinkRelay<()>,
     input_handle: InputHandle,
 ) -> Result<OutputHandle, AllocLinkError> {
     let (responder, resp_rx) = oneshot::channel();
@@ -56,7 +58,7 @@ pub(crate) async fn allocate_incoming_link(
     control
         .send(SessionControl::AllocateIncomingLink {
             link_name,
-            link_handle,
+            link_relay,
             input_handle,
             responder,
         })
@@ -155,7 +157,10 @@ impl SessionAcceptor {
             self.0
                 .clone()
                 .into_session(session_control_tx.clone(), outgoing_channel, local_state);
-        session.on_incoming_begin(IncomingChannel(incoming_session.channel), incoming_session.begin)?;
+        session.on_incoming_begin(
+            IncomingChannel(incoming_session.channel),
+            incoming_session.begin,
+        )?;
 
         let listener_session = ListenerSession {
             session,
@@ -234,8 +239,6 @@ impl endpoint::Session for ListenerSession {
 
     type State = <session::Session as endpoint::Session>::State;
 
-    type LinkRelay = <session::Session as endpoint::Session>::LinkRelay;
-
     fn local_state(&self) -> &Self::State {
         self.session.local_state()
     }
@@ -251,7 +254,7 @@ impl endpoint::Session for ListenerSession {
     fn allocate_link(
         &mut self,
         link_name: String,
-        link_handle: Self::LinkRelay,
+        link_handle: Option<LinkRelay<()>>,
     ) -> Result<OutputHandle, Self::AllocError> {
         self.session.allocate_link(link_name, link_handle)
     }
@@ -259,18 +262,22 @@ impl endpoint::Session for ListenerSession {
     fn allocate_incoming_link(
         &mut self,
         link_name: String,
-        link_handle: LinkRelay,
+        link_handle: LinkRelay<()>,
         input_handle: InputHandle,
     ) -> Result<OutputHandle, Self::AllocError> {
         self.session
             .allocate_incoming_link(link_name, link_handle, input_handle)
     }
 
-    fn deallocate_link(&mut self, link_name: String) {
-        self.session.deallocate_link(link_name)
+    fn deallocate_link(&mut self, output_handle: OutputHandle) {
+        self.session.deallocate_link(output_handle)
     }
 
-    fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error> {
+    fn on_incoming_begin(
+        &mut self,
+        channel: IncomingChannel,
+        begin: Begin,
+    ) -> Result<(), Self::Error> {
         self.session.on_incoming_begin(channel, begin)
     }
 
@@ -279,42 +286,36 @@ impl endpoint::Session for ListenerSession {
         _channel: IncomingChannel,
         attach: Attach,
     ) -> Result<(), Self::Error> {
-        // Look up link handle by link name
-        match self.session.link_by_name.get(&attach.name) {
-            Some(output_handle) => match self.session.local_links.get_mut(output_handle.0 as usize)
-            {
-                Some(link) => {
+        match self.session.link_by_name.get_mut(&attach.name) {
+            Some(link) => match link.take() {
+                Some(mut relay) => {
                     // Only Sender need to update the receiver settle mode
                     // because the sender needs to echo a disposition if
                     // rcv-settle-mode is 1
                     if let LinkRelay::Sender {
                         receiver_settle_mode,
                         ..
-                    } = link
+                    } = &mut relay
                     {
                         *receiver_settle_mode = attach.rcv_settle_mode.clone();
                     }
 
                     let input_handle = attach.handle.clone().into(); // handle is just a wrapper around u32
+                    relay
+                        .send(LinkFrame::Attach(attach))
+                        .await
+                        .map_err(|_| Error::session_error(SessionError::UnattachedHandle, None))?;
                     self.session
                         .link_by_input_handle
-                        .insert(input_handle, output_handle.clone());
-                    match link.send(LinkFrame::Attach(attach)).await {
-                        Ok(_) => Ok(()),
-                        Err(_) => {
-                            // TODO: how should this error be handled?
-                            // End with UnattachedHandle?
-                            return Err(Error::session_error(SessionError::UnattachedHandle, None));
-                            // End session with unattached handle?
-                        }
-                    }
+                        .insert(input_handle, relay);
+                    Ok(())
                 }
                 None => {
                     // TODO: Resuming link
-                    return Err(Error::amqp_error(
+                    Err(Error::amqp_error(
                         AmqpError::NotImplemented,
                         "Link resumption is not supported yet".to_string(),
-                    ));
+                    ))
                 }
             },
             None => {
@@ -331,12 +332,16 @@ impl endpoint::Session for ListenerSession {
                         Some("Listener session handle must have been dropped".to_string()),
                     )
                 })?;
-                Ok(())
+                return Ok(());
             }
         }
     }
 
-    async fn on_incoming_flow(&mut self, channel: IncomingChannel, flow: Flow) -> Result<(), Self::Error> {
+    async fn on_incoming_flow(
+        &mut self,
+        channel: IncomingChannel,
+        flow: Flow,
+    ) -> Result<(), Self::Error> {
         self.session.on_incoming_flow(channel, flow).await
     }
 
@@ -369,7 +374,11 @@ impl endpoint::Session for ListenerSession {
         self.session.on_incoming_detach(channel, detach).await
     }
 
-    async fn on_incoming_end(&mut self, channel: IncomingChannel, end: End) -> Result<(), Self::Error> {
+    async fn on_incoming_end(
+        &mut self,
+        channel: IncomingChannel,
+        end: End,
+    ) -> Result<(), Self::Error> {
         self.session.on_incoming_end(channel, end).await
     }
 
@@ -403,10 +412,12 @@ impl endpoint::Session for ListenerSession {
 
     fn on_outgoing_transfer(
         &mut self,
+        input_handle: InputHandle,
         transfer: Transfer,
         payload: Payload,
     ) -> Result<SessionFrame, Self::Error> {
-        self.session.on_outgoing_transfer(transfer, payload)
+        self.session
+            .on_outgoing_transfer(input_handle, transfer, payload)
     }
 
     fn on_outgoing_disposition(

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -23,8 +23,6 @@ use crate::{endpoint, transport};
 use super::{heartbeat::HeartBeat, ConnectionState, Error};
 use super::{AllocSessionError, OpenError};
 
-pub(crate) type SessionId = usize;
-
 #[derive(Debug)]
 pub(crate) struct ConnectionEngine<Io, C> {
     transport: Transport<Io, amqp::Frame>,

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -162,7 +162,11 @@ where
     C::AllocError: Into<AllocSessionError>,
 {
     #[instrument(skip_all)]
-    async fn forward_to_session(&mut self, channel: IncomingChannel, frame: SessionFrame) -> Result<(), Error> {
+    async fn forward_to_session(
+        &mut self,
+        channel: IncomingChannel,
+        frame: SessionFrame,
+    ) -> Result<(), Error> {
         trace!(frame = ?frame);
         match &self.connection.local_state() {
             ConnectionState::Opened => {}

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -651,9 +651,6 @@ impl endpoint::Connection for Connection {
 
     #[instrument(skip_all)]
     fn on_outgoing_end(&mut self, channel: OutgoingChannel, end: End) -> Result<Frame, Self::Error> {
-        self.session_by_outgoing_channel
-            .try_remove(channel.0 as usize)
-            .ok_or_else(|| Error::amqp_error(AmqpError::NotFound, None))?;
         let frame = Frame::new(channel, FrameBody::End(end));
         Ok(frame)
     }

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -7,8 +7,8 @@ use fe2o3_amqp_types::{
 use tokio::sync::{mpsc::Sender, oneshot};
 
 use crate::{
-    connection::{AllocSessionError},
-    endpoint::{LinkFlow, OutgoingChannel, OutputHandle, InputHandle},
+    connection::AllocSessionError,
+    endpoint::{InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
     link::LinkRelay,
     session::{frame::SessionIncomingItem, AllocLinkError},
 };
@@ -43,16 +43,16 @@ pub(crate) enum SessionControl {
     End(Option<definitions::Error>),
     AllocateLink {
         link_name: String,
-        link_handle: LinkRelay,
+        link_relay: LinkRelay<()>,
         responder: oneshot::Sender<Result<OutputHandle, AllocLinkError>>,
     },
     AllocateIncomingLink {
         link_name: String,
-        link_handle: LinkRelay,
+        link_relay: LinkRelay<()>,
         input_handle: InputHandle,
         responder: oneshot::Sender<Result<OutputHandle, AllocLinkError>>,
     },
-    DeallocateLink(String),
+    DeallocateLink(OutputHandle),
     LinkFlow(LinkFlow),
     Disposition(Disposition),
 }
@@ -63,16 +63,16 @@ impl std::fmt::Display for SessionControl {
             SessionControl::End(_) => write!(f, "End"),
             SessionControl::AllocateLink {
                 link_name: _,
-                link_handle: _,
+                link_relay: _,
                 responder: _,
             } => write!(f, "AllocateLink"),
             SessionControl::AllocateIncomingLink {
                 link_name: _,
-                link_handle: _,
+                link_relay: _,
                 input_handle: _,
                 responder: _,
             } => write!(f, "AllocateIncomingLink"),
-            SessionControl::DeallocateLink(name) => write!(f, "DeallocateLink({})", name),
+            SessionControl::DeallocateLink(name) => write!(f, "DeallocateLink({:?})", name),
             SessionControl::LinkFlow(_) => write!(f, "LinkFlow"),
             SessionControl::Disposition(_) => write!(f, "Disposition"),
         }

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -1,14 +1,14 @@
 //! Controls for Connection, Session, and Link
 
 use fe2o3_amqp_types::{
-    definitions::{self, Handle},
+    definitions::{self},
     performatives::Disposition,
 };
 use tokio::sync::{mpsc::Sender, oneshot};
 
 use crate::{
     connection::{AllocSessionError},
-    endpoint::{LinkFlow, OutgoingChannel},
+    endpoint::{LinkFlow, OutgoingChannel, OutputHandle, InputHandle},
     link::LinkRelay,
     session::{frame::SessionIncomingItem, AllocLinkError},
 };
@@ -44,13 +44,13 @@ pub(crate) enum SessionControl {
     AllocateLink {
         link_name: String,
         link_handle: LinkRelay,
-        responder: oneshot::Sender<Result<Handle, AllocLinkError>>,
+        responder: oneshot::Sender<Result<OutputHandle, AllocLinkError>>,
     },
     AllocateIncomingLink {
         link_name: String,
         link_handle: LinkRelay,
-        input_handle: Handle,
-        responder: oneshot::Sender<Result<Handle, AllocLinkError>>,
+        input_handle: InputHandle,
+        responder: oneshot::Sender<Result<OutputHandle, AllocLinkError>>,
     },
     DeallocateLink(String),
     LinkFlow(LinkFlow),

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc::Sender, oneshot};
 use crate::{
     connection::{AllocSessionError},
     endpoint::{LinkFlow, OutgoingChannel},
-    link::LinkHandle,
+    link::LinkRelay,
     session::{frame::SessionIncomingItem, AllocLinkError},
 };
 
@@ -43,12 +43,12 @@ pub(crate) enum SessionControl {
     End(Option<definitions::Error>),
     AllocateLink {
         link_name: String,
-        link_handle: LinkHandle,
+        link_handle: LinkRelay,
         responder: oneshot::Sender<Result<Handle, AllocLinkError>>,
     },
     AllocateIncomingLink {
         link_name: String,
-        link_handle: LinkHandle,
+        link_handle: LinkRelay,
         input_handle: Handle,
         responder: oneshot::Sender<Result<Handle, AllocLinkError>>,
     },

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -7,8 +7,8 @@ use fe2o3_amqp_types::{
 use tokio::sync::{mpsc::Sender, oneshot};
 
 use crate::{
-    connection::{engine::SessionId, AllocSessionError},
-    endpoint::LinkFlow,
+    connection::{AllocSessionError},
+    endpoint::{LinkFlow, OutgoingChannel},
     link::LinkHandle,
     session::{frame::SessionIncomingItem, AllocLinkError},
 };
@@ -19,9 +19,9 @@ pub(crate) enum ConnectionControl {
     Close(Option<definitions::Error>),
     AllocateSession {
         tx: Sender<SessionIncomingItem>,
-        responder: oneshot::Sender<Result<(u16, SessionId), AllocSessionError>>,
+        responder: oneshot::Sender<Result<OutgoingChannel, AllocSessionError>>,
     },
-    DeallocateSession(SessionId),
+    DeallocateSession(OutgoingChannel),
 }
 
 impl std::fmt::Display for ConnectionControl {
@@ -33,7 +33,7 @@ impl std::fmt::Display for ConnectionControl {
                 tx: _,
                 responder: _,
             } => write!(f, "AllocateSession"),
-            Self::DeallocateSession(id) => write!(f, "DeallocateSession({})", id),
+            Self::DeallocateSession(id) => write!(f, "DeallocateSession({})", id.0),
         }
     }
 }

--- a/fe2o3-amqp/src/endpoint.rs
+++ b/fe2o3-amqp/src/endpoint.rs
@@ -127,6 +127,36 @@ pub(crate) trait Connection {
     ) -> Option<&mpsc::Sender<SessionIncomingItem>>;
 }
 
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub(crate) struct OutputHandle(pub UInt);
+
+impl From<Handle> for OutputHandle {
+    fn from(handle: Handle) -> Self {
+        Self(handle.0)
+    }
+}
+
+impl From<OutputHandle> for Handle {
+    fn from(handle: OutputHandle) -> Self {
+        Self(handle.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub(crate) struct InputHandle(pub UInt);
+
+impl From<Handle> for InputHandle {
+    fn from(handle: Handle) -> Self {
+        Self(handle.0)
+    }
+}
+
+impl From<InputHandle> for Handle {
+    fn from(handle: InputHandle) -> Self {
+        Self(handle.0)
+    }
+}
+
 #[async_trait]
 pub(crate) trait Session {
     type AllocError: Send;
@@ -142,14 +172,16 @@ pub(crate) trait Session {
     fn allocate_link(
         &mut self,
         link_name: String,
-        link_handle: Self::LinkRelay,
-    ) -> Result<Handle, Self::AllocError>;
+        link_relay: Self::LinkRelay,
+    ) -> Result<OutputHandle, Self::AllocError>;
+
     fn allocate_incoming_link(
         &mut self,
         link_name: String,
-        link_handle: Self::LinkRelay,
-        input_handle: Handle,
-    ) -> Result<Handle, Self::AllocError>;
+        link_relay: Self::LinkRelay,
+        input_handle: InputHandle,
+    ) -> Result<OutputHandle, Self::AllocError>;
+
     fn deallocate_link(&mut self, link_name: String);
 
     fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error>;
@@ -240,9 +272,9 @@ pub(crate) trait LinkExt: Link {
 
     fn name(&self) -> &str;
 
-    fn output_handle(&self) -> &Option<Handle>;
+    fn output_handle(&self) -> &Option<OutputHandle>;
 
-    fn output_handle_mut(&mut self) -> &mut Option<Handle>;
+    fn output_handle_mut(&mut self) -> &mut Option<OutputHandle>;
 
     fn flow_state(&self) -> &Self::FlowState;
 

--- a/fe2o3-amqp/src/endpoint.rs
+++ b/fe2o3-amqp/src/endpoint.rs
@@ -152,24 +152,30 @@ pub(crate) trait Session {
     ) -> Result<Handle, Self::AllocError>;
     fn deallocate_link(&mut self, link_name: String);
 
-    fn on_incoming_begin(&mut self, channel: u16, begin: Begin) -> Result<(), Self::Error>;
-    async fn on_incoming_attach(&mut self, channel: u16, attach: Attach)
+    fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error>;
+
+    async fn on_incoming_attach(&mut self, channel: IncomingChannel, attach: Attach)
         -> Result<(), Self::Error>;
-    async fn on_incoming_flow(&mut self, channel: u16, flow: Flow) -> Result<(), Self::Error>;
+
+    async fn on_incoming_flow(&mut self, channel: IncomingChannel, flow: Flow) -> Result<(), Self::Error>;
+
     async fn on_incoming_transfer(
         &mut self,
-        channel: u16,
+        channel: IncomingChannel,
         transfer: Transfer,
         payload: Payload,
     ) -> Result<(), Self::Error>;
+
     async fn on_incoming_disposition(
         &mut self,
-        channel: u16,
+        channel: IncomingChannel,
         disposition: Disposition,
     ) -> Result<(), Self::Error>;
-    async fn on_incoming_detach(&mut self, channel: u16, detach: Detach)
+
+    async fn on_incoming_detach(&mut self, channel: IncomingChannel, detach: Detach)
         -> Result<(), Self::Error>;
-    async fn on_incoming_end(&mut self, channel: u16, end: End) -> Result<(), Self::Error>;
+
+    async fn on_incoming_end(&mut self, channel: IncomingChannel, end: End) -> Result<(), Self::Error>;
 
     // Handling SessionFrames
     async fn send_begin<W>(&mut self, writer: &mut W) -> Result<(), Self::Error>

--- a/fe2o3-amqp/src/endpoint.rs
+++ b/fe2o3-amqp/src/endpoint.rs
@@ -132,7 +132,7 @@ pub(crate) trait Session {
     type AllocError: Send;
     type Error: Send;
     type State;
-    type LinkHandle;
+    type LinkRelay;
 
     fn local_state(&self) -> &Self::State;
     fn local_state_mut(&mut self) -> &mut Self::State;
@@ -142,12 +142,12 @@ pub(crate) trait Session {
     fn allocate_link(
         &mut self,
         link_name: String,
-        link_handle: Self::LinkHandle,
+        link_handle: Self::LinkRelay,
     ) -> Result<Handle, Self::AllocError>;
     fn allocate_incoming_link(
         &mut self,
         link_name: String,
-        link_handle: Self::LinkHandle,
+        link_handle: Self::LinkRelay,
         input_handle: Handle,
     ) -> Result<Handle, Self::AllocError>;
     fn deallocate_link(&mut self, link_name: String);

--- a/fe2o3-amqp/src/lib.rs
+++ b/fe2o3-amqp/src/lib.rs
@@ -12,7 +12,7 @@
 //! - `"rustls"`: enables TLS integration with `tokio-rustls` and `rustls`
 //! - `"native-tls"`: enables TLS integration with `tokio-native-tls` and `native-tls`
 //! - `"acceptor"`: enables `ConnectionAcceptor`, `SessionAcceptor`, and `LinkAcceptor`
-//! - `"transaction"`: enables `Controller`, `Transaction`, `TxnAcquisition` 
+//! - `"transaction"`: enables `Controller`, `Transaction`, `TxnAcquisition`
 //! (only the client side is implemented so far)
 //!
 //! # Quick start

--- a/fe2o3-amqp/src/link/builder.rs
+++ b/fe2o3-amqp/src/link/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     connection::DEFAULT_OUTGOING_BUFFER_SIZE,
     link::{Link, LinkRelay, LinkIncomingItem},
     session::{self, SessionHandle},
-    util::{Consumer, Producer},
+    util::{Consumer, Producer}, endpoint::OutputHandle,
 };
 
 use super::{
@@ -333,7 +333,7 @@ impl<Role, T, NameState, Addr> Builder<Role, T, NameState, Addr> {
     pub(crate) fn create_link<C, M>(
         self,
         unsettled: Arc<RwLock<UnsettledMap<M>>>,
-        output_handle: Handle,
+        output_handle: OutputHandle,
         flow_state_consumer: C,
         // state_code: Arc<AtomicU8>,
     ) -> Link<Role, T, C, M> {
@@ -347,7 +347,7 @@ impl<Role, T, NameState, Addr> Builder<Role, T, NameState, Addr> {
             local_state,
             // state_code,
             name: self.name,
-            output_handle: Some(output_handle),
+            output_handle: Some(output_handle.into()),
             input_handle: None,
             snd_settle_mode: self.snd_settle_mode,
             rcv_settle_mode: self.rcv_settle_mode,

--- a/fe2o3-amqp/src/link/builder.rs
+++ b/fe2o3-amqp/src/link/builder.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::PollSender;
 
 use crate::{
     connection::DEFAULT_OUTGOING_BUFFER_SIZE,
-    link::{Link, LinkHandle, LinkIncomingItem},
+    link::{Link, LinkRelay, LinkIncomingItem},
     session::{self, SessionHandle},
     util::{Consumer, Producer},
 };
@@ -428,7 +428,7 @@ where
 
         let unsettled = Arc::new(RwLock::new(BTreeMap::new()));
         // let state_code = Arc::new(AtomicU8::new(0));
-        let link_handle = LinkHandle::Sender {
+        let link_handle = LinkRelay::Sender {
             tx: incoming_tx,
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),
@@ -501,7 +501,7 @@ impl Builder<role::Receiver, Target, WithName, WithTarget> {
         let flow_state_producer = flow_state.clone();
         let flow_state_consumer = flow_state;
         // let state_code = Arc::new(AtomicU8::new(0));
-        let link_handle = LinkHandle::Receiver {
+        let link_handle = LinkRelay::Receiver {
             tx: incoming_tx,
             flow_state: flow_state_producer,
             unsettled: unsettled.clone(),

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -6,7 +6,7 @@ use fe2o3_amqp_types::{
 };
 use tokio::sync::{mpsc, oneshot::error::RecvError};
 
-use crate::session::{AllocLinkError, DeallocLinkError};
+use crate::session::AllocLinkError;
 
 #[cfg(feature = "transaction")]
 use fe2o3_amqp_types::transaction::TransactionId;
@@ -80,21 +80,6 @@ impl TryFrom<Error> for DetachError {
                 Ok(error)
             }
             Error::Rejected(_) | Error::Released(_) | Error::Modified(_) => Err(value),
-        }
-    }
-}
-
-impl From<DeallocLinkError> for DetachError {
-    fn from(err: DeallocLinkError) -> Self {
-        match err {
-            DeallocLinkError::IllegalState => DetachError::new(
-                false,
-                Some(definitions::Error::new(
-                    AmqpError::IllegalState,
-                    "Session must have been dropped".to_string(),
-                    None,
-                )),
-            ),
         }
     }
 }

--- a/fe2o3-amqp/src/link/frame.rs
+++ b/fe2o3-amqp/src/link/frame.rs
@@ -1,6 +1,9 @@
 use fe2o3_amqp_types::performatives::{Attach, Detach, Disposition, Transfer};
 
-use crate::{endpoint::LinkFlow, Payload};
+use crate::{
+    endpoint::{InputHandle, LinkFlow},
+    Payload,
+};
 
 pub(crate) type LinkIncomingItem = LinkFrame;
 
@@ -12,6 +15,7 @@ pub(crate) enum LinkFrame {
     Attach(Attach),
     Flow(LinkFlow),
     Transfer {
+        input_handle: InputHandle,
         performative: Transfer,
         payload: Payload,
     },

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -220,7 +220,7 @@ impl Drop for Receiver {
         if let Some(handle) = self.link.output_handle.take() {
             if let Some(sender) = self.outgoing.get_ref() {
                 let detach = Detach {
-                    handle,
+                    handle: handle.into(),
                     closed: true,
                     error: None,
                 };
@@ -309,7 +309,7 @@ impl Receiver {
                     })
                 }
             };
-            self.link.output_handle = Some(handle);
+            self.link.output_handle = Some(handle.into());
         }
 
         if let Err(_err) =

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -24,7 +24,7 @@ use super::{
     delivery::Delivery,
     error::{AttachError, DetachError},
     receiver_link::section_number_and_offset,
-    role, Error, LinkFrame, LinkHandle, ReceiverLink, DEFAULT_CREDIT,
+    role, Error, LinkFrame, LinkRelay, ReceiverLink, DEFAULT_CREDIT,
 };
 
 macro_rules! or_assign {
@@ -283,7 +283,7 @@ impl Receiver {
     ) -> Result<&mut Self, DetachError> {
         if self.link.output_handle.is_none() {
             let (tx, incoming) = mpsc::channel(self.buffer_size);
-            let link_handle = LinkHandle::Receiver {
+            let link_handle = LinkRelay::Receiver {
                 tx,
                 flow_state: self.link.flow_state.clone(),
                 unsettled: self.link.unsettled.clone(),
@@ -377,7 +377,7 @@ impl Receiver {
                 )))
             }
             LinkFrame::Flow(_) | LinkFrame::Disposition(_) => {
-                // Flow and Disposition are handled by LinkHandle which runs
+                // Flow and Disposition are handled by LinkRelay which runs
                 // in the session loop
                 unreachable!()
             }

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -36,7 +36,8 @@ impl endpoint::ReceiverLink for ReceiverLink {
         let handle = self
             .output_handle
             .clone()
-            .ok_or_else(Error::not_attached)?;
+            .ok_or_else(Error::not_attached)?
+            .into();
 
         let flow = match (link_credit, drain) {
             (Some(link_credit), Some(drain)) => {
@@ -271,7 +272,8 @@ impl endpoint::ReceiverLink for ReceiverLink {
         let link_output_handle = self
             .output_handle
             .clone()
-            .ok_or_else(Error::not_attached)?;
+            .ok_or_else(Error::not_attached)?
+            .into();
 
         let delivery = Delivery {
             link_output_handle,
@@ -421,7 +423,8 @@ impl ReceiverLink {
         let handle = self
             .output_handle
             .clone()
-            .ok_or_else(|| Error::not_attached())?;
+            .ok_or_else(|| Error::not_attached())?
+            .into();
 
         let flow = match (link_credit, drain) {
             (Some(link_credit), Some(drain)) => {

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -353,7 +353,7 @@ fn rfind_offset_of_complete_message(bytes: &[u8]) -> Option<u64> {
 
     iter.rposition(|(&b0, (&b1, &b2))| {
         matches!(
-            (b0, b1, b2), 
+            (b0, b1, b2),
             (DESCRIBED_TYPE, SMALL_ULONG_TYPE, DATA_CODE)
             | (DESCRIBED_TYPE, SMALL_ULONG_TYPE, AMQP_SEQ_CODE)
             | (DESCRIBED_TYPE, SMALL_ULONG_TYPE, AMQP_VAL_CODE)

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -268,7 +268,7 @@ impl<L: endpoint::SenderLink> Drop for SenderInner<L> {
         if let Some(handle) = self.link.output_handle() {
             if let Some(sender) = self.outgoing.get_ref() {
                 let detach = Detach {
-                    handle: handle.clone(),
+                    handle: handle.clone().into(),
                     closed: true,
                     error: None,
                 };
@@ -384,7 +384,7 @@ where
                     });
                 }
             };
-            *self.link.output_handle_mut() = Some(handle);
+            *self.link.output_handle_mut() = Some(handle.into());
         }
 
         if let Err(_err) =

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -28,7 +28,7 @@ use super::{
     builder::{self, WithoutName, WithoutTarget},
     delivery::{DeliveryFut, Sendable},
     error::{AttachError, DetachError},
-    role, ArcSenderUnsettledMap, Error, LinkFrame, LinkHandle, SenderFlowState, SenderLink,
+    role, ArcSenderUnsettledMap, Error, LinkFrame, LinkRelay, SenderFlowState, SenderLink,
 };
 
 /// An AMQP1.0 sender
@@ -360,7 +360,7 @@ where
         // May need to re-allocate output handle
         if self.link.output_handle().is_none() {
             let (tx, incoming) = mpsc::channel(self.buffer_size);
-            let link_handle = LinkHandle::Sender {
+            let link_handle = LinkRelay::Sender {
                 tx,
                 flow_state: self.link.flow_state().producer(),
                 // TODO: what else to do during re-attaching

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -298,6 +298,8 @@ impl SenderInner<SenderLink> {
             return Err(DetachError::new(false, Some(e)));
         };
 
+        // session::deallocate_link(&mut self.session, output_handle).await?;
+
         // Wait for remote detach
         let frame = match self.incoming.next().await {
             Some(frame) => frame,
@@ -339,8 +341,6 @@ impl SenderInner<SenderLink> {
             }
         }
 
-        session::deallocate_link(&mut self.session, self.link.name.clone()).await?;
-
         Ok(())
     }
 }
@@ -362,6 +362,7 @@ where
             let (tx, incoming) = mpsc::channel(self.buffer_size);
             let link_handle = LinkRelay::Sender {
                 tx,
+                output_handle: (),
                 flow_state: self.link.flow_state().producer(),
                 // TODO: what else to do during re-attaching
                 unsettled: self.link.unsettled().clone(),
@@ -458,8 +459,6 @@ where
                 Err(e) => return Err(DetachError::new(false, Some(e))),
             }
         };
-
-        session::deallocate_link(&mut self.session, self.link.name().into()).await?;
 
         Ok(())
     }

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -28,7 +28,8 @@ where
         let handle = self
             .output_handle
             .clone()
-            .ok_or_else(Error::not_attached)?;
+            .ok_or_else(Error::not_attached)?
+            .into();
 
         let flow = match (delivery_count, available) {
             (Some(delivery_count), Some(available)) => {
@@ -167,7 +168,8 @@ where
         let handle = self
             .output_handle
             .clone()
-            .ok_or(AmqpError::IllegalState)?;
+            .ok_or(AmqpError::IllegalState)?
+            .into();
 
         let tag = self.flow_state.state().delivery_count().await.to_be_bytes();
         let delivery_tag = DeliveryTag::from(tag);

--- a/fe2o3-amqp/src/link/state.rs
+++ b/fe2o3-amqp/src/link/state.rs
@@ -134,7 +134,7 @@ impl LinkFlowState<role::Sender> {
             // the delivery-count_rcv is the first delivery-count_snd sent from sender
             // to receiver, i.e., the delivery-count_snd specified in the flow state
             // carried by the initial attach frame from the sender to the receiver.
-            state.initial_delivery_count
+            state.initial_delivery_count,
         );
 
         if let Some(link_credit_rcv) = flow.link_credit {

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -11,9 +11,10 @@ use tokio_util::sync::PollSender;
 use crate::{
     connection::ConnectionHandle,
     control::SessionControl,
+    endpoint::OutgoingChannel,
     session::{engine::SessionEngine, SessionState},
     util::Constant,
-    Session, endpoint::OutgoingChannel,
+    Session,
 };
 
 use super::{Error, SessionHandle, DEFAULT_WINDOW};
@@ -94,7 +95,7 @@ impl Builder {
             desired_capabilities: self.desired_capabilities,
             properties: self.properties,
 
-            local_links: Slab::new(),
+            link_name_by_output_handle: Slab::new(),
             link_by_name: BTreeMap::new(),
             link_by_input_handle: BTreeMap::new(),
             delivery_tag_by_id: BTreeMap::new(),

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     connection::{self},
     control::{ConnectionControl, SessionControl},
     endpoint::{self, Session},
-    link::{LinkFrame, LinkHandle},
+    link::{LinkFrame, LinkRelay},
     util::Running,
 };
 
@@ -84,7 +84,7 @@ impl SessionEngine<super::Session> {
 
 impl<S> SessionEngine<S>
 where
-    S: endpoint::Session<State = SessionState, LinkHandle = LinkHandle> + Send + Sync + 'static,
+    S: endpoint::Session<State = SessionState, LinkRelay = LinkRelay> + Send + Sync + 'static,
     S::Error: Into<Error> + Debug,
     S::AllocError: Into<AllocLinkError>,
 {

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, instrument, trace};
 use crate::{
     connection::{self},
     control::{ConnectionControl, SessionControl},
-    endpoint::{self, Session},
+    endpoint::{self, Session, IncomingChannel},
     link::{LinkFrame, LinkRelay},
     util::Running,
 };
@@ -64,6 +64,7 @@ impl SessionEngine<super::Session> {
             }
         };
         let SessionFrame { channel, body } = frame;
+        let channel = IncomingChannel(channel);
         let remote_begin = match body {
             SessionFrameBody::Begin(begin) => begin,
             SessionFrameBody::End(end) => {
@@ -96,7 +97,7 @@ where
     #[instrument(skip_all)]
     async fn on_incoming(&mut self, incoming: SessionIncomingItem) -> Result<Running, Error> {
         let SessionFrame { channel, body } = incoming;
-
+        let channel = IncomingChannel(channel);
         match body {
             SessionFrameBody::Begin(begin) => {
                 self.session

--- a/fe2o3-amqp/src/session/error.rs
+++ b/fe2o3-amqp/src/session/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
 
     /// TODO: hide this from public API
     /// Link handle error should be handled differently. Link handle is only local
-    #[error("Local LinkHandle {:?} error {:?}", .handle, .error)]
+    #[error("Local LinkRelay {:?} error {:?}", .handle, .error)]
     LinkHandleError {
         /// Handle of the link
         handle: Handle,

--- a/fe2o3-amqp/src/session/error.rs
+++ b/fe2o3-amqp/src/session/error.rs
@@ -114,8 +114,8 @@ impl From<AllocLinkError> for definitions::Error {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum DeallocLinkError {
-    #[error("Illegal session state")]
-    IllegalState,
-}
+// #[derive(Debug, thiserror::Error)]
+// pub(crate) enum DeallocLinkError {
+//     #[error("Illegal session state")]
+//     IllegalState,
+// }

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -26,7 +26,7 @@ use tracing::{instrument, trace};
 use crate::{
     connection::ConnectionHandle,
     control::SessionControl,
-    endpoint::{self, LinkFlow, OutgoingChannel, IncomingChannel, OutputHandle, InputHandle},
+    endpoint::{self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
     link::{LinkFrame, LinkRelay},
     util::Constant,
     Payload,
@@ -36,8 +36,8 @@ pub(crate) mod engine;
 pub(crate) mod frame;
 
 mod error;
+pub(crate) use error::AllocLinkError;
 pub use error::Error;
-pub(crate) use error::{AllocLinkError, DeallocLinkError};
 
 mod builder;
 pub use builder::*;
@@ -135,14 +135,14 @@ impl<R> SessionHandle<R> {
 pub(crate) async fn allocate_link(
     control: &mut mpsc::Sender<SessionControl>,
     link_name: String,
-    link_handle: LinkRelay,
+    link_relay: LinkRelay<()>,
 ) -> Result<OutputHandle, AllocLinkError> {
     let (responder, resp_rx) = oneshot::channel();
 
     control
         .send(SessionControl::AllocateLink {
             link_name,
-            link_handle,
+            link_relay,
             responder,
         })
         .await
@@ -160,15 +160,15 @@ pub(crate) async fn allocate_link(
     result
 }
 
-pub(crate) async fn deallocate_link(
-    control: &mut mpsc::Sender<SessionControl>,
-    link_name: String,
-) -> Result<(), DeallocLinkError> {
-    control
-        .send(SessionControl::DeallocateLink(link_name))
-        .await
-        .map_err(|_| DeallocLinkError::IllegalState)
-}
+// pub(crate) async fn deallocate_link(
+//     control: &mut mpsc::Sender<SessionControl>,
+//     output_handle: OutputHandle,
+// ) -> Result<(), DeallocLinkError> {
+//     control
+//         .send(SessionControl::DeallocateLink(output_handle))
+//         .await
+//         .map_err(|_| DeallocLinkError::IllegalState)
+// }
 
 /// AMQP1.0 Session
 ///
@@ -231,12 +231,11 @@ pub struct Session {
     pub(crate) properties: Option<Fields>,
 
     /// local links by output handle
-    pub(crate) local_links: Slab<LinkRelay>,
-    pub(crate) link_by_name: BTreeMap<String, OutputHandle>,
-    // The key is not InputHandle to avoid additional clone
-    pub(crate) link_by_input_handle: BTreeMap<Handle, OutputHandle>,
+    pub(crate) link_name_by_output_handle: Slab<String>,
+    pub(crate) link_by_name: BTreeMap<String, Option<LinkRelay<OutputHandle>>>,
+    pub(crate) link_by_input_handle: BTreeMap<InputHandle, LinkRelay<OutputHandle>>,
     // Maps from DeliveryId to link.DeliveryCount
-    pub(crate) delivery_tag_by_id: BTreeMap<DeliveryNumber, (Handle, DeliveryTag)>,
+    pub(crate) delivery_tag_by_id: BTreeMap<DeliveryNumber, (InputHandle, DeliveryTag)>,
 }
 
 impl Session {
@@ -276,7 +275,6 @@ impl endpoint::Session for Session {
     type AllocError = AllocLinkError;
     type Error = Error;
     type State = SessionState;
-    type LinkRelay = LinkRelay;
 
     fn local_state(&self) -> &Self::State {
         &self.local_state
@@ -293,7 +291,7 @@ impl endpoint::Session for Session {
     fn allocate_link(
         &mut self,
         link_name: String,
-        link_handle: LinkRelay,
+        link_relay: Option<LinkRelay<()>>,
     ) -> Result<OutputHandle, Self::AllocError> {
         match &self.local_state {
             SessionState::Mapped => {}
@@ -306,15 +304,16 @@ impl endpoint::Session for Session {
         }
 
         // get a new entry index
-        let entry = self.local_links.vacant_entry();
+        let entry = self.link_name_by_output_handle.vacant_entry();
         let handle = OutputHandle(entry.key() as u32);
 
         // check if handle max is exceeded
         if handle.0 > self.handle_max.0 {
             Err(AllocLinkError::HandleMaxReached)
         } else {
-            entry.insert(link_handle);
-            self.link_by_name.insert(link_name, handle.clone());
+            entry.insert(link_name.clone());
+            let value = link_relay.map(|val| val.with_output_handle(handle.clone()));
+            self.link_by_name.insert(link_name, value);
             // TODO: how to know which link to send the Flow frames to?
             Ok(handle)
         }
@@ -323,26 +322,34 @@ impl endpoint::Session for Session {
     fn allocate_incoming_link(
         &mut self,
         link_name: String,
-        link_handle: LinkRelay,
+        link_relay: LinkRelay<()>,
         input_handle: InputHandle,
     ) -> Result<OutputHandle, Self::AllocError> {
-        match self.allocate_link(link_name, link_handle) {
+        match self.allocate_link(link_name, None) {
             Ok(output_handle) => {
-                self.link_by_input_handle
-                    .insert(input_handle.into(), output_handle.clone());
+                let value = link_relay.with_output_handle(output_handle.clone());
+                self.link_by_input_handle.insert(input_handle.into(), value);
                 Ok(output_handle)
             }
             Err(err) => Err(err),
         }
     }
 
-    fn deallocate_link(&mut self, link_name: String) {
-        if let Some(handle) = self.link_by_name.remove(&link_name) {
-            self.local_links.remove(handle.0 as usize);
+    /// This should only deallocate the output handle
+    fn deallocate_link(&mut self, output_handle: OutputHandle) {
+        if let Some(name) = self
+            .link_name_by_output_handle
+            .try_remove(output_handle.0 as usize)
+        {
+            let _ = self.link_by_name.remove(&name);
         }
     }
 
-    fn on_incoming_begin(&mut self, channel: IncomingChannel, begin: Begin) -> Result<(), Self::Error> {
+    fn on_incoming_begin(
+        &mut self,
+        channel: IncomingChannel,
+        begin: Begin,
+    ) -> Result<(), Self::Error> {
         match self.local_state {
             SessionState::Unmapped => self.local_state = SessionState::BeginReceived,
             SessionState::BeginSent => self.local_state = SessionState::Mapped,
@@ -362,43 +369,40 @@ impl endpoint::Session for Session {
         _channel: IncomingChannel,
         attach: Attach,
     ) -> Result<(), Self::Error> {
-        // look up link Handle by link name
-        match self.link_by_name.get(&attach.name) {
-            Some(output_handle) => match self.local_links.get_mut(output_handle.0 as usize) {
-                Some(link) => {
+        match self.link_by_name.get_mut(&attach.name) {
+            Some(link) => match link.take() {
+                Some(mut relay) => {
                     // Only Sender need to update the receiver settle mode
                     // because the sender needs to echo a disposition if
                     // rcv-settle-mode is 1
                     if let LinkRelay::Sender {
                         receiver_settle_mode,
                         ..
-                    } = link
+                    } = &mut relay
                     {
                         *receiver_settle_mode = attach.rcv_settle_mode.clone();
                     }
 
-                    let input_handle = attach.handle.clone(); // handle is just a wrapper around u32
-                    self.link_by_input_handle
-                        .insert(input_handle, output_handle.clone());
-                    match link.send(LinkFrame::Attach(attach)).await {
-                        Ok(_) => {}
-                        Err(_) => {
-                            // TODO: how should this error be handled?
-                            // End with UnattachedHandle?
-                            return Err(Error::session_error(SessionError::UnattachedHandle, None));
-                            // End session with unattached handle?
-                        }
-                    }
-                }
-                None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
-            },
-            None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
-        }
+                    let input_handle = InputHandle::from(attach.handle.clone()); // handle is just a wrapper around u32
+                    relay
+                        .send(LinkFrame::Attach(attach))
+                        .await
+                        .map_err(|_| Error::session_error(SessionError::UnattachedHandle, None))?;
+                    self.link_by_input_handle.insert(input_handle, relay);
 
-        Ok(())
+                    Ok(())
+                }
+                None => Err(Error::session_error(SessionError::HandleInUse, None)),
+            },
+            None => Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?,
+        }
     }
 
-    async fn on_incoming_flow(&mut self, _channel: IncomingChannel, flow: Flow) -> Result<(), Self::Error> {
+    async fn on_incoming_flow(
+        &mut self,
+        _channel: IncomingChannel,
+        flow: Flow,
+    ) -> Result<(), Self::Error> {
         // Handle session flow control
         //
         // When the endpoint receives a flow frame from its peer, it MUST update the next-incoming-id
@@ -425,26 +429,21 @@ impl endpoint::Session for Session {
 
         // Handle link flow control
         if let Ok(link_flow) = LinkFlow::try_from(flow) {
-            match self.link_by_input_handle.get(&link_flow.handle) {
-                Some(output_handle) => match self.local_links.get_mut(output_handle.0 as usize) {
-                    Some(link_handle) => {
-                        if let Some(echo_flow) = link_handle
-                            .on_incoming_flow(link_flow, output_handle.clone())
+            let input_handle = InputHandle::from(link_flow.handle.clone());
+            match self.link_by_input_handle.get_mut(&input_handle) {
+                Some(link_relay) => {
+                    if let Some(echo_flow) = link_relay.on_incoming_flow(link_flow).await {
+                        self.control
+                            .send(SessionControl::LinkFlow(echo_flow))
                             .await
-                        {
-                            self.control
-                                .send(SessionControl::LinkFlow(echo_flow))
-                                .await
-                                // Sending control to self. This will only give an error if the receiving
-                                // half is dropped. An error would thus indicate that the event loop
-                                // has stopped, so it could be considered illegal state.
-                                //
-                                // If the event loop has stopped, this should not be executed at all
-                                .map_err(|_| Error::amqp_error(AmqpError::IllegalState, None))?;
-                        }
+                            // Sending control to self. This will only give an error if the receiving
+                            // half is dropped. An error would thus indicate that the event loop
+                            // has stopped, so it could be considered illegal state.
+                            //
+                            // If the event loop has stopped, this should not be executed at all
+                            .map_err(|_| Error::amqp_error(AmqpError::IllegalState, None))?;
                     }
-                    None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
-                },
+                }
                 None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
             }
         }
@@ -465,29 +464,26 @@ impl endpoint::Session for Session {
         self.next_incoming_id += 1;
         self.remote_outgoing_window -= 1;
 
-        match self.link_by_input_handle.get(&transfer.handle) {
-            Some(output_handle) => match self.local_links.get_mut(output_handle.0 as usize) {
-                Some(link_handle) => {
-                    let id_and_tag = match link_handle.on_incoming_transfer(transfer, payload).await
-                    {
-                        Ok(opt) => opt,
-                        Err((closed, error)) => {
-                            return Err(Error::LinkHandleError {
-                                handle: output_handle.clone().into(),
-                                closed,
-                                error,
-                            })
-                        }
-                    };
-
-                    // If the unsettled map needs this
-                    if let Some((delivery_id, delivery_tag)) = id_and_tag {
-                        self.delivery_tag_by_id
-                            .insert(delivery_id, (output_handle.clone().into(), delivery_tag));
+        let input_handle = InputHandle::from(transfer.handle.clone());
+        match self.link_by_input_handle.get_mut(&input_handle) {
+            Some(link_relay) => {
+                let id_and_tag = match link_relay.on_incoming_transfer(transfer, payload).await {
+                    Ok(opt) => opt,
+                    Err((closed, error)) => {
+                        return Err(Error::LinkHandleError {
+                            handle: link_relay.output_handle().clone().into(),
+                            closed,
+                            error,
+                        })
                     }
+                };
+
+                // If the unsettled map needs this
+                if let Some((delivery_id, delivery_tag)) = id_and_tag {
+                    self.delivery_tag_by_id
+                        .insert(delivery_id, (input_handle, delivery_tag));
                 }
-                None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
-            },
+            }
             None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle?
         };
 
@@ -521,7 +517,7 @@ impl endpoint::Session for Session {
             // If it is alrea
             for delivery_id in first..=last {
                 if let Some((handle, delivery_tag)) = self.delivery_tag_by_id.remove(&delivery_id) {
-                    if let Some(link_handle) = self.local_links.get_mut(handle.0 as usize) {
+                    if let Some(link_handle) = self.link_by_input_handle.get_mut(&handle) {
                         let _echo = link_handle
                             .on_incoming_disposition(
                                 disposition.role.clone(),
@@ -536,7 +532,7 @@ impl endpoint::Session for Session {
         } else {
             for delivery_id in first..last {
                 if let Some((handle, delivery_tag)) = self.delivery_tag_by_id.get(&delivery_id) {
-                    if let Some(link_handle) = self.local_links.get_mut(handle.0 as usize) {
+                    if let Some(link_handle) = self.link_by_input_handle.get_mut(&handle) {
                         // In mode Second, the receiver will first send a non-settled disposition,
                         // and wait for sender's settled disposition
                         let echo = link_handle
@@ -596,28 +592,24 @@ impl endpoint::Session for Session {
     ) -> Result<(), Self::Error> {
         trace!(channel = ?_channel, frame = ?detach);
         // Remove the link by input handle
-        let output_handle = match self.link_by_input_handle.remove(&detach.handle) {
-            Some(handle) => handle,
-            None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle
-        };
-        match self.local_links.get_mut(output_handle.0 as usize) {
-            Some(link) => {
-                // TODO:
-                match link.on_incoming_detach(detach).await {
-                    Ok(_) => {}
-                    Err(_) => {
-                        return Err(Error::session_error(SessionError::UnattachedHandle, None))
-                    } // End session with unattached handle
-                }
-            }
-            None => return Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle
+        match self
+            .link_by_input_handle
+            .remove(&InputHandle::from(detach.handle.clone()))
+        {
+            Some(mut link) => match link.on_incoming_detach(detach).await {
+                Ok(_) => Ok(()),
+                Err(_) => Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle
+            },
+            None => Err(Error::session_error(SessionError::UnattachedHandle, None)), // End session with unattached handle
         }
-
-        Ok(())
     }
 
     #[instrument(skip_all)]
-    async fn on_incoming_end(&mut self, _channel: IncomingChannel, end: End) -> Result<(), Self::Error> {
+    async fn on_incoming_end(
+        &mut self,
+        _channel: IncomingChannel,
+        end: End,
+    ) -> Result<(), Self::Error> {
         trace!(end = ?end);
         match self.local_state {
             SessionState::BeginSent | SessionState::BeginReceived | SessionState::Mapped => {
@@ -759,6 +751,7 @@ impl endpoint::Session for Session {
 
     fn on_outgoing_transfer(
         &mut self,
+        input_handle: InputHandle,
         mut transfer: Transfer,
         payload: Payload,
     ) -> Result<SessionFrame, Self::Error> {
@@ -768,6 +761,18 @@ impl endpoint::Session for Session {
 
         // TODO: What policy would result in a decrement in outgoing-window?
 
+        // If not set on the first (or only) transfer for a (multi-transfer)
+        // delivery, then the settled flag MUST be interpreted as being false.
+        //
+        // If the negotiated value for snd-settle-mode at attachment is settled,
+        // then this field MUST be true on at least one transfer frame for a
+        // delivery
+        //
+        // If the negotiated value for snd-settle-mode at attachment is unsettled,
+        // then this field MUST be false (or unset) on every transfer frame for a
+        // delivery
+        let settled = transfer.settled.unwrap_or(false);
+
         // Only the first transfer is required to have delivery_tag and delivery_id
         if let Some(delivery_tag) = &transfer.delivery_tag {
             // The next-outgoing-id is the transfer-id to assign to the next transfer frame.
@@ -775,8 +780,10 @@ impl endpoint::Session for Session {
             transfer.delivery_id = Some(delivery_id);
 
             // Disposition doesn't carry delivery tag
-            self.delivery_tag_by_id
-                .insert(delivery_id, (transfer.handle.clone(), delivery_tag.clone()));
+            if !settled {
+                self.delivery_tag_by_id
+                    .insert(delivery_id, (input_handle, delivery_tag.clone()));
+            }
         }
 
         self.next_outgoing_id += 1;
@@ -810,7 +817,7 @@ impl endpoint::Session for Session {
 
     fn on_outgoing_detach(&mut self, detach: Detach) -> Result<SessionFrame, Self::Error> {
         // TODO: what else do we need to do here?
-
+        self.deallocate_link(detach.handle.clone().into());
         let body = SessionFrameBody::Detach(detach);
         let frame = SessionFrame::new(self.outgoing_channel, body);
         Ok(frame)

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -26,7 +26,7 @@ use tracing::{instrument, trace};
 use crate::{
     connection::ConnectionHandle,
     control::SessionControl,
-    endpoint::{self, LinkFlow},
+    endpoint::{self, LinkFlow, OutgoingChannel},
     link::{LinkFrame, LinkHandle},
     util::Constant,
     Payload,
@@ -208,7 +208,7 @@ pub(crate) async fn deallocate_link(
 pub struct Session {
     pub(crate) control: mpsc::Sender<SessionControl>,
     // session_id: usize,
-    pub(crate) outgoing_channel: u16,
+    pub(crate) outgoing_channel: OutgoingChannel,
 
     // local amqp states
     pub(crate) local_state: SessionState,
@@ -285,7 +285,7 @@ impl endpoint::Session for Session {
         &mut self.local_state
     }
 
-    fn outgoing_channel(&self) -> u16 {
+    fn outgoing_channel(&self) -> OutgoingChannel {
         self.outgoing_channel
     }
 

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -160,16 +160,6 @@ pub(crate) async fn allocate_link(
     result
 }
 
-// pub(crate) async fn deallocate_link(
-//     control: &mut mpsc::Sender<SessionControl>,
-//     output_handle: OutputHandle,
-// ) -> Result<(), DeallocLinkError> {
-//     control
-//         .send(SessionControl::DeallocateLink(output_handle))
-//         .await
-//         .map_err(|_| DeallocLinkError::IllegalState)
-// }
-
 /// AMQP1.0 Session
 ///
 /// # Begin a new Session with default configuration

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -233,6 +233,7 @@ pub struct Session {
     /// local links by output handle
     pub(crate) local_links: Slab<LinkRelay>,
     pub(crate) link_by_name: BTreeMap<String, OutputHandle>,
+    // The key is not InputHandle to avoid additional clone
     pub(crate) link_by_input_handle: BTreeMap<Handle, OutputHandle>,
     // Maps from DeliveryId to link.DeliveryCount
     pub(crate) delivery_tag_by_id: BTreeMap<DeliveryNumber, (Handle, DeliveryTag)>,


### PR DESCRIPTION
Previous design uses three maps and for each incoming frame, two look-ups are needed to find the channel to send the incoming frame. The look-up at connection and at session are both reduced down to one.