### PR TITLE
Avoid copy partial payload for multi-frame delivery

### DIFF
--- a/examples/protocol_test/src/bin/connector.rs
+++ b/examples/protocol_test/src/bin/connector.rs
@@ -4,8 +4,8 @@ use fe2o3_amqp::{types::primitives::Value, Connection, Delivery, Receiver, Sende
 use tracing::{instrument, Level};
 use tracing_subscriber::FmtSubscriber;
 
-// const SASL_PLAIN: &str = "";
-const SASL_PLAIN: &str = "guest:guest";
+const SASL_PLAIN: &str = "";
+// const SASL_PLAIN: &str = "guest:guest";
 const BASE_ADDR: &str = "localhost:5672";
 
 #[instrument]

--- a/examples/protocol_test/src/bin/listener.rs
+++ b/examples/protocol_test/src/bin/listener.rs
@@ -34,7 +34,7 @@ async fn session_main(mut session: ListenerSessionHandle) {
                 let handle = tokio::spawn(async move {
                     tracing::info!("Incoming link is connected (remote: sender, local: receiver");
                     let delivery = recver.recv::<Value>().await.unwrap();
-                    tracing::info!(message = ?delivery.message());
+                    tracing::info!(id = ?delivery.delivery_id());
                     recver.accept(&delivery).await.unwrap();
                     if let Err(e) = recver.close().await {
                         // The remote may close the session
@@ -72,7 +72,7 @@ async fn main() {
     // let connection_acceptor = ConnectionAcceptor::new("test_conn_listener");
     let connection_acceptor = ConnectionAcceptor::builder()
         .container_id("example_connection_acceptor")
-        .sasl_acceptor(SaslPlainMechanism::new("guest", "guest"))
+        // .sasl_acceptor(SaslPlainMechanism::new("guest", "guest"))
         .build();
 
     while let Ok((stream, addr)) = tcp_listener.accept().await {

--- a/examples/protocol_test/src/bin/receiver.rs
+++ b/examples/protocol_test/src/bin/receiver.rs
@@ -70,10 +70,7 @@ async fn main() {
     // let body = delivery.into_body();
     println!("{:?}", delivery.delivery_id());
 
-    if let Err(err) = receiver.close().await {
-        println!("{}", err);
-    }
-
+    receiver.close().await.unwrap();
     session.end().await.unwrap();
     connection.close().await.unwrap();
 }

--- a/examples/protocol_test/src/bin/send_large_content.rs
+++ b/examples/protocol_test/src/bin/send_large_content.rs
@@ -206,7 +206,7 @@ async fn main() -> Result<()> {
 
     // let args: Vec<String> = env::args().collect();
     // let test_sender = TestSender::try_from(args)?;
-    let message_iter = create_message_sizes("string", "[10, 10, 10, 10]")?;
+    let message_iter = create_message_sizes("string", "[10, 10]")?;
     let test_sender = TestSender {
         broker_addr: "localhost:5672".to_string(),
         target_addr: "q1".to_string(),

--- a/examples/protocol_test/src/bin/sender.rs
+++ b/examples/protocol_test/src/bin/sender.rs
@@ -22,40 +22,41 @@ async fn main() {
     let subscriber = FmtSubscriber::builder()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
-        .with_max_level(Level::TRACE)
+        .with_max_level(Level::DEBUG)
         // .with_max_level(Level::DEBUG)
         // completes the builder.
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    let addr = "localhost:5671";
-    let domain = "localhost";
-    let stream = TcpStream::connect(addr).await.unwrap();
-    let connector = native_tls::TlsConnector::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap();
-    let connector = tokio_native_tls::TlsConnector::from(connector);
-    let tls_stream = connector.connect(domain, stream).await.unwrap();
+    // let addr = "localhost:5671";
+    // let domain = "localhost";
+    // let stream = TcpStream::connect(addr).await.unwrap();
+    // let connector = native_tls::TlsConnector::builder()
+    //     .danger_accept_invalid_certs(true)
+    //     .build()
+    //     .unwrap();
+    // let connector = tokio_native_tls::TlsConnector::from(connector);
+    // let tls_stream = connector.connect(domain, stream).await.unwrap();
 
-    // let mut connection = Connection::open("connection-1", "amqp://guest:guest@localhost:5671")
+    // let mut connection = Connection::builder()
+    //     .container_id("connection-1")
+    //     .scheme("amqp")
+    //     .max_frame_size(1000)
+    //     .channel_max(9)
+    //     .idle_time_out(50_000 as u32)
+    //     // .sasl_profile(SaslProfile::Plain {
+    //     //     username: "guest".into(),
+    //     //     password: "guest".into(),
+    //     // })
+    //     .open_with_stream(tls_stream)
+    //     // .open("amqp://localhost:5672")
+    //     // .open("amqp://guest:guest@localhost:5672")
+    //     // .open("localhost:5672")
     //     .await
     //     .unwrap();
-    let mut connection = Connection::builder()
-        .container_id("connection-1")
-        .scheme("amqp")
-        .max_frame_size(1000)
-        .channel_max(9)
-        .idle_time_out(50_000 as u32)
-        // .sasl_profile(SaslProfile::Plain {
-        //     username: "guest".into(),
-        //     password: "guest".into(),
-        // })
-        .open_with_stream(tls_stream)
-        // .open("amqp://localhost:5672")
-        // .open("amqp://guest:guest@localhost:5672")
-        // .open("localhost:5672")
+
+    let mut connection = Connection::open("connection-1", "amqp://localhost:5672")
         .await
         .unwrap();
 

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -87,7 +87,7 @@ pub(crate) enum SessionControl {
 impl std::fmt::Display for SessionControl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SessionControl::End(_) => write!(f, "End"),
+            SessionControl::End(err) => write!(f, "End({:?})", err),
             SessionControl::AllocateLink {
                 link_name: _,
                 link_relay: _,

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 use crate::{
     control::SessionControl,
     link::{delivery::Delivery, state::LinkState, LinkFrame},
-    Payload, util::AsByteIterator,
+    Payload, util::{AsByteIterator, IntoReader},
 };
 
 use super::{OutputHandle, Settlement};
@@ -179,7 +179,7 @@ pub(crate) trait ReceiverLink: Link + LinkExt {
     >
     where
         T: DecodeIntoMessage + Send,
-        for<'b> P: io::Read + AsByteIterator<'b> + Send + 'a;
+        for<'b> P: IntoReader + AsByteIterator<'b> + Send + 'a;
 
     async fn dispose(
         &mut self,

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -1,6 +1,7 @@
 //! Defines traits for link implementations
 
 use async_trait::async_trait;
+use bytes::Buf;
 use fe2o3_amqp_types::{
     definitions::{
         DeliveryNumber, DeliveryTag, Error, MessageFormat, ReceiverSettleMode, Role, SequenceNo,
@@ -163,10 +164,10 @@ pub(crate) trait ReceiverLink: Link + LinkExt {
 
     // More than one transfer frames should be hanlded by the
     // `Receiver`
-    async fn on_complete_transfer<'a, T>(
+    async fn on_complete_transfer<'a, T, P>(
         &'a mut self,
         transfer: Transfer,
-        payload: Payload,
+        payload: P,
     ) -> Result<
         (
             Delivery<T>,
@@ -175,7 +176,8 @@ pub(crate) trait ReceiverLink: Link + LinkExt {
         Self::TransferError,
     >
     where
-        T: DecodeIntoMessage + Send;
+        T: DecodeIntoMessage + Send,
+        P: Buf + Send;
 
     async fn dispose(
         &mut self,

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -1,9 +1,6 @@
 //! Defines traits for link implementations
 
-use std::io;
-
 use async_trait::async_trait;
-use bytes::Buf;
 use fe2o3_amqp_types::{
     definitions::{
         DeliveryNumber, DeliveryTag, Error, MessageFormat, ReceiverSettleMode, Role, SequenceNo,

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -1,5 +1,7 @@
 //! Defines traits for link implementations
 
+use std::io;
+
 use async_trait::async_trait;
 use bytes::Buf;
 use fe2o3_amqp_types::{
@@ -15,7 +17,7 @@ use tokio::sync::mpsc;
 use crate::{
     control::SessionControl,
     link::{delivery::Delivery, state::LinkState, LinkFrame},
-    Payload,
+    Payload, util::AsByteIterator,
 };
 
 use super::{OutputHandle, Settlement};
@@ -177,7 +179,7 @@ pub(crate) trait ReceiverLink: Link + LinkExt {
     >
     where
         T: DecodeIntoMessage + Send,
-        P: Buf + Send;
+        for<'b> P: io::Read + AsByteIterator<'b> + Send + 'a;
 
     async fn dispose(
         &mut self,

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -5,7 +5,6 @@ mod source;
 use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use bytes::Buf;
 use fe2o3_amqp_types::{
     definitions::{
         self, AmqpError, DeliveryNumber, DeliveryTag, MessageFormat, ReceiverSettleMode, Role,

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bytes::BytesMut;
 use fe2o3_amqp_types::{
     definitions::{self, DeliveryNumber, DeliveryTag, SequenceNo},
     messaging::{
@@ -21,7 +20,7 @@ use crate::{
     control::SessionControl,
     endpoint::{self, LinkAttach, LinkDetach, LinkExt},
     session::SessionHandle,
-    Payload, util::BytesReader,
+    Payload, 
 };
 
 use super::{
@@ -655,16 +654,14 @@ where
                 Some(mut incomplete) => {
                     incomplete.or_assign(transfer)?;
                     incomplete.buffer.push(payload);
-                    let complete_payload = BytesReader(incomplete.buffer);
 
                     self.link
-                        .on_complete_transfer(incomplete.performative, complete_payload)
+                        .on_complete_transfer(incomplete.performative, incomplete.buffer)
                         .await?
                 }
                 None => {
                     // let message: Message = from_reader(payload.reader())?;
                     // TODO: Is there any way to optimize this?
-                    let payload = BytesReader(payload);
                     // let (section_number, section_offset) = section_number_and_offset(payload.as_ref());
                     self.link.on_complete_transfer(transfer, payload).await?
                 }

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use fe2o3_amqp_types::messaging::message::DecodeIntoMessage;
 use serde_amqp::format_code::EncodingCodes;
 
-use crate::util::AsByteIterator;
+use crate::util::{AsByteIterator, IntoReader};
 
 use super::*;
 
@@ -163,7 +161,7 @@ where
     >
     where
         T: DecodeIntoMessage + Send,
-        for<'b> P: io::Read + AsByteIterator<'b> + Send + 'a,
+        for<'b> P: IntoReader + AsByteIterator<'b> + Send + 'a,
     {
         // ReceiverFlowState will not wait until link credit is available.
         // Will return with an error if there is not enough link credit.
@@ -187,7 +185,7 @@ where
         let (message, delivery_state) = if settled_by_sender {
             // If the message is pre-settled, there is no need to
             // add to the unsettled map and no need to reply to the Sender
-            let message = T::decode_into_message(payload)
+            let message = T::decode_into_message(payload.into_reader())
                 .map_err(|_| Self::TransferError::MessageDecodeError)?;
             (message, None)
         } else {
@@ -213,7 +211,7 @@ where
                 // once it has arrived without waiting for the sender to settle first.
                 ReceiverSettleMode::First => {
                     // Spontaneously settle the message with an Accept
-                    let message = T::decode_into_message(payload)
+                    let message = T::decode_into_message(payload.into_reader())
                         .map_err(|_| Self::TransferError::MessageDecodeError)?;
 
                     (message, Some(DeliveryState::Accepted(Accepted {})))
@@ -225,7 +223,7 @@ where
                     // Add to unsettled map
                     let section_offset = rfind_offset_of_complete_message(&payload)
                         .ok_or(Self::TransferError::MessageDecodeError)?;
-                    let message = T::decode_into_message(payload)
+                    let message = T::decode_into_message(payload.into_reader())
                         .map_err(|_| Self::TransferError::MessageDecodeError)?;
                     let section_number = message.sections();
 
@@ -336,7 +334,7 @@ where
     let len = b0.len();
     let mut iter = b0.zip(b1.zip(b2));
 
-    iter.rposition(|(b0, (b1, b2))| {
+    iter.rposition(|(&b0, (&b1, &b2))| {
         matches!(
             (b0, b1, b2),
             (DESCRIBED_TYPE, SMALL_ULONG_TYPE, DATA_CODE)

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -146,10 +146,10 @@ where
         }
     }
 
-    async fn on_complete_transfer<'a, T>(
+    async fn on_complete_transfer<'a, T, P>(
         &'a mut self,
         transfer: Transfer,
-        payload: Payload,
+        payload: P,
     ) -> Result<
         (
             Delivery<T>,
@@ -159,6 +159,7 @@ where
     >
     where
         T: DecodeIntoMessage + Send,
+        P: Buf + Send,
     {
         // ReceiverFlowState will not wait until link credit is available.
         // Will return with an error if there is not enough link credit.
@@ -218,7 +219,7 @@ where
                 // disposition from the sender.
                 ReceiverSettleMode::Second => {
                     // Add to unsettled map
-                    let section_offset = rfind_offset_of_complete_message(payload.as_ref())
+                    let section_offset = rfind_offset_of_complete_message(payload.chunk())
                         .ok_or(Self::TransferError::MessageDecodeError)?;
                     let message = T::decode_into_message(payload.reader())
                         .map_err(|_| Self::TransferError::MessageDecodeError)?;

--- a/fe2o3-amqp/src/util/mod.rs
+++ b/fe2o3-amqp/src/util/mod.rs
@@ -1,5 +1,6 @@
 //! Common utilities
 
+use bytes::Bytes;
 use futures_util::Future;
 use std::ops::Deref;
 use std::{pin::Pin, task::Poll, time::Duration};
@@ -10,6 +11,8 @@ mod consumer;
 mod producer;
 pub use consumer::*;
 pub use producer::*;
+
+use crate::Payload;
 
 #[derive(Debug)]
 pub(crate) enum Running {
@@ -77,3 +80,86 @@ pub struct Uninitialized {}
 /// Shared type state for builders
 #[derive(Debug)]
 pub struct Initialized {}
+
+pub(crate) trait AsByteIterator<'a> {
+    type IterImpl: Iterator<Item = u8> + ExactSizeIterator + DoubleEndedIterator;
+
+    fn as_byte_iterator(&'a self) -> Self::IterImpl;
+}
+
+/// This is used as a buffer for multi-frame delivery
+#[derive(Debug)]
+pub(crate) struct BytesReader<T>(pub T);
+
+impl std::io::Read for BytesReader<Vec<Payload>> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        todo!()
+    }
+}
+
+impl<'a> AsByteIterator<'a> for BytesReader<Vec<Payload>> {
+    type IterImpl = BytesReaderIter<Vec<&'a [u8]>>;
+    
+    fn as_byte_iterator(&self) -> Self::IterImpl {
+        todo!()
+    }
+}
+
+impl std::io::Read for BytesReader<Payload> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        todo!()
+    }
+}
+
+impl<'a> AsByteIterator<'a> for BytesReader<Payload> {
+    type IterImpl = BytesReaderIter<&'a [u8]>;
+    
+    fn as_byte_iterator(&self) -> Self::IterImpl {
+        todo!()
+    }
+}
+
+pub(crate) struct BytesReaderIter<T>(pub T);
+
+/// 
+// pub(crate) struct BytesReaderIter<'a>(pub Vec<&'a [u8]>);
+
+impl<'a> Iterator for BytesReaderIter<Vec<&'a [u8]>> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+impl<'a> ExactSizeIterator for BytesReaderIter<Vec<&'a [u8]>> {
+    fn len(&self) -> usize {
+        todo!()
+    }
+}
+
+impl<'a> DoubleEndedIterator for BytesReaderIter<Vec<&'a [u8]>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+impl<'a> Iterator for BytesReaderIter<&'a [u8]> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+impl<'a> ExactSizeIterator for BytesReaderIter<&'a [u8]> {
+    fn len(&self) -> usize {
+        todo!()
+    }
+}
+
+impl<'a> DoubleEndedIterator for BytesReaderIter<&'a [u8]> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/fe2o3-amqp/src/util/mod.rs
+++ b/fe2o3-amqp/src/util/mod.rs
@@ -1,8 +1,10 @@
 //! Common utilities
 
-use bytes::Bytes;
+use bytes::{Buf, buf};
 use futures_util::Future;
+use std::io;
 use std::ops::Deref;
+use std::slice::Iter;
 use std::{pin::Pin, task::Poll, time::Duration};
 use tokio::time::Instant;
 use tokio::time::Sleep;
@@ -82,84 +84,165 @@ pub struct Uninitialized {}
 pub struct Initialized {}
 
 pub(crate) trait AsByteIterator<'a> {
-    type IterImpl: Iterator<Item = u8> + ExactSizeIterator + DoubleEndedIterator;
+    type IterImpl: Iterator<Item = &'a u8> + ExactSizeIterator + DoubleEndedIterator;
 
     fn as_byte_iterator(&'a self) -> Self::IterImpl;
 }
 
-/// This is used as a buffer for multi-frame delivery
-#[derive(Debug)]
-pub(crate) struct BytesReader<T>(pub T);
+pub(crate) trait IntoReader {
+    type Reader: io::Read;
 
-impl std::io::Read for BytesReader<Vec<Payload>> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        todo!()
+    fn into_reader(self) -> Self::Reader;
+}
+
+impl IntoReader for Payload {
+    type Reader = buf::Reader<Payload>;
+
+    fn into_reader(self) -> Self::Reader {
+        self.reader()
     }
 }
 
-impl<'a> AsByteIterator<'a> for BytesReader<Vec<Payload>> {
-    type IterImpl = BytesReaderIter<Vec<&'a [u8]>>;
+impl<'a> AsByteIterator<'a> for Payload {
+    type IterImpl = std::slice::Iter<'a, u8>;
     
-    fn as_byte_iterator(&self) -> Self::IterImpl {
-        todo!()
+    fn as_byte_iterator(&'a self) -> Self::IterImpl {
+        self.iter()
     }
 }
 
-impl std::io::Read for BytesReader<Payload> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        todo!()
+impl IntoReader for Vec<Payload> {
+    type Reader = ByteReader<Payload>;
+
+    fn into_reader(self) -> Self::Reader {
+        ByteReader {
+            inner: self
+        }
     }
 }
 
-impl<'a> AsByteIterator<'a> for BytesReader<Payload> {
-    type IterImpl = BytesReaderIter<&'a [u8]>;
-    
-    fn as_byte_iterator(&self) -> Self::IterImpl {
-        todo!()
+impl<'a> AsByteIterator<'a> for Vec<Payload> {
+    type IterImpl = ByteReaderIter<'a>;
+
+    fn as_byte_iterator(&'a self) -> Self::IterImpl {
+        ByteReaderIter {
+            inner: self.iter().map(|p| p.iter()).collect()
+        }
     }
 }
 
-pub(crate) struct BytesReaderIter<T>(pub T);
+pub(crate) struct ByteReader<T> {
+    inner: Vec<T>,
+}
 
-/// 
-// pub(crate) struct BytesReaderIter<'a>(pub Vec<&'a [u8]>);
+impl io::Read for ByteReader<Payload> {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        let mut nbytes_read = 0;
 
-impl<'a> Iterator for BytesReaderIter<Vec<&'a [u8]>> {
-    type Item = u8;
+        for payload in self.inner.iter_mut() {
+            if payload.remaining() >= dst.len() - nbytes_read {
+                let mut partial = payload.split_to(dst.len()-nbytes_read);
+                Buf::copy_to_slice(&mut partial, &mut dst[nbytes_read..]);
+                nbytes_read = dst.len();
+                break
+            } else if payload.remaining() < dst.len() {
+                let remaining = payload.remaining();
+                Buf::copy_to_slice(payload, &mut dst[nbytes_read..nbytes_read+remaining]);
+                nbytes_read += remaining;
+            } 
+        }
+        
+        Ok(nbytes_read)
+    }
+}
+
+pub(crate) struct ByteReaderIter<'a> {
+    pub inner: Vec<Iter<'a, u8>>,
+}
+
+impl<'a> Iterator for ByteReaderIter<'a> {
+    type Item = &'a u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+        self.inner.iter_mut().flat_map(|iter| iter.next()).next()
     }
 }
 
-impl<'a> ExactSizeIterator for BytesReaderIter<Vec<&'a [u8]>> {
-    fn len(&self) -> usize {
-        todo!()
+impl<'a> ExactSizeIterator for ByteReaderIter<'a> {
+    fn len(&self) -> usize {    
+        self.inner.iter().map(|iter| iter.len()).sum()
     }
 }
 
-impl<'a> DoubleEndedIterator for BytesReaderIter<Vec<&'a [u8]>> {
+impl<'a> DoubleEndedIterator for ByteReaderIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        todo!()
+        self.inner.iter_mut().flat_map(|iter| iter.next_back()).next_back()
     }
 }
 
-impl<'a> Iterator for BytesReaderIter<&'a [u8]> {
-    type Item = u8;
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+    use bytes::{Bytes, Buf};
+
+    use super::{IntoReader, AsByteIterator};
+
+    #[test]
+    fn test_multile_payload_reader() {
+        let b0 = Bytes::from(vec![1, 2, 3]);
+        let b1 = Bytes::from(vec![4, 5, 6, 7, 8]);
+        let b2 = Bytes::from(vec![9]);
+
+        let v = vec![b0, b1, b2];
+        let mut reader = v.into_reader();
+
+        let mut buf = [0u8; 1];
+        let nread = reader.read(&mut buf).unwrap();
+        assert_eq!(nread, 1);
+        assert_eq!(buf, [1u8]);
+
+        let mut buf = [0u8; 1];
+        let nread = reader.read(&mut buf).unwrap();
+        assert_eq!(nread, 1);
+        assert_eq!(buf, [2u8]);
+
+        let mut buf = [0u8; 3];
+        let nread = reader.read(&mut buf).unwrap();
+        assert_eq!(nread, 3);
+        assert_eq!(buf, [3, 4, 5]);
+
+        let mut buf = [0u8; 10];
+        let nread = reader.read(&mut buf).unwrap();
+        assert_eq!(nread, 4);
+        assert_eq!(buf, [6, 7, 8, 9, 0, 0, 0, 0, 0, 0]);
     }
-}
 
-impl<'a> ExactSizeIterator for BytesReaderIter<&'a [u8]> {
-    fn len(&self) -> usize {
-        todo!()
+    #[test]
+    fn test_regular_read() {
+        let src = &[1u8, 2, 3, 4];
+        let mut dst = [0u8; 6];
+
+        let nread = src.reader().read(&mut dst).unwrap();
+        assert_eq!(nread, 4);
+        assert_eq!(dst, [1, 2, 3, 4, 0, 0]);
     }
-}
 
-impl<'a> DoubleEndedIterator for BytesReaderIter<&'a [u8]> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        todo!()
+    #[test]
+    fn test_multiply_payload_iter() {
+        let b0 = Bytes::from(vec![1, 2, 3]);
+        let b1 = Bytes::from(vec![4, 5, 6, 7, 8]);
+        let b2 = Bytes::from(vec![9]);
+
+        let v = vec![b0, b1, b2];
+        let iter = v.as_byte_iterator();
+        assert_eq!(iter.len(), 9);
+        
+        let forward: Vec<u8> = iter.map(|e| *e).collect();
+        assert_eq!(forward, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        let iter = v.as_byte_iterator();
+        let reverse: Vec<u8> = iter.rev().map(|e| *e).collect();
+        assert_eq!(reverse, vec![9, 8, 7, 6, 5, 4, 3, 2, 1]);
     }
 }


### PR DESCRIPTION
The original implementation copies partial payload to a buffer for multi-frame deliveries. In this PR, instead of maintaining a single buffer where partial payloads are copied over, a `Vec<Payload>` is used to store the partial deliveries, and thus avoiding large number of memory copy for large content.

In a very non-scientific "benchmark" (`amqp-large-content-test` with only the `fe2o3-amqp` shim enabled and all the types), it is found:

1. the old implementation takes about 1.21 seconds
2. the new implementation takes about 0.81 seconds

The test environment is a Ubuntu 20.04 WSL2 with qdrouterd 0.37.0 running as broker.
