### PR TITLE
96 alternative map

### DIFF
--- a/fe2o3-amqp-ext/Cargo.toml
+++ b/fe2o3-amqp-ext/Cargo.toml
@@ -12,7 +12,7 @@ readme = "Readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_amqp = { version = "0.3.1", features = ["derive"] }
-# serde_amqp = { path = "../serde_amqp", features = ["derive"] }
-fe2o3-amqp-types = "0.4.1"
-# fe2o3-amqp-types = { path = "../fe2o3-amqp-types" }
+# serde_amqp = { version = "0.3.1", features = ["derive"] }
+serde_amqp = { path = "../serde_amqp", features = ["derive"] }
+# fe2o3-amqp-types = "0.4.1"
+fe2o3-amqp-types = { path = "../fe2o3-amqp-types" }

--- a/fe2o3-amqp-ext/src/filters.rs
+++ b/fe2o3-amqp-ext/src/filters.rs
@@ -1,8 +1,6 @@
 //! Define filters from AMQP Capabilities Registry: Filters
 //! https://svn.apache.org/repos/asf/qpid/trunk/qpid/specs/apache-filters.xml#section-legacy-amqp
 
-use std::collections::BTreeMap;
-
 use fe2o3_amqp_types::primitives::{SimpleValue, Symbol, OrderedMap};
 use serde_amqp::{
     described::Described, descriptor::Descriptor, value::Value, DeserializeComposite,

--- a/fe2o3-amqp-ext/src/filters.rs
+++ b/fe2o3-amqp-ext/src/filters.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use fe2o3_amqp_types::primitives::{SimpleValue, Symbol};
+use fe2o3_amqp_types::primitives::{SimpleValue, Symbol, OrderedMap};
 use serde_amqp::{
     described::Described, descriptor::Descriptor, value::Value, DeserializeComposite,
     SerializeComposite,
@@ -130,7 +130,7 @@ impl From<LegacyAmqpTopicBinding> for Option<Described<Value>> {
     code = 0x0000_468c_0000_0002,
     encoding = "basic"
 )]
-pub struct LegacyAmqpHeadersBinding(pub BTreeMap<String, SimpleValue>);
+pub struct LegacyAmqpHeadersBinding(pub OrderedMap<String, SimpleValue>);
 
 impl LegacyAmqpHeadersBinding {
     /// Returns the descriptor code
@@ -144,7 +144,7 @@ impl LegacyAmqpHeadersBinding {
     }
 }
 
-impl From<LegacyAmqpHeadersBinding> for Described<BTreeMap<String, SimpleValue>> {
+impl From<LegacyAmqpHeadersBinding> for Described<OrderedMap<String, SimpleValue>> {
     fn from(value: LegacyAmqpHeadersBinding) -> Self {
         Self {
             descriptor: Descriptor::Code(0x0000_468c_0000_0002),

--- a/fe2o3-amqp-types/Cargo.toml
+++ b/fe2o3-amqp-types/Cargo.toml
@@ -33,8 +33,8 @@ transaction = ["primitive", "messaging"]
 security = ["primitive"]
 
 [dependencies]
-# serde_amqp = { path = "../serde_amqp", features = ["derive"] }
-serde_amqp = { version = "0.3.1", features = ["derive"] }
+serde_amqp = { path = "../serde_amqp", features = ["derive"] }
+# serde_amqp = { version = "0.3.1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 ordered-float = { version = "3", features = ["serde"] }

--- a/fe2o3-amqp-types/src/definitions/mod.rs
+++ b/fe2o3-amqp-types/src/definitions/mod.rs
@@ -2,10 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use std::collections::BTreeMap;
 
 use serde_amqp::{
-    primitives::{Symbol, UInt},
+    primitives::{Symbol, UInt, OrderedMap},
     value::Value,
 };
 
@@ -69,7 +68,7 @@ pub type MessageFormat = UInt;
 pub type IetfLanguageTag = Symbol;
 
 /// 2.8.13 Fields
-pub type Fields = BTreeMap<Symbol, Value>;
+pub type Fields = OrderedMap<Symbol, Value>;
 
 /// 2.8.14 Error
 mod error;

--- a/fe2o3-amqp-types/src/messaging/format/map_builder.rs
+++ b/fe2o3-amqp-types/src/messaging/format/map_builder.rs
@@ -1,8 +1,11 @@
 //! AnnotationBuilder for types that are simply a wrapper around Annotation
 
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{hash::Hash, marker::PhantomData};
 
-use serde_amqp::{primitives::Symbol, Value};
+use serde_amqp::{
+    primitives::{OrderedMap, Symbol},
+    Value,
+};
 
 use crate::primitives::SimpleValue;
 
@@ -13,32 +16,32 @@ use super::{ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotatio
 ///
 /// This simply provides a convenient way of inserting entries into the map
 #[derive(Debug)]
-pub struct MapBuilder<K, V, T>
-where
-    K: Ord,
-{
-    map: BTreeMap<K, V>,
+pub struct MapBuilder<K, V, T> {
+    map: OrderedMap<K, V>,
     marker: PhantomData<T>,
 }
 
-impl<K: Ord, V, T> Default for MapBuilder<K, V, T> {
+impl<K, V, T> Default for MapBuilder<K, V, T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<K, V, T> MapBuilder<K, V, T>
-where
-    K: Ord,
 {
     /// Creates a new builder for annotation types
     pub fn new() -> Self {
         Self {
-            map: BTreeMap::new(),
+            map: OrderedMap::new(),
             marker: PhantomData,
         }
     }
+}
 
+impl<K, V, T> MapBuilder<K, V, T>
+where
+    K: Hash + Eq,
+{
     /// A convenience method to insert an entry into the annotation map
     pub fn insert(mut self, key: impl Into<K>, value: impl Into<V>) -> Self {
         self.map.insert(key.into(), value.into());

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -1,11 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_amqp::{
     macros::{DeserializeComposite, SerializeComposite},
-    primitives::{Boolean, Symbol, UByte, UInt},
+    primitives::{Boolean, Symbol, UByte, UInt, OrderedMap},
     value::Value,
 };
 use std::{
-    collections::BTreeMap,
     ops::{Deref, DerefMut},
 };
 
@@ -149,7 +148,7 @@ use self::map_builder::MapBuilder;
     code = 0x0000_0000_0000_0074,
     encoding = "basic"
 )]
-pub struct ApplicationProperties(pub BTreeMap<String, SimpleValue>);
+pub struct ApplicationProperties(pub OrderedMap<String, SimpleValue>);
 
 impl ApplicationProperties {
     /// Creates a builder for ApplicationProperties
@@ -159,7 +158,7 @@ impl ApplicationProperties {
 }
 
 impl Deref for ApplicationProperties {
-    type Target = BTreeMap<String, SimpleValue>;
+    type Target = OrderedMap<String, SimpleValue>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -223,7 +222,7 @@ impl DerefMut for Footer {
 /// keys, and all symbolic keys except those beginning with “x-” are reserved. Keys beginning with “x-opt-” MUST be
 /// ignored if not understood. On receiving an annotation key which is not understood, and which does not begin with
 /// “x-opt”, the receiving AMQP container MUST detach the link with a not-implemented error.
-pub type Annotations = BTreeMap<Symbol, Value>;
+pub type Annotations = OrderedMap<Symbol, Value>;
 
 mod message_id;
 pub use message_id::*;

--- a/fe2o3-amqp-types/src/messaging/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/mod.rs
@@ -2,9 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 use serde_amqp::described::Described;
-use serde_amqp::primitives::Array;
+use serde_amqp::primitives::{Array, OrderedMap};
 use serde_amqp::{primitives::Symbol, value::Value};
-use std::collections::BTreeMap;
 
 pub mod message;
 pub use message::{Body, Message};
@@ -52,7 +51,7 @@ pub use lifetime_policy::*;
 /// A registry of commonly defined filter types and their capabilities is
 /// maintained \[AMQPFILTERS\].
 ///
-pub type FilterSet = BTreeMap<Symbol, Option<Described<Value>>>;
+pub type FilterSet = OrderedMap<Symbol, Option<Described<Value>>>;
 
 use crate::definitions::Fields;
 

--- a/fe2o3-amqp-types/src/messaging/source.rs
+++ b/fe2o3-amqp-types/src/messaging/source.rs
@@ -1,8 +1,6 @@
-use std::collections::BTreeMap;
-
 use serde_amqp::described::Described;
 use serde_amqp::macros::{DeserializeComposite, SerializeComposite};
-use serde_amqp::primitives::{Array, Boolean, Symbol};
+use serde_amqp::primitives::{Array, Boolean, Symbol, OrderedMap};
 use serde_amqp::Value;
 
 use crate::definitions::{Fields, Seconds};
@@ -239,7 +237,7 @@ impl SourceBuilder {
     ) -> Self {
         self.source
             .filter
-            .get_or_insert(BTreeMap::new())
+            .get_or_insert(OrderedMap::new())
             .insert(key.into(), value.into());
         self
     }

--- a/fe2o3-amqp-types/src/performatives/attach.rs
+++ b/fe2o3-amqp-types/src/performatives/attach.rs
@@ -1,8 +1,6 @@
-use std::collections::BTreeMap;
-
 use serde_amqp::{
     macros::{DeserializeComposite, SerializeComposite},
-    primitives::{Array, Boolean, Symbol, ULong},
+    primitives::{Array, Boolean, Symbol, ULong, OrderedMap},
 };
 
 use crate::{
@@ -89,7 +87,7 @@ pub struct Attach {
     pub target: Option<Box<TargetArchetype>>,
 
     /// <field name="unsettled" type="map"/>
-    pub unsettled: Option<BTreeMap<DeliveryTag, Option<DeliveryState>>>,
+    pub unsettled: Option<OrderedMap<DeliveryTag, Option<DeliveryState>>>,
 
     /// <field name="incomplete-unsettled" type="boolean" default="false"/>
     #[amqp_contract(default)]
@@ -198,7 +196,7 @@ mod tests {
         let s = std::mem::size_of::<Option<Box<TargetArchetype>>>();
         println!("target {:?}", s);
 
-        let s = std::mem::size_of::<Option<BTreeMap<DeliveryTag, DeliveryState>>>();
+        let s = std::mem::size_of::<Option<OrderedMap<DeliveryTag, DeliveryState>>>();
         println!("unsettled {:?}", s);
 
         let s = std::mem::size_of::<Boolean>();

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -44,10 +44,10 @@ tokio-test = { version = "0.4" }
 testcontainers = "0.14"
 
 [dependencies]
-serde_amqp = "0.3.1"
-# serde_amqp = { path = "../serde_amqp" }
-fe2o3-amqp-types = "0.4.1"
-# fe2o3-amqp-types = { path = "../fe2o3-amqp-types" }
+# serde_amqp = "0.3.1"
+serde_amqp = { path = "../serde_amqp" }
+# fe2o3-amqp-types = "0.4.1"
+fe2o3-amqp-types = { path = "../fe2o3-amqp-types" }
 
 bytes = "1"
 tokio = { version = "^1.16.1", features = ["io-util", "net", "rt", "macros"] }

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -1,13 +1,13 @@
 //! Implements AMQP1.0 Connection
 
-use std::{cmp::min, collections::BTreeMap, convert::TryInto, sync::Arc};
+use std::{cmp::min, convert::TryInto, sync::Arc};
 
 use async_trait::async_trait;
 
 use fe2o3_amqp_types::{
     definitions::{self},
     performatives::{Begin, Close, End, Open},
-    states::ConnectionState,
+    states::ConnectionState, primitives::OrderedMap,
 };
 use futures_util::{Sink, SinkExt};
 use slab::Slab;
@@ -347,7 +347,7 @@ pub struct Connection {
     // local
     pub(crate) local_state: ConnectionState,
     pub(crate) local_open: Open,
-    pub(crate) session_by_incoming_channel: BTreeMap<IncomingChannel, SessionRelay>,
+    pub(crate) session_by_incoming_channel: OrderedMap<IncomingChannel, SessionRelay>,
     pub(crate) session_by_outgoing_channel: Slab<SessionRelay>,
 
     // remote
@@ -461,7 +461,7 @@ impl Connection {
             // control,
             local_state,
             local_open,
-            session_by_incoming_channel: BTreeMap::new(),
+            session_by_incoming_channel: OrderedMap::new(),
             session_by_outgoing_channel: Slab::new(),
 
             remote_open: None,

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -1,13 +1,13 @@
 //! Implements AMQP1.0 Connection
 
-use std::{cmp::min, convert::TryInto, sync::Arc};
+use std::{cmp::min, convert::TryInto, sync::Arc, collections::HashMap};
 
 use async_trait::async_trait;
 
 use fe2o3_amqp_types::{
     definitions::{self},
     performatives::{Begin, Close, End, Open},
-    states::ConnectionState, primitives::OrderedMap,
+    states::ConnectionState,
 };
 use futures_util::{Sink, SinkExt};
 use slab::Slab;
@@ -347,7 +347,7 @@ pub struct Connection {
     // local
     pub(crate) local_state: ConnectionState,
     pub(crate) local_open: Open,
-    pub(crate) session_by_incoming_channel: OrderedMap<IncomingChannel, SessionRelay>,
+    pub(crate) session_by_incoming_channel: HashMap<IncomingChannel, SessionRelay>,
     pub(crate) session_by_outgoing_channel: Slab<SessionRelay>,
 
     // remote
@@ -461,7 +461,7 @@ impl Connection {
             // control,
             local_state,
             local_open,
-            session_by_incoming_channel: OrderedMap::new(),
+            session_by_incoming_channel: HashMap::new(),
             session_by_outgoing_channel: Slab::new(),
 
             remote_open: None,

--- a/fe2o3-amqp/src/endpoint/mod.rs
+++ b/fe2o3-amqp/src/endpoint/mod.rs
@@ -62,7 +62,7 @@ impl From<OutgoingChannel> for u16 {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub(crate) struct IncomingChannel(pub u16);
 
 impl From<IncomingChannel> for u16 {
@@ -71,7 +71,7 @@ impl From<IncomingChannel> for u16 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub(crate) struct OutputHandle(pub UInt);
 
 impl From<Handle> for OutputHandle {
@@ -86,7 +86,7 @@ impl From<OutputHandle> for Handle {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub(crate) struct InputHandle(pub UInt);
 
 impl From<Handle> for InputHandle {

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -34,7 +34,7 @@ use crate::{
 use self::{
     delivery::Delivery,
     resumption::ResumingDelivery,
-    state::{LinkFlowState, LinkState, UnsettledMap},
+    state::{LinkFlowState, LinkState},
     target_archetype::VerifyTargetArchetype,
 };
 
@@ -59,6 +59,10 @@ pub(crate) mod target_archetype;
 
 /// Default amount of link credit
 pub const DEFAULT_CREDIT: SequenceNo = 200;
+
+/// An OrderedMap is used because Link may exchange their unsettled map 
+/// and `Map` should be considered ordered
+pub(crate) type UnsettledMap<M> = OrderedMap<DeliveryTag, M>;
 
 pub(crate) type SenderFlowState = Consumer<Arc<LinkFlowState<role::SenderMarker>>>;
 pub(crate) type ReceiverFlowState = Arc<LinkFlowState<role::ReceiverMarker>>;

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -1,6 +1,6 @@
 //! Implements AMQP1.0 Link
 
-use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
@@ -11,7 +11,7 @@ use fe2o3_amqp_types::{
     },
     messaging::{DeliveryState, Received, Source, Target, TargetArchetype},
     performatives::{Attach, Detach, Disposition, Transfer},
-    primitives::Symbol,
+    primitives::{Symbol, OrderedMap},
 };
 
 pub use error::*;
@@ -222,7 +222,7 @@ where
         &self,
         is_reattaching: bool,
         partial_unsettled: usize,
-    ) -> Option<BTreeMap<DeliveryTag, Option<DeliveryState>>> {
+    ) -> Option<OrderedMap<DeliveryTag, Option<DeliveryState>>> {
         // When reattaching (as opposed to resuming), the unsettled map MUST be null.
         if is_reattaching {
             return None;

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -258,7 +258,7 @@ where
                 {
                     let mut guard = self.unsettled.write().await;
                     guard
-                        .get_or_insert(BTreeMap::new())
+                        .get_or_insert(OrderedMap::new())
                         .insert(delivery_tag.clone(), unsettled);
                 }
 
@@ -416,7 +416,7 @@ async fn send_disposition(
 impl<T> SenderLink<T> {
     async fn handle_unsettled_in_attach(
         &mut self,
-        remote_unsettled: Option<BTreeMap<DeliveryTag, Option<DeliveryState>>>,
+        remote_unsettled: Option<OrderedMap<DeliveryTag, Option<DeliveryState>>>,
     ) -> Result<SenderAttachExchange, SenderAttachError> {
         let mut guard = self.unsettled.write().await;
         let v: Vec<(DeliveryTag, ResumingDelivery)> = match (guard.take(), remote_unsettled) {

--- a/fe2o3-amqp/src/link/state.rs
+++ b/fe2o3-amqp/src/link/state.rs
@@ -3,7 +3,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use fe2o3_amqp_types::{definitions::{DeliveryTag, Fields, SequenceNo}, primitives::OrderedMap};
+use fe2o3_amqp_types::{definitions::{Fields, SequenceNo}};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -286,8 +286,6 @@ impl LinkFlowState<role::ReceiverMarker> {
         }
     }
 }
-
-pub(crate) type UnsettledMap<M> = OrderedMap<DeliveryTag, M>;
 
 #[async_trait]
 impl ProducerState for Arc<LinkFlowState<role::SenderMarker>> {

--- a/fe2o3-amqp/src/link/state.rs
+++ b/fe2o3-amqp/src/link/state.rs
@@ -1,9 +1,9 @@
 //! Link state and link flow state
 
-use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use fe2o3_amqp_types::definitions::{DeliveryTag, Fields, SequenceNo};
+use fe2o3_amqp_types::{definitions::{DeliveryTag, Fields, SequenceNo}, primitives::OrderedMap};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -287,8 +287,7 @@ impl LinkFlowState<role::ReceiverMarker> {
     }
 }
 
-// pub type UnsettledMap<M> = BTreeMap<[u8; 4], M>;
-pub(crate) type UnsettledMap<M> = BTreeMap<DeliveryTag, M>;
+pub(crate) type UnsettledMap<M> = OrderedMap<DeliveryTag, M>;
 
 #[async_trait]
 impl ProducerState for Arc<LinkFlowState<role::SenderMarker>> {

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -1,6 +1,8 @@
 //! Session builder
 
-use fe2o3_amqp_types::{definitions::{Fields, Handle, TransferNumber}, primitives::OrderedMap};
+use std::collections::HashMap;
+
+use fe2o3_amqp_types::{definitions::{Fields, Handle, TransferNumber}};
 use serde_amqp::primitives::Symbol;
 use slab::Slab;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -110,9 +112,9 @@ impl Builder {
             properties: self.properties,
 
             link_name_by_output_handle: Slab::new(),
-            link_by_name: OrderedMap::new(),
-            link_by_input_handle: OrderedMap::new(),
-            delivery_tag_by_id: OrderedMap::new(),
+            link_by_name: HashMap::new(),
+            link_by_input_handle: HashMap::new(),
+            delivery_tag_by_id: HashMap::new(),
         }
     }
 

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -146,9 +146,9 @@ impl Builder {
             properties: self.properties,
 
             link_name_by_output_handle: Slab::new(),
-            link_by_name: OrderedMap::new(),
-            link_by_input_handle: OrderedMap::new(),
-            delivery_tag_by_id: OrderedMap::new(),
+            link_by_name: HashMap::new(),
+            link_by_input_handle: HashMap::new(),
+            delivery_tag_by_id: HashMap::new(),
         };
 
         TxnSession {

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -1,8 +1,6 @@
 //! Session builder
 
-use std::collections::BTreeMap;
-
-use fe2o3_amqp_types::definitions::{Fields, Handle, TransferNumber};
+use fe2o3_amqp_types::{definitions::{Fields, Handle, TransferNumber}, primitives::OrderedMap};
 use serde_amqp::primitives::Symbol;
 use slab::Slab;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -112,9 +110,9 @@ impl Builder {
             properties: self.properties,
 
             link_name_by_output_handle: Slab::new(),
-            link_by_name: BTreeMap::new(),
-            link_by_input_handle: BTreeMap::new(),
-            delivery_tag_by_id: BTreeMap::new(),
+            link_by_name: OrderedMap::new(),
+            link_by_input_handle: OrderedMap::new(),
+            delivery_tag_by_id: OrderedMap::new(),
         }
     }
 
@@ -146,9 +144,9 @@ impl Builder {
             properties: self.properties,
 
             link_name_by_output_handle: Slab::new(),
-            link_by_name: BTreeMap::new(),
-            link_by_input_handle: BTreeMap::new(),
-            delivery_tag_by_id: BTreeMap::new(),
+            link_by_name: OrderedMap::new(),
+            link_by_input_handle: OrderedMap::new(),
+            delivery_tag_by_id: OrderedMap::new(),
         };
 
         TxnSession {

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -1,14 +1,12 @@
 //! Implements AMQP1.0 Session
 
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use fe2o3_amqp_types::{
     definitions::{
         self, DeliveryNumber, DeliveryTag, Fields, Handle, Role, SequenceNo, TransferNumber,
     },
     performatives::{Attach, Begin, Detach, Disposition, End, Flow, Transfer},
-    primitives::{Symbol, UInt},
+    primitives::{Symbol, UInt, OrderedMap},
     states::SessionState,
 };
 use slab::Slab;
@@ -228,10 +226,10 @@ pub struct Session {
 
     // local links by output handle
     pub(crate) link_name_by_output_handle: Slab<String>,
-    pub(crate) link_by_name: BTreeMap<String, Option<LinkRelay<OutputHandle>>>,
-    pub(crate) link_by_input_handle: BTreeMap<InputHandle, LinkRelay<OutputHandle>>,
+    pub(crate) link_by_name: OrderedMap<String, Option<LinkRelay<OutputHandle>>>,
+    pub(crate) link_by_input_handle: OrderedMap<InputHandle, LinkRelay<OutputHandle>>,
     // Maps from DeliveryId to link.DeliveryCount
-    pub(crate) delivery_tag_by_id: BTreeMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
+    pub(crate) delivery_tag_by_id: OrderedMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
 }
 
 impl Session {

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -1,12 +1,14 @@
 //! Implements AMQP1.0 Session
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use fe2o3_amqp_types::{
     definitions::{
         self, DeliveryNumber, DeliveryTag, Fields, Handle, Role, SequenceNo, TransferNumber,
     },
     performatives::{Attach, Begin, Detach, Disposition, End, Flow, Transfer},
-    primitives::{Symbol, UInt, OrderedMap},
+    primitives::{Symbol, UInt},
     states::SessionState,
 };
 use slab::Slab;
@@ -226,10 +228,10 @@ pub struct Session {
 
     // local links by output handle
     pub(crate) link_name_by_output_handle: Slab<String>,
-    pub(crate) link_by_name: OrderedMap<String, Option<LinkRelay<OutputHandle>>>,
-    pub(crate) link_by_input_handle: OrderedMap<InputHandle, LinkRelay<OutputHandle>>,
+    pub(crate) link_by_name: HashMap<String, Option<LinkRelay<OutputHandle>>>,
+    pub(crate) link_by_input_handle: HashMap<InputHandle, LinkRelay<OutputHandle>>,
     // Maps from DeliveryId to link.DeliveryCount
-    pub(crate) delivery_tag_by_id: OrderedMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
+    pub(crate) delivery_tag_by_id: HashMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
 }
 
 impl Session {

--- a/fe2o3-amqp/src/transaction/manager.rs
+++ b/fe2o3-amqp/src/transaction/manager.rs
@@ -1,6 +1,6 @@
 //! Manages incoming transaction on the resource side
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{sync::Arc};
 
 use async_trait::async_trait;
 use fe2o3_amqp_types::{

--- a/fe2o3-amqp/src/transaction/manager.rs
+++ b/fe2o3-amqp/src/transaction/manager.rs
@@ -7,7 +7,7 @@ use fe2o3_amqp_types::{
     definitions::Role,
     messaging::{Accepted, DeliveryState, Outcome},
     performatives::{Attach, Disposition, Transfer},
-    transaction::{TransactionId, TransactionalState},
+    transaction::{TransactionId, TransactionalState}, primitives::OrderedMap,
 };
 use tokio::sync::mpsc;
 
@@ -26,7 +26,7 @@ pub(crate) trait HandleControlLink {
 #[derive(Debug)]
 pub(crate) struct TransactionManager {
     pub control_link_outgoing: mpsc::Sender<LinkFrame>,
-    pub txns: BTreeMap<TransactionId, ResourceTransaction>,
+    pub txns: OrderedMap<TransactionId, ResourceTransaction>,
     pub control_link_acceptor: Arc<ControlLinkAcceptor>,
 }
 
@@ -37,7 +37,7 @@ impl TransactionManager {
     ) -> Self {
         Self {
             control_link_outgoing,
-            txns: BTreeMap::new(),
+            txns: OrderedMap::new(),
             control_link_acceptor: Arc::new(control_link_acceptor),
         }
     }

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -44,7 +44,7 @@ use fe2o3_amqp_types::{
         Rejected, Released,
     },
     performatives::Transfer,
-    primitives::Symbol,
+    primitives::{Symbol, OrderedMap},
     transaction::{Declared, Discharge, TransactionId, TransactionalState},
 };
 
@@ -552,7 +552,7 @@ impl<'t> Drop for Transaction<'t> {
                             }
                         };
                         guard
-                            .get_or_insert(BTreeMap::new())
+                            .get_or_insert(OrderedMap::new())
                             .insert(delivery_tag, unsettled);
                     }
                     match rx.blocking_recv() {

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -24,8 +24,6 @@
 //! ```
 //!
 
-use std::collections::BTreeMap;
-
 use crate::{
     endpoint::ReceiverLink,
     link::{

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -45,3 +45,4 @@ bytes = "1"
 serde_json = { version = "1", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
+indexmap = { version = "1.9.1", features = ["serde"] }

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.4.0
+
+1. Bug fixes (Breaking)
+   1. Switched from `Value::Map(BTreeMap<Value, Value>)` to `Value::Map(OrderedMap<Value, Value>)` to preserve the encoded order
+2. New features
+   1. Added `OrderedMap` which is a wrapper around `IndexMap` with custom implementation of some traits
+   2. More `TryFrom<Value>` impl for common map types
+
 ## 0.3.1
 
 1. Made constant `VALUE` public for possible downstream uses

--- a/serde_amqp/src/constants.rs
+++ b/serde_amqp/src/constants.rs
@@ -11,7 +11,8 @@ pub const DESCRIPTOR: &str = "AMQP1.0_DESCRIPTOR";
 #[doc(hidden)]
 pub const UNTAGGED_ENUM: &str = "FE2O3_AMQP_UNTAGGED";
 
-#[doc(hidden)]
+/// Use [`VALUE`] as the name if an enum needs to peek the format code before performing
+/// deserialization
 pub const VALUE: &str = "AMQP1.0_VALUE";
 
 // These constants should only be public on the crate level

--- a/serde_amqp/src/primitives/map.rs
+++ b/serde_amqp/src/primitives/map.rs
@@ -6,7 +6,7 @@ use serde::{de, ser::SerializeMap, Deserialize, Serialize};
 pub use indexmap::map::{Drain, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
 
 /// A wrapper around [`IndexMap`] with custom implementation of [`PartialEq`], [`Eq`],
-/// [`PartialOrd`], [`Ord`], and [`Hash`].
+/// [`PartialOrd`], [`Ord`], [`Hash`], [`Serialize`], and [`Deserialize`].
 ///
 /// Only a selected list of methods are re-exported for convenience.
 #[derive(Debug, Clone, Default)]
@@ -122,6 +122,8 @@ impl<K, V> OrderedMap<K, V>
 where
     K: Hash + Eq,
 {
+    /// Insert a key-value pair in the map.
+    /// 
     /// Calls [`IndexMap::insert`] internally
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.0.insert(key, value)
@@ -143,6 +145,8 @@ where
         self.0.get_mut(key)
     }
 
+    /// Remove the key-value pair equivalent to key and return its value.
+    /// 
     /// Calls [`IndexMap::remove`] internally
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
@@ -151,12 +155,38 @@ where
         self.0.remove(key)
     }
 
+    /// Remove and return the key-value pair equivalent to key.
+    /// 
+    /// Calls [`IndexMap::remove_entry`] internally
+    pub fn remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        self.0.remove_entry(key)
+    }
+
     /// Return true if an equivalent to key exists in the map.
+    /// 
+    /// Calls [`IndexMap::contains_key`] internally
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
     where
         Q: Hash + Equivalent<K>,
     {
         self.0.contains_key(key)
+    }
+
+    /// Create a new map with capacity for n key-value pairs. (Does not allocate if n is zero.)
+    /// 
+    /// Calls [`IndexMap::with_capacity`] internally
+    pub fn with_capacity(n: usize) -> Self {
+        Self(IndexMap::with_capacity(n))
+    }
+
+    /// Shrink the capacity of the map as much as possible.
+    /// 
+    /// Calss [`IndexMap::shrink_to_fit`] internally
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit()
     }
 }
 

--- a/serde_amqp/src/primitives/map.rs
+++ b/serde_amqp/src/primitives/map.rs
@@ -3,6 +3,8 @@ use std::{hash::Hash, marker::PhantomData};
 use indexmap::{Equivalent, IndexMap};
 use serde::{de, ser::SerializeMap, Deserialize, Serialize};
 
+pub use indexmap::map::{Iter, IterMut, IntoKeys};
+
 /// A wrapper around [`IndexMap`] with custom implementation of [`PartialEq`], [`Eq`],
 /// [`PartialOrd`], [`Ord`], and [`Hash`].
 ///
@@ -20,6 +22,27 @@ impl<K, V> OrderedMap<K, V> {
     /// Creates a new [`OrderedMap`]
     pub fn new() -> Self {
         Self(IndexMap::new())
+    }
+
+    /// Return the number of key-value pairs in the map.
+    /// 
+    /// Calls [`IndexMap::len`] internally
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return an iterator over the key-value pairs of the map, in their order
+    /// 
+    /// Calls [`IndexMap::iter`] internally
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        self.0.iter()
+    }
+
+    /// Return an iterator over the key-value pairs of the map, in their order
+    /// 
+    /// Calls [`IndexMap::iter_mut`] internally
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        self.0.iter_mut()
     }
 
     /// Get a reference to the inner [`IndexMap`]
@@ -41,6 +64,16 @@ impl<K, V> OrderedMap<K, V> {
     /// Consumes the wrapper and returns the inner [`IndexMap`]
     pub fn into_inner(self) -> IndexMap<K, V> {
         self.0
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return an owning iterator over the keys of the map, in their order
+    pub fn into_keys(self) -> IntoKeys<K, V> {
+        self.0.into_keys()
     }
 }
 
@@ -75,6 +108,14 @@ where
         Q: Hash + Equivalent<K>,
     {
         self.0.remove(key)
+    }
+
+    /// Return true if an equivalent to key exists in the map.
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        Q: Hash + Equivalent<K>, 
+    {
+        self.0.contains_key(key)
     }
 }
 

--- a/serde_amqp/src/primitives/map.rs
+++ b/serde_amqp/src/primitives/map.rs
@@ -1,0 +1,153 @@
+use std::{
+    hash::Hash,
+};
+
+use indexmap::{IndexMap, Equivalent};
+use serde::{Deserialize, Serialize};
+
+/// A wrapper around [`IndexMap`] with custom implementation of [`PartialEq`], [`Eq`],
+/// [`PartialOrd`], [`Ord`], and [`Hash`].
+/// 
+/// Only a selected list of methods are re-exported for convenience.
+#[derive(Debug, Default)]
+pub struct OrderedMap<K, V>(IndexMap<K, V>);
+
+impl<K, V> From<IndexMap<K, V>> for OrderedMap<K, V> {
+    fn from(map: IndexMap<K, V>) -> Self {
+        Self(map)
+    }
+}
+
+impl<K, V> OrderedMap<K, V> {
+    /// Get a reference to the inner [`IndexMap`]
+    /// 
+    /// It is intentional to NOT implement the `AsRef<IndexMap>` trait to avoid potential 
+    /// misuse
+    pub fn as_inner(&self) -> &IndexMap<K, V> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner [`IndexMap`]
+    /// 
+    /// It is intentional to NOT implement the `AsMut<IndexMap>` trait to avoid potential 
+    /// misuse
+    pub fn as_inner_mut(&mut self) -> &mut IndexMap<K, V> {
+        &mut self.0
+    }
+
+    /// Consumes the wrapper and returns the inner [`IndexMap`]
+    pub fn into_inner(self) -> IndexMap<K, V> {
+        self.0
+    }
+}
+
+impl<K, V> OrderedMap<K, V> 
+where
+    K: Hash + Eq,
+{
+    /// Calls [`IndexMap::insert`] internally
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.0.insert(key, value)
+    }
+
+    /// Calls [`IndexMap::get`] internally
+    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V> 
+    where
+        Q: Hash + Equivalent<K>
+    {
+        self.0.get(key)
+    }
+
+    /// Calls [`IndexMap::get_mut`] internally
+    pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V> 
+    where
+        Q: Hash + Equivalent<K>
+    {
+        self.0.get_mut(key)
+    }
+
+    /// Calls [`IndexMap::remove`] internally
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V> 
+    where
+        Q: Hash + Equivalent<K>
+    {
+        self.0.remove(key)
+    }
+}
+
+impl<K, V> Serialize for OrderedMap<K, V>
+where
+    K: Serialize + Eq + Hash,
+    V: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        indexmap::serde_seq::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de, K, V> Deserialize<'de> for OrderedMap<K, V>
+where
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map: IndexMap<K, V> = indexmap::serde_seq::deserialize(deserializer)?;
+        Ok(Self(map))
+    }
+}
+
+impl<K, V> PartialEq for OrderedMap<K, V>
+where
+    K: PartialEq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len() && self.0.iter().zip(&other.0).all(|(a, b)| a == b)
+    }
+}
+
+impl<K, V> Eq for OrderedMap<K, V>
+where
+    K: Eq,
+    V: Eq,
+{}
+
+impl<K, V> PartialOrd for OrderedMap<K, V> 
+where
+    K: PartialOrd,
+    V: PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.iter().partial_cmp(other.0.iter())
+    }
+}
+
+impl<K, V> Ord for OrderedMap<K, V> 
+where
+    K: Ord,
+    V: Ord,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.iter().cmp(other.0.iter())
+    }
+}
+
+impl<K, V> Hash for OrderedMap<K, V> 
+where
+    K: Hash,
+    V: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_usize(self.0.len());
+        for entry in &self.0 {
+            entry.hash(state)
+        }
+    }
+}

--- a/serde_amqp/src/primitives/map.rs
+++ b/serde_amqp/src/primitives/map.rs
@@ -145,6 +145,7 @@ where
     K: PartialEq,
     V: PartialEq,
 {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.0.len() == other.0.len() && self.0.iter().zip(&other.0).all(|(a, b)| a == b)
     }
@@ -173,6 +174,7 @@ where
     K: Ord,
     V: Ord,
 {
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.iter().cmp(other.0.iter())
     }
@@ -183,6 +185,7 @@ where
     K: Hash,
     V: Hash,
 {
+    #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         state.write_usize(self.0.len());
         for entry in &self.0 {
@@ -196,6 +199,7 @@ impl<'a, K, V> IntoIterator for &'a OrderedMap<K, V> {
 
     type IntoIter = indexmap::map::Iter<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
     }
@@ -206,6 +210,7 @@ impl<'a, K, V> IntoIterator for &'a mut OrderedMap<K, V> {
 
     type IntoIter = indexmap::map::IterMut<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter_mut()
     }
@@ -215,8 +220,20 @@ impl<K, V> IntoIterator for OrderedMap<K, V> {
     type Item = (K, V);
 
     type IntoIter = indexmap::map::IntoIter<K, V>;
-
+    
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for OrderedMap<K, V> 
+where
+    K: Hash + Eq,
+{
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let index_map = IndexMap::from_iter(iter);
+        Self(index_map)
     }
 }

--- a/serde_amqp/src/primitives/mod.rs
+++ b/serde_amqp/src/primitives/mod.rs
@@ -5,6 +5,7 @@ mod decimal;
 mod symbol;
 mod timestamp;
 mod uuid;
+mod map;
 
 // to avoid ambiguity
 pub use crate::primitives::array::*;
@@ -12,6 +13,7 @@ pub use crate::primitives::decimal::*;
 pub use crate::primitives::symbol::*;
 pub use crate::primitives::timestamp::*;
 pub use crate::primitives::uuid::*;
+pub use crate::primitives::map::*;
 
 // Alias for the primitive types to match those in the spec
 use serde_bytes::ByteBuf;

--- a/serde_amqp/src/primitives/symbol.rs
+++ b/serde_amqp/src/primitives/symbol.rs
@@ -130,7 +130,7 @@ impl<'de> de::Deserialize<'de> for SymbolRef<'de> {
 ///
 /// Symbol should only contain ASCII characters. The implementation, however, wraps
 /// over a String. `AmqpNetLite` also wraps around a String, which in c# is utf-16.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Symbol(pub String);
 
 impl Symbol {

--- a/serde_amqp/src/primitives/symbol.rs
+++ b/serde_amqp/src/primitives/symbol.rs
@@ -235,7 +235,7 @@ impl<'de> de::Deserialize<'de> for Symbol {
 
 #[cfg(test)]
 mod tests {
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, to_vec, primitives::OrderedMap};
 
     use super::{Symbol, SymbolRef};
 
@@ -264,9 +264,8 @@ mod tests {
     #[test]
     fn test_borrow_str() {
         use crate::value::Value;
-        use std::collections::BTreeMap;
 
-        let mut map = BTreeMap::new();
+        let mut map = OrderedMap::new();
         map.insert(Symbol::from("hello"), Value::from("world"));
 
         let val = map.get("hello");

--- a/serde_amqp/src/value/de.rs
+++ b/serde_amqp/src/value/de.rs
@@ -1,6 +1,6 @@
 //! Value deserializer
 
-use std::{collections::BTreeMap, convert::TryInto};
+use std::convert::TryInto;
 
 use ordered_float::OrderedFloat;
 use serde::de::{self};
@@ -13,6 +13,7 @@ use crate::{
     },
     error::Error,
     format_code::EncodingCodes,
+    primitives::OrderedMap,
     util::{EnumType, NewType},
 };
 
@@ -479,7 +480,7 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
     where
         A: de::MapAccess<'de>,
     {
-        let mut map = BTreeMap::new();
+        let mut map = OrderedMap::new();
         while let Some((key, val)) = map_accessor.next_entry()? {
             map.insert(key, val);
         }
@@ -1064,7 +1065,7 @@ impl<'de> de::SeqAccess<'de> for SeqAccess {
 /// Accssor for map types
 #[derive(Debug)]
 pub struct MapAccess {
-    iter: <BTreeMap<Value, Value> as IntoIterator>::IntoIter,
+    iter: <OrderedMap<Value, Value> as IntoIterator>::IntoIter,
 }
 
 impl<'de> de::MapAccess<'de> for MapAccess {
@@ -1180,7 +1181,9 @@ mod tests {
     use crate::{
         described::Described,
         descriptor::Descriptor,
-        from_slice, to_vec,
+        from_slice,
+        primitives::OrderedMap,
+        to_vec,
         value::{ser::to_value, Value},
     };
 
@@ -1264,6 +1267,18 @@ mod tests {
         let expected = Array::from(vec![1i32, 2, 3, 4]);
         let buf = to_value(&expected).unwrap();
         assert_eq_from_value_vs_expected(buf, expected);
+    }
+
+    #[test]
+    fn test_deserialize_map() {
+        let mut expected: OrderedMap<Value, Value> = OrderedMap::new();
+        expected.insert("a".into(), 1i32.into());
+        expected.insert("m".into(), 2.into());
+        expected.insert("q".into(), 3.into());
+        expected.insert("p".into(), 4.into());
+
+        let value = Value::Map(expected.clone());
+        assert_eq_from_value_vs_expected(value, expected);
     }
 
     #[test]

--- a/serde_amqp/src/value/mod.rs
+++ b/serde_amqp/src/value/mod.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use crate::{
     described::Described,
     format_code::EncodingCodes,
-    primitives::{Array, Dec128, Dec32, Dec64, Symbol, Timestamp, Uuid, OrderedMap},
+    primitives::{Array, Dec128, Dec32, Dec64, OrderedMap, Symbol, Timestamp, Uuid},
     util::TryFromSerializable,
     Error,
 };
@@ -402,6 +402,17 @@ where
     }
 }
 
+impl<K, V> From<OrderedMap<K, V>> for Value
+where
+    K: Into<Value>,
+    V: Into<Value>,
+{
+    fn from(map: OrderedMap<K, V>) -> Self {
+        let map = map.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        Value::Map(map)
+    }
+}
+
 impl<T: Serialize> TryFromSerializable<T> for Value {
     type Error = Error;
 
@@ -501,11 +512,12 @@ impl From<serde_json::Value> for Value {
                 Value::List(v)
             }
             serde_json::Value::Object(o) => {
-                let map: IndexMap<_, _> =o.into_iter()
+                let map: IndexMap<_, _> = o
+                    .into_iter()
                     .map(|(key, value)| (Value::String(key), Value::from(value)))
                     .collect();
                 Value::Map(OrderedMap::from(map))
-            },
+            }
         }
     }
 }

--- a/serde_amqp/src/value/mod.rs
+++ b/serde_amqp/src/value/mod.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use ordered_float::OrderedFloat;
 use serde::Serialize;
 use serde_bytes::ByteBuf;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     described::Described,
@@ -485,6 +485,78 @@ impl TryFrom<Value> for f64 {
         match value {
             Value::Double(val) => Ok(val.0),
             _ => Err(value),
+        }
+    }
+}
+
+impl<K, V> TryFrom<Value> for BTreeMap<K, V>
+where
+    K: TryFrom<Value, Error = Value> + Ord,
+    V: TryFrom<Value, Error = Value>
+{
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Map(map) => {
+                map.into_iter()
+                    .map(|(k,v)| {
+                        match (K::try_from(k), V::try_from(v)) {
+                            (Ok(k), Ok(v)) => Ok((k, v)),
+                            (Err(err), _) => Err(err),
+                            (_, Err(err)) => Err(err),
+                        }
+                    }).collect()
+            },
+            _ => Err(value)
+        }
+    }
+}
+
+impl<K, V> TryFrom<Value> for HashMap<K, V>
+where
+    K: TryFrom<Value, Error = Value> + std::hash::Hash + Eq,
+    V: TryFrom<Value, Error = Value>
+{
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Map(map) => {
+                map.into_iter()
+                    .map(|(k,v)| {
+                        match (K::try_from(k), V::try_from(v)) {
+                            (Ok(k), Ok(v)) => Ok((k, v)),
+                            (Err(err), _) => Err(err),
+                            (_, Err(err)) => Err(err),
+                        }
+                    }).collect()
+            },
+            _ => Err(value)
+        }
+    }
+}
+
+impl<K, V> TryFrom<Value> for IndexMap<K, V>
+where
+    K: TryFrom<Value, Error = Value> + std::hash::Hash + Eq,
+    V: TryFrom<Value, Error = Value>
+{
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Map(map) => {
+                map.into_iter()
+                    .map(|(k,v)| {
+                        match (K::try_from(k), V::try_from(v)) {
+                            (Ok(k), Ok(v)) => Ok((k, v)),
+                            (Err(err), _) => Err(err),
+                            (_, Err(err)) => Err(err),
+                        }
+                    }).collect()
+            },
+            _ => Err(value)
         }
     }
 }


### PR DESCRIPTION
Switched from `BTreeMap` to `OrderedMap` which is a custom wrapper around `IndexMap`. This preserves the encoded order as the order of insertion.