### PR TITLE
Fix large payload transfer for different brokers

### DIFF
--- a/examples/protocol_test/Cargo.toml
+++ b/examples/protocol_test/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1"
 serde = "1"
 serde_json = "1"
-fe2o3-amqp = { version = "0.0.29", path = "../../fe2o3-amqp", default-features = false, features = ["acceptor", "transaction"] }
+fe2o3-amqp = { version = "0.0.30", path = "../../fe2o3-amqp", default-features = false, features = ["acceptor", "transaction"] }
 # fe2o3-amqp = { version = "0.0.13", features = ["acceptor", "transaction"] }
 tokio = { version = "1", features = ["net", "macros", "rt-multi-thread", "rt", "time"] }
 tracing = "0.1.31"

--- a/examples/protocol_test/src/bin/send_large_content.rs
+++ b/examples/protocol_test/src/bin/send_large_content.rs
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
     let subscriber = FmtSubscriber::builder()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
-        .with_max_level(Level::DEBUG)
+        .with_max_level(Level::TRACE)
         // .with_max_level(Level::DEBUG)
         // completes the builder.
         .finish();

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"
@@ -18,12 +18,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 ## dev defaults
-default = [
-    "acceptor",
-    "rustls",
-    "native-tls",
-    "transaction",
-]
+# default = [
+#     "acceptor",
+#     "rustls",
+#     "native-tls",
+#     "transaction",
+# ]
 
 transaction = ["fe2o3-amqp-types/transaction", "uuid"]
 
@@ -47,7 +47,7 @@ fe2o3-amqp-types = "0.0.30"
 
 bytes = "1"
 tokio = { version = "^1.16.1", features = ["io-util", "net", "rt", "macros"] }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { version = "=0.7.3", features = ["codec"] }
 thiserror = "1"
 serde = "1"
 # erased-serde = "^0.3.16"

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -18,12 +18,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 ## dev defaults
-# default = [
-#     "acceptor",
-#     "rustls",
-#     "native-tls",
-#     "transaction",
-# ]
+default = [
+    "acceptor",
+    "rustls",
+    "native-tls",
+    "transaction",
+]
 
 transaction = ["fe2o3-amqp-types/transaction", "uuid"]
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.0.30
+
+1. Fixed large content transfer problem by
+   1. Separating the length delimited codec into encoder and decoder to deal with potentially a bug upstream (tokio-rs/tokio#4815)
+   2. The length delimited encoder's max frame length is set to the remote max frame size
+   3. The length delimited decoder's max frame length is set to the local max frame size
+
 ## 0.0.29
 
 1. Updated doc to make it clear that the exposed `max_frame_size` API includes the 8 bytes taken by the frame header

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -11,10 +11,10 @@ use fe2o3_amqp_types::{
 };
 use futures_util::{Sink, SinkExt, StreamExt};
 use tokio::{
-    io::{AsyncRead, AsyncWrite},
+    io::{AsyncRead, AsyncWrite, WriteHalf, ReadHalf},
     sync::mpsc::{self, Receiver},
 };
-use tokio_util::codec::Framed;
+use tokio_util::codec::{FramedWrite, FramedRead};
 use tracing::instrument;
 
 use crate::{
@@ -176,7 +176,8 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
 
     async fn negotiate_amqp_with_framed<Io>(
         &self,
-        framed: Framed<Io, ProtocolHeaderCodec>,
+        framed_write: FramedWrite<WriteHalf<Io>, ProtocolHeaderCodec>,
+        framed_read: FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
     ) -> Result<ListenerConnectionHandle, OpenError>
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
@@ -187,7 +188,7 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
             .idle_time_out
             .map(|millis| Duration::from_millis(millis as u64));
         let transport =
-            Transport::negotiate_amqp_header(framed, &mut local_state, idle_timeout).await?;
+            Transport::negotiate_amqp_header(framed_write, framed_read, &mut local_state, idle_timeout).await?;
 
         let (control_tx, control_rx) = mpsc::channel(DEFAULT_CONTROL_CHAN_BUF);
         let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
@@ -220,8 +221,10 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
-        let framed = Framed::new(stream, ProtocolHeaderCodec::new());
-        self.negotiate_amqp_with_framed(framed).await
+        let (reader, writer) = tokio::io::split(stream);
+        let framed_write = FramedWrite::new(writer, ProtocolHeaderCodec::new());
+        let framed_read = FramedRead::new(reader, ProtocolHeaderCodec::new());
+        self.negotiate_amqp_with_framed(framed_write, framed_read).await
     }
 }
 
@@ -232,12 +235,13 @@ where
     #[instrument(skip_all)]
     async fn negotiate_sasl_with_framed<Io>(
         &self,
-        framed: Framed<Io, ProtocolHeaderCodec>,
+        framed_write: FramedWrite<WriteHalf<Io>, ProtocolHeaderCodec>,
+        framed_read: FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
     ) -> Result<ListenerConnectionHandle, OpenError>
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
-        let mut transport = Transport::negotiate_sasl_header(framed).await?;
+        let mut transport = Transport::negotiate_sasl_header(framed_write, framed_read).await?;
 
         // Send mechanisms
         let frame = sasl::Frame::Mechanisms(self.sasl_acceptor.sasl_mechanisms());
@@ -281,10 +285,10 @@ where
 
         // NOTE: LengthDelimitedCodec itself doesn't seem to carry any buffer, so
         // it should be fine to simply drop it.
-        let framed = transport
-            .into_framed_codec()
-            .map_codec(|_| ProtocolHeaderCodec::new());
-        self.negotiate_amqp_with_framed(framed).await
+        let (framed_write, framed_read) = transport.into_framed_codec();
+        let framed_write = framed_write.map_encoder(|_| ProtocolHeaderCodec::new());
+        let framed_read = framed_read.map_decoder(|_| ProtocolHeaderCodec::new());
+        self.negotiate_amqp_with_framed(framed_write, framed_read).await
     }
 
     async fn negotiate_sasl_with_stream<Io>(
@@ -294,8 +298,10 @@ where
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
-        let framed = Framed::new(stream, ProtocolHeaderCodec::new());
-        self.negotiate_sasl_with_framed(framed).await
+        let (reader, writer) = tokio::io::split(stream);
+        let framed_write = FramedWrite::new(writer, ProtocolHeaderCodec::new());
+        let framed_read = FramedRead::new(reader, ProtocolHeaderCodec::new());
+        self.negotiate_sasl_with_framed(framed_write, framed_read).await
     }
 
     async fn negotiate_sasl_challenge<Io>(

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -1,7 +1,6 @@
 //! The engine handles incoming and outgoing frames and messages to reduce
 //! transferring frames/messages over channels
 
-use std::cmp::min;
 use std::io;
 use std::time::Duration;
 
@@ -114,7 +113,7 @@ where
         };
 
         // Handle incoming remote_open
-        let remote_max_frame_size = remote_open.max_frame_size.0;
+        let remote_max_frame_size = remote_open.max_frame_size.0 as usize;
         let remote_idle_timeout = remote_open.idle_time_out;
         if let Err(error) = engine
             .connection
@@ -130,11 +129,10 @@ where
         }
 
         // update transport setting
-        let max_frame_size = min(
-            engine.connection.local_open().max_frame_size.0,
-            remote_max_frame_size,
-        );
-        engine.transport.set_max_frame_size(max_frame_size as usize);
+        let local_max_frame_size = engine.connection.local_open().max_frame_size.0 as usize;
+        engine.transport
+            .set_encoder_max_frame_size(remote_max_frame_size)
+            .set_decoder_max_frame_size(local_max_frame_size);
 
         // Set heartbeat here because in pipelined-open, the Open frame
         // may be recved after mux loop is started
@@ -187,19 +185,11 @@ where
         let channel = IncomingChannel(channel);
         match body {
             FrameBody::Open(open) => {
-                let remote_max_frame_size = open.max_frame_size.0;
                 let remote_idle_timeout = open.idle_time_out;
                 self.connection
                     .on_incoming_open(channel, open)
                     .await
                     .map_err(Into::into)?;
-
-                // update transport setting
-                let max_frame_size = min(
-                    self.connection.local_open().max_frame_size.0,
-                    remote_max_frame_size,
-                );
-                self.transport.set_max_frame_size(max_frame_size as usize);
 
                 // Set heartbeat here because in pipelined-open, the Open frame
                 // may be recved after mux loop is started

--- a/fe2o3-amqp/src/frames/amqp.rs
+++ b/fe2o3-amqp/src/frames/amqp.rs
@@ -209,6 +209,8 @@ impl Decoder for FrameDecoder {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         // use fe2o3_amqp_types::definitions::{AmqpError, ConnectionError};
 
+        tracing::debug!(frame_len=?src.len());
+
         let doff = src.get_u8();
         let ftype = src.get_u8();
         let channel = src.get_u16();

--- a/fe2o3-amqp/src/transport/mod.rs
+++ b/fe2o3-amqp/src/transport/mod.rs
@@ -23,9 +23,9 @@ use std::{convert::TryFrom, io, marker::PhantomData, task::Poll, time::Duration}
 use bytes::BytesMut;
 use futures_util::{Future, Sink, SinkExt, Stream, StreamExt};
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, WriteHalf, ReadHalf};
 use tokio_util::codec::{
-    Decoder, Encoder, Framed, LengthDelimitedCodec, LengthDelimitedCodecError,
+    Decoder, Encoder, LengthDelimitedCodec, LengthDelimitedCodecError, FramedRead, FramedWrite
 };
 
 use crate::{
@@ -47,8 +47,15 @@ pin_project! {
     /// Frame transport
     #[derive(Debug)]
     pub struct Transport<Io, Ftype> {
+        // #[pin]
+        // framed: Framed<Io, LengthDelimitedCodec>,
+
         #[pin]
-        framed: Framed<Io, LengthDelimitedCodec>,
+        framed_write: FramedWrite<WriteHalf<Io>, LengthDelimitedCodec>,
+        
+        #[pin]
+        framed_read: FramedRead<ReadHalf<Io>, LengthDelimitedCodec>,
+
         #[pin]
         idle_timeout: Option<IdleTimeout>,
         // frame type
@@ -61,21 +68,30 @@ where
     Io: AsyncRead + AsyncWrite + Unpin,
 {
     /// Consume the transport and return the underlying codec
-    pub fn into_framed_codec(self) -> Framed<Io, LengthDelimitedCodec> {
-        self.framed
+    pub fn into_framed_codec(self) -> (FramedWrite<WriteHalf<Io>, LengthDelimitedCodec>, FramedRead<ReadHalf<Io>, LengthDelimitedCodec>) {
+        (self.framed_write, self.framed_read)
     }
 
     /// Bind to an IO
     pub fn bind(io: Io, max_frame_size: usize, idle_timeout: Option<Duration>) -> Self {
-        let codec = length_delimited_codec(max_frame_size);
-        let framed = Framed::new(io, codec);
+        // let codec = length_delimited_codec(max_frame_size);
+        // let framed = Framed::new(io, codec);
+        let (reader, writer) = tokio::io::split(io);
 
-        Self::bind_to_framed_codec(framed, idle_timeout)
+        let encoder = length_delimited_encoder(max_frame_size);
+        let framed_write = FramedWrite::new(writer, encoder);
+
+        let decoder = length_delimited_decoder(max_frame_size);
+        let framed_read = FramedRead::new(reader, decoder);
+
+        Self::bind_to_framed_codec(framed_write, framed_read, idle_timeout)
     }
 
     /// Bind transport a framed codec
     pub fn bind_to_framed_codec(
-        framed: Framed<Io, LengthDelimitedCodec>,
+        // framed: Framed<Io, LengthDelimitedCodec>,
+        framed_write: FramedWrite<WriteHalf<Io>, LengthDelimitedCodec>,
+        framed_read: FramedRead<ReadHalf<Io>, LengthDelimitedCodec>,
         idle_timeout: Option<Duration>,
     ) -> Self {
         let idle_timeout = match idle_timeout {
@@ -87,7 +103,8 @@ where
         };
 
         Self {
-            framed,
+            framed_write,
+            framed_read,
             idle_timeout,
             ftype: PhantomData,
         }
@@ -153,16 +170,18 @@ where
     /// This is separate from negotiate_amqp_header because SASL header exchange
     /// doesn't modify the connection state
     pub async fn negotiate_sasl_header(
-        mut framed: Framed<Io, ProtocolHeaderCodec>,
+        // mut framed: Framed<Io, ProtocolHeaderCodec>,
+        mut framed_write: FramedWrite<WriteHalf<Io>, ProtocolHeaderCodec>,
+        mut framed_read: FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
     ) -> Result<Self, NegotiationError> {
         let span = span!(Level::TRACE, "SEND");
         let proto_header = ProtocolHeader::sasl();
         event!(parent: &span, Level::TRACE, ?proto_header);
-        framed.send(proto_header).await?;
+        framed_write.send(proto_header).await?;
 
         let span = span!(Level::TRACE, "RECV");
         let incoming_header =
-            framed
+            framed_read
                 .next()
                 .await
                 .ok_or(NegotiationError::Io(std::io::Error::new(
@@ -181,9 +200,11 @@ where
             ));
         }
 
-        let codec = length_delimited_codec(MIN_MAX_FRAME_SIZE);
-        let framed = framed.map_codec(|_| codec);
-        let transport = Self::bind_to_framed_codec(framed, None);
+        let encoder = length_delimited_encoder(MIN_MAX_FRAME_SIZE);
+        let framed_write = framed_write.map_encoder(|_| encoder);
+        let decoder = length_delimited_decoder(MIN_MAX_FRAME_SIZE);
+        let framed_read = framed_read.map_decoder(|_| decoder);
+        let transport = Self::bind_to_framed_codec(framed_write, framed_read, None);
 
         Ok(transport)
     }
@@ -196,29 +217,54 @@ where
     /// Performs AMQP negotiation
     #[instrument(skip_all)]
     pub async fn negotiate_amqp_header(
-        mut framed: Framed<Io, ProtocolHeaderCodec>,
+        mut framed_write: FramedWrite<WriteHalf<Io>, ProtocolHeaderCodec>,
+        mut framed_read: FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
         local_state: &mut ConnectionState,
         idle_timeout: Option<Duration>,
     ) -> Result<Self, NegotiationError> {
         let proto_header = ProtocolHeader::amqp();
-        send_amqp_proto_header(&mut framed, local_state, proto_header.clone()).await?;
-        let _ = recv_amqp_proto_header(&mut framed, local_state, proto_header).await?;
+        send_amqp_proto_header(&mut framed_write, local_state, proto_header.clone()).await?;
+        let _ = recv_amqp_proto_header(&mut framed_read, local_state, proto_header).await?;
 
-        let codec = length_delimited_codec(MIN_MAX_FRAME_SIZE);
-        let framed = framed.map_codec(|_| codec);
-        let transport = Transport::bind_to_framed_codec(framed, idle_timeout);
+        let encoder = length_delimited_encoder(MIN_MAX_FRAME_SIZE);
+        let framed_write = framed_write.map_encoder(|_| encoder);
+        let decoder = length_delimited_decoder(MIN_MAX_FRAME_SIZE);
+        let framed_read = framed_read.map_decoder(|_| decoder);
+        let transport = Transport::bind_to_framed_codec(framed_write, framed_read, idle_timeout);
 
         Ok(transport)
     }
 
-    /// Change the max_frame_size for the transport
-    pub fn set_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
+    // /// Change the max_frame_size for the transport
+    // pub fn set_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
+    //     let max_frame_size = std::cmp::max(MIN_MAX_FRAME_SIZE, max_frame_size);
+    //     self.framed_write
+    //         .encoder_mut()
+    //         .set_max_frame_length(max_frame_size - 4);
+    //     self.framed_read
+    //         .decoder_mut()
+    //         .set_max_frame_length(max_frame_size);
+    //     self
+    // }
+
+    /// Change the max_frame_size for the transport length delimited encoder
+    pub fn set_decoder_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
         let max_frame_size = std::cmp::max(MIN_MAX_FRAME_SIZE, max_frame_size);
-        self.framed
-            .codec_mut()
+        self.framed_read
+            .decoder_mut()
+            .set_max_frame_length(max_frame_size);
+        self
+    }
+
+    /// Change the max_frame_size for the transport length delimited decoder
+    pub fn set_encoder_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
+        let max_frame_size = std::cmp::max(MIN_MAX_FRAME_SIZE, max_frame_size);
+        self.framed_write
+            .encoder_mut()
             .set_max_frame_length(max_frame_size - 4);
         self
     }
+
 
     /// Set the idle timeout of the transport
     pub fn set_idle_timeout(&mut self, duration: Duration) -> &mut Self {
@@ -233,7 +279,7 @@ where
 }
 
 /// Creates a LengthDelimitedCodec that can handle the AMQP and SASL frames
-fn length_delimited_codec(max_frame_size: usize) -> LengthDelimitedCodec {
+fn length_delimited_encoder(max_frame_size: usize) -> LengthDelimitedCodec {
     LengthDelimitedCodec::builder()
         .big_endian()
         .length_field_length(4)
@@ -244,9 +290,18 @@ fn length_delimited_codec(max_frame_size: usize) -> LengthDelimitedCodec {
         .new_codec()
 }
 
+fn length_delimited_decoder(max_frame_size: usize) -> LengthDelimitedCodec {
+    LengthDelimitedCodec::builder()
+        .big_endian()
+        .length_field_length(4)
+        .max_frame_length(max_frame_size)
+        .length_adjustment(-4)
+        .new_codec()
+}
+
 #[instrument(name = "SEND", skip_all)]
 pub(crate) async fn send_amqp_proto_header<Io>(
-    framed: &mut Framed<Io, ProtocolHeaderCodec>,
+    framed_write: &mut FramedWrite<WriteHalf<Io>, ProtocolHeaderCodec>,
     local_state: &mut ConnectionState,
     proto_header: ProtocolHeader,
 ) -> Result<(), NegotiationError>
@@ -256,11 +311,11 @@ where
     trace!(?proto_header);
     match local_state {
         ConnectionState::Start => {
-            framed.send(proto_header).await?;
+            framed_write.send(proto_header).await?;
             *local_state = ConnectionState::HeaderSent;
         }
         ConnectionState::HeaderReceived => {
-            framed.send(proto_header).await?;
+            framed_write.send(proto_header).await?;
             *local_state = ConnectionState::HeaderExchange;
         }
         _ => return Err(NegotiationError::IllegalState), // TODO: is this necessary?
@@ -270,7 +325,7 @@ where
 
 #[instrument(name = "RECV", skip_all)]
 async fn recv_amqp_proto_header<Io>(
-    framed: &mut Framed<Io, ProtocolHeaderCodec>,
+    framed_read: &mut FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
     local_state: &mut ConnectionState,
     proto_header: ProtocolHeader,
 ) -> Result<ProtocolHeader, NegotiationError>
@@ -281,13 +336,13 @@ where
     let proto_header = match local_state {
         ConnectionState::Start => {
             let incoming_header =
-                read_and_compare_amqp_proto_header(framed, local_state, &proto_header).await?;
+                read_and_compare_amqp_proto_header(framed_read, local_state, &proto_header).await?;
             *local_state = ConnectionState::HeaderReceived;
             incoming_header
         }
         ConnectionState::HeaderSent => {
             let incoming_header =
-                read_and_compare_amqp_proto_header(framed, local_state, &proto_header).await?;
+                read_and_compare_amqp_proto_header(framed_read, local_state, &proto_header).await?;
             *local_state = ConnectionState::HeaderExchange;
             incoming_header
         }
@@ -326,7 +381,7 @@ where
 }
 
 async fn read_and_compare_amqp_proto_header<Io>(
-    framed: &mut Framed<Io, ProtocolHeaderCodec>,
+    framed_read: &mut FramedRead<ReadHalf<Io>, ProtocolHeaderCodec>,
     local_state: &mut ConnectionState,
     proto_header: &ProtocolHeader,
 ) -> Result<ProtocolHeader, NegotiationError>
@@ -334,7 +389,7 @@ where
     Io: AsyncRead + AsyncWrite + Unpin,
 {
     // check header
-    let incoming_header = framed
+    let incoming_header = framed_read
         .next()
         .await
         .ok_or(NegotiationError::Io(io::Error::new(
@@ -362,7 +417,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed
+        this.framed_write
             .poll_ready(cx) // Result<_, std::io::Error>
             .map_err(Into::into)
     }
@@ -374,18 +429,18 @@ where
         use std::pin::Pin;
 
         let mut bytesmut = BytesMut::new();
-        let max_frame_size = self.framed.codec().max_frame_length();
+        let max_frame_size = self.framed_write.encoder().max_frame_length();
         let mut encoder = amqp::FrameEncoder::new(max_frame_size);
         encoder.encode(item, &mut bytesmut)?;
 
         while bytesmut.len() > max_frame_size {
             let partial = bytesmut.split_to(max_frame_size);
-            let framed = Pin::new(&mut self.framed);
-            framed.start_send(partial.freeze())?;
+            let writer = Pin::new(&mut self.framed_write);
+            writer.start_send(partial.freeze())?;
         }
 
-        let framed = Pin::new(&mut self.framed);
-        framed
+        let writer = Pin::new(&mut self.framed_write);
+        writer
             .start_send(bytesmut.freeze()) // Result<_, std::io::Error>
             .map_err(Into::into)
     }
@@ -395,7 +450,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed
+        this.framed_write
             .poll_flush(cx) // Result<_, std::io::Error>
             .map_err(Into::into)
     }
@@ -405,7 +460,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed
+        this.framed_write
             .poll_close(cx) // Result<_, std::io::Error>
             .map_err(Into::into)
     }
@@ -424,7 +479,7 @@ where
         let this = self.project();
 
         // First poll codec
-        match this.framed.poll_next(cx) {
+        match this.framed_read.poll_next(cx) {
             Poll::Ready(next) => {
                 if let Some(mut delay) = this.idle_timeout.as_pin_mut() {
                     delay.reset();
@@ -480,7 +535,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed.poll_ready(cx).map_err(Into::into)
+        this.framed_write.poll_ready(cx).map_err(Into::into)
     }
 
     // #[instrument(skip_all)]
@@ -493,7 +548,7 @@ where
         encoder.encode(item, &mut bytesmut)?;
 
         let this = self.project();
-        this.framed
+        this.framed_write
             .start_send(bytesmut.freeze())
             .map_err(Into::into)
     }
@@ -503,7 +558,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed.poll_flush(cx).map_err(Into::into)
+        this.framed_write.poll_flush(cx).map_err(Into::into)
     }
 
     fn poll_close(
@@ -511,7 +566,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
-        this.framed.poll_close(cx).map_err(Into::into)
+        this.framed_write.poll_close(cx).map_err(Into::into)
     }
 }
 
@@ -527,7 +582,7 @@ where
     ) -> Poll<Option<Self::Item>> {
         let this = self.project();
 
-        match this.framed.poll_next(cx) {
+        match this.framed_read.poll_next(cx) {
             Poll::Ready(next) => match next {
                 Some(item) => {
                     let mut src = match item {
@@ -552,7 +607,7 @@ mod tests {
     use fe2o3_amqp_types::{performatives::Open, states::ConnectionState};
     use futures_util::{SinkExt, StreamExt};
     use tokio_test::io::Builder;
-    use tokio_util::codec::{Encoder, Framed, LengthDelimitedCodec};
+    use tokio_util::codec::{Encoder, LengthDelimitedCodec, FramedRead, FramedWrite};
 
     use crate::frames::amqp::FrameEncoder;
 
@@ -622,10 +677,13 @@ mod tests {
             .read(b"AMQP")
             .read(&[0, 1, 0, 0])
             .build();
+        
+        let (reader, writer) = tokio::io::split(mock);
+        let framed_read = FramedRead::new(reader, ProtocolHeaderCodec::new());
+        let framed_write = FramedWrite::new(writer, ProtocolHeaderCodec::new());
 
-        let framed = Framed::new(mock, ProtocolHeaderCodec::new());
         let mut local_state = ConnectionState::Start;
-        Transport::negotiate_amqp_header(framed, &mut local_state, None)
+        Transport::negotiate_amqp_header(framed_write, framed_read, &mut local_state, None)
             .await
             .unwrap();
     }


### PR DESCRIPTION
## Description
This fixes #54, which is caused by two "bug"s

1. The `LengthDelimitedCodec` doesn't make adjustment to the decoded length before checking overflow, and thus would return `LengthDelimitedCodecError` which indicates overflow. This is potentially a bug in the upstream but may take some time to get fixed. 
2. A single `Framed<Io, LengthDelimitedCodec>` was used for both outgoing and incoming frames, which then restricts the `max_frame_length` to be the same no matter the direction of the frame. This would cause the codec to fail when the remote peer send a frame that is larger than `remote_max_frame_size` but smaller than or equal to `local_max_frame_size`.

## Solution

Split the codec into separate encoder and decoder.
Set the encoder `max_frame_length` to `remote_max_frame_size - 4`, and set the decoder `max_frame_length` to `local_max_frame_size` (with `tokio-util` version set to "=0.7.3")
