### PR TITLE
94 annotation map key

### DIFF
--- a/fe2o3-amqp-types/src/messaging/format/annotations.rs
+++ b/fe2o3-amqp-types/src/messaging/format/annotations.rs
@@ -25,22 +25,22 @@ use serde_amqp::{
 /// beginning with “x-opt-” MUST be ignored if not understood. On receiving an annotation key which
 /// is not understood, and which does not begin with “x-opt”, the receiving AMQP container MUST
 /// detach the link with a not-implemented error.
-/// 
+///
 /// The key type allows looking up from the map using multiple types. The user may need to
 /// explicitly coerce a type into a trait object
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// use fe2o3_amqp_types::primitives::{Value, Symbol};
 /// use fe2o3_amqp_types::messaging::annotations::{Annotations, OwnedKey, AnnotationKey};
-/// 
+///
 /// let key = "key";
 /// let val = Value::Symbol(Symbol::from("value"));
-/// 
+///
 /// let mut annotations = Annotations::new();
 /// annotations.insert(OwnedKey::from(key), val.clone());
-/// 
+///
 /// let removed = annotations.remove(&key as &dyn AnnotationKey);
 /// assert_eq!(removed, Some(val));
 /// ```
@@ -284,11 +284,15 @@ impl<'a> Hash for (dyn AnnotationKey + 'a) {
 
 #[cfg(test)]
 mod tests {
-    use serde_amqp::{Value, primitives::{Symbol, SymbolRef}, to_vec, from_slice};
+    use serde_amqp::{
+        from_slice,
+        primitives::{Symbol, SymbolRef},
+        to_vec, Value,
+    };
 
     use crate::messaging::format::annotations::AnnotationKey;
 
-    use super::{Annotations};
+    use super::Annotations;
 
     const STRING_KEY: &str = "string_key";
     const STR_KEY: &str = "str_key";
@@ -360,7 +364,7 @@ mod tests {
     #[test]
     fn test_annotations_get_with_different_key_types() {
         let mut annotations = create_annotations();
-        
+
         let key = String::from(STRING_KEY);
         let val = annotations.remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(string_val()));

--- a/fe2o3-amqp-types/src/messaging/format/annotations.rs
+++ b/fe2o3-amqp-types/src/messaging/format/annotations.rs
@@ -1,12 +1,16 @@
-use std::{borrow::Borrow, collections::BTreeMap};
+use std::{borrow::Borrow, collections::BTreeMap, hash::{Hash, Hasher}};
 
 use serde_amqp::{primitives::{ULong, Symbol, SymbolRef}, Value};
 
 pub type Annotations = BTreeMap<OwnedKey, Value>;
 
+/// Key type for [`Annotations`]
 #[derive(Debug)]
 pub enum OwnedKey {
+    /// Symbol
     Symbol(Symbol),
+
+    /// ULong
     ULong(ULong),
 }
 
@@ -47,9 +51,52 @@ impl AnnotationKey for str {
     }
 }
 
+impl AnnotationKey for String {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::Symbol(SymbolRef(self))
+    }
+}
+
+impl AnnotationKey for Symbol {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::Symbol(SymbolRef(&self.0))
+    }
+}
+
+impl<'a> AnnotationKey for SymbolRef<'a> {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::Symbol(SymbolRef(self.0))
+    }
+}
+
 impl<'a> Borrow<dyn AnnotationKey + 'a> for OwnedKey {
     fn borrow(&self) -> &(dyn AnnotationKey + 'a) {
         self
     }
 }
 
+impl<'a> PartialEq for (dyn AnnotationKey + 'a) {
+    fn eq(&self, other: &Self) -> bool {
+        self.key().eq(&other.key())
+    }
+}
+
+impl<'a> Eq for (dyn AnnotationKey + 'a) { }
+
+impl<'a> PartialOrd for (dyn AnnotationKey + 'a) {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.key().partial_cmp(&other.key())
+    }
+}
+
+impl<'a> Ord for (dyn AnnotationKey + 'a) {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key().cmp(&other.key())
+    }
+}
+
+impl<'a> Hash for (dyn AnnotationKey + 'a) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key().hash(state)
+    }
+}

--- a/fe2o3-amqp-types/src/messaging/format/annotations.rs
+++ b/fe2o3-amqp-types/src/messaging/format/annotations.rs
@@ -1,11 +1,53 @@
-use std::{borrow::Borrow, collections::BTreeMap, hash::{Hash, Hasher}};
+//! Implements 3.2.10 Annotations
 
-use serde_amqp::{primitives::{ULong, Symbol, SymbolRef}, Value};
+use std::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+};
 
-pub type Annotations = BTreeMap<OwnedKey, Value>;
+use serde::{
+    de::{self, VariantAccess},
+    Serialize,
+};
+use serde_amqp::{
+    format_code::EncodingCodes,
+    primitives::{OrderedMap, Symbol, SymbolRef, ULong},
+    Value,
+    __constants::VALUE,
+};
+
+/// 3.2.10 Annotations
+///
+/// <type name="annotations" class="restricted" source="map"/>
+///
+/// The annotations type is a map where the keys are restricted to be of type symbol or of type
+/// ulong. All ulong keys, and all symbolic keys except those beginning with “x-” are reserved. Keys
+/// beginning with “x-opt-” MUST be ignored if not understood. On receiving an annotation key which
+/// is not understood, and which does not begin with “x-opt”, the receiving AMQP container MUST
+/// detach the link with a not-implemented error.
+/// 
+/// The key type allows looking up from the map using multiple types. The user may need to
+/// explicitly coerce a type into a trait object
+/// 
+/// # Example
+/// 
+/// ```rust
+/// use fe2o3_amqp_types::primitives::{Value, Symbol};
+/// use fe2o3_amqp_types::messaging::annotations::{Annotations, OwnedKey, AnnotationKey};
+/// 
+/// let key = "key";
+/// let val = Value::Symbol(Symbol::from("value"));
+/// 
+/// let mut annotations = Annotations::new();
+/// annotations.insert(OwnedKey::from(key), val.clone());
+/// 
+/// let removed = annotations.remove(&key as &dyn AnnotationKey);
+/// assert_eq!(removed, Some(val));
+/// ```
+pub type Annotations = OrderedMap<OwnedKey, Value>;
 
 /// Key type for [`Annotations`]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum OwnedKey {
     /// Symbol
     Symbol(Symbol),
@@ -14,13 +56,146 @@ pub enum OwnedKey {
     ULong(ULong),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum BorrowedKey<'k> {
-    Symbol(SymbolRef<'k>),
-    ULong(&'k u64)
+impl Default for OwnedKey {
+    fn default() -> Self {
+        Self::Symbol(Symbol::default())
+    }
 }
 
+impl From<Symbol> for OwnedKey {
+    fn from(value: Symbol) -> Self {
+        Self::Symbol(value)
+    }
+}
+
+impl<'a> From<SymbolRef<'a>> for OwnedKey {
+    fn from(value: SymbolRef<'a>) -> Self {
+        Self::Symbol(Symbol::from(value.0))
+    }
+}
+
+impl From<u64> for OwnedKey {
+    fn from(value: u64) -> Self {
+        Self::ULong(value)
+    }
+}
+
+impl From<String> for OwnedKey {
+    fn from(value: String) -> Self {
+        Self::Symbol(Symbol(value))
+    }
+}
+
+impl<'a> From<&'a str> for OwnedKey {
+    fn from(value: &'a str) -> Self {
+        Self::Symbol(Symbol::from(value))
+    }
+}
+
+impl Serialize for OwnedKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            OwnedKey::Symbol(value) => value.serialize(serializer),
+            OwnedKey::ULong(value) => value.serialize(serializer),
+        }
+    }
+}
+
+enum Field {
+    Symbol,
+    ULong,
+}
+
+struct FieldVisitor {}
+
+impl<'de> de::Visitor<'de> for FieldVisitor {
+    type Value = Field;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("OwnedKey variant")
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match v
+            .try_into()
+            .map_err(|_| de::Error::custom("Unable to convert to EncodingCodes"))?
+        {
+            EncodingCodes::Sym8 | EncodingCodes::Sym32 => Ok(Field::Symbol),
+            EncodingCodes::ULong0 | EncodingCodes::SmallULong | EncodingCodes::ULong => {
+                Ok(Field::ULong)
+            }
+            _ => Err(de::Error::custom("Invalid format code")),
+        }
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Field {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_identifier(FieldVisitor {})
+    }
+}
+
+struct Visitor {}
+
+impl<'de> de::Visitor<'de> for Visitor {
+    type Value = OwnedKey;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("OwnedKey")
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        let (val, de) = data.variant()?;
+
+        match val {
+            Field::Symbol => {
+                let val = de.newtype_variant()?;
+                Ok(OwnedKey::Symbol(val))
+            }
+            Field::ULong => {
+                let val = de.newtype_variant()?;
+                Ok(OwnedKey::ULong(val))
+            }
+        }
+    }
+}
+
+impl<'de> de::Deserialize<'de> for OwnedKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const VARIANTS: &[&str] = &["Symbol", "ULong"];
+        deserializer.deserialize_enum(VALUE, VARIANTS, Visitor {})
+    }
+}
+
+/// A borrowed version of [`OwnedKey`] which can be used to get entry/value from
+/// [`Annotations`]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BorrowedKey<'k> {
+    /// Symbol
+    Symbol(SymbolRef<'k>),
+
+    /// u64
+    ULong(&'k u64),
+}
+
+/// This trait allows using different types as keys to get entry/value from [`Annotations`]
 pub trait AnnotationKey {
+    /// Returns a [`BorrowedKey`] that will be used to as the key
     fn key<'k>(&'k self) -> BorrowedKey<'k>;
 }
 
@@ -46,6 +221,12 @@ impl AnnotationKey for u64 {
 }
 
 impl AnnotationKey for str {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::Symbol(SymbolRef(self))
+    }
+}
+
+impl AnnotationKey for &str {
     fn key<'k>(&'k self) -> BorrowedKey<'k> {
         BorrowedKey::Symbol(SymbolRef(self))
     }
@@ -81,7 +262,7 @@ impl<'a> PartialEq for (dyn AnnotationKey + 'a) {
     }
 }
 
-impl<'a> Eq for (dyn AnnotationKey + 'a) { }
+impl<'a> Eq for (dyn AnnotationKey + 'a) {}
 
 impl<'a> PartialOrd for (dyn AnnotationKey + 'a) {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -98,5 +279,127 @@ impl<'a> Ord for (dyn AnnotationKey + 'a) {
 impl<'a> Hash for (dyn AnnotationKey + 'a) {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.key().hash(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_amqp::{Value, primitives::{Symbol, SymbolRef}, to_vec, from_slice};
+
+    use crate::messaging::format::annotations::AnnotationKey;
+
+    use super::{Annotations};
+
+    const STRING_KEY: &str = "string_key";
+    const STR_KEY: &str = "str_key";
+    const SYMBOL_KEY: &str = "symbol_key";
+    const SYMBOL_REF_KEY: &str = "symbol_ref_key";
+    const U64_KEY: &str = "u64_key";
+
+    const STRING_VAL: &str = "string_val";
+    const STR_VAL: &str = "str_val";
+    const SYMBOL_VAL: &str = "symbol_val";
+    const SYMBOL_REF_VAL: &str = "symbol_ref_val";
+    const U64_VAL: u64 = 1000;
+
+    fn string_val() -> Value {
+        Value::String(String::from(STRING_VAL))
+    }
+
+    fn str_val() -> Value {
+        Value::String(String::from(STR_VAL))
+    }
+
+    fn symbol_val() -> Value {
+        Value::Symbol(Symbol::from(SYMBOL_VAL))
+    }
+
+    fn symbol_ref_val() -> Value {
+        Value::Symbol(Symbol::from(SYMBOL_REF_VAL))
+    }
+
+    fn u64_val() -> Value {
+        Value::ULong(U64_VAL)
+    }
+
+    fn create_annotations() -> Annotations {
+        let mut annotations = Annotations::new();
+        annotations.insert(STRING_KEY.into(), string_val());
+        annotations.insert(STR_KEY.into(), str_val());
+        annotations.insert(SYMBOL_KEY.into(), symbol_val());
+        annotations.insert(SYMBOL_REF_KEY.into(), symbol_ref_val());
+        annotations.insert(U64_KEY.into(), u64_val());
+        annotations
+    }
+
+    fn create_annotations_with_different_order() -> Annotations {
+        let mut annotations = Annotations::new();
+        annotations.insert(U64_KEY.into(), u64_val());
+        annotations.insert(SYMBOL_REF_KEY.into(), symbol_ref_val());
+        annotations.insert(SYMBOL_KEY.into(), symbol_val());
+        annotations.insert(STRING_KEY.into(), string_val());
+        annotations.insert(STR_KEY.into(), str_val());
+        annotations
+    }
+
+    #[test]
+    fn test_annotations_with_different_order() {
+        let annotations_1 = create_annotations();
+        let annotations_2 = create_annotations_with_different_order();
+
+        assert_ne!(annotations_1, annotations_2);
+    }
+
+    #[test]
+    fn test_annotations_insert_with_different_key_types() {
+        let annotations = create_annotations();
+
+        assert_eq!(annotations.len(), 5);
+    }
+
+    #[test]
+    fn test_annotations_get_with_different_key_types() {
+        let mut annotations = create_annotations();
+        
+        let key = String::from(STRING_KEY);
+        let val = annotations.remove(&key as &dyn AnnotationKey);
+        assert_eq!(val, Some(string_val()));
+
+        let key = STR_KEY;
+        let val = annotations.remove(&key as &dyn AnnotationKey);
+        assert_eq!(val, Some(str_val()));
+
+        let key = Symbol::from(SYMBOL_KEY);
+        let val = annotations.remove(&key as &dyn AnnotationKey);
+        assert_eq!(val, Some(symbol_val()));
+
+        let key = SymbolRef(SYMBOL_REF_KEY);
+        let val = annotations.remove(&key as &dyn AnnotationKey);
+        assert_eq!(val, Some(symbol_ref_val()));
+
+        let key = U64_KEY;
+        let val = annotations.remove(&key as &dyn AnnotationKey);
+        assert_eq!(val, Some(u64_val()));
+
+        assert!(annotations.is_empty())
+    }
+
+    #[test]
+    fn test_serde_annotations() {
+        let annotations = create_annotations();
+        let buf = to_vec(&annotations).unwrap();
+        let deserialized = from_slice(&buf).unwrap();
+        assert_eq!(annotations, deserialized);
+    }
+
+    #[test]
+    fn test_serde_annotations_with_different_order() {
+        let annotations_1 = create_annotations();
+        let annotations_2 = create_annotations_with_different_order();
+        assert_ne!(annotations_1, annotations_2);
+
+        let buf = to_vec(&annotations_1).unwrap();
+        let deserialized: Annotations = from_slice(&buf).unwrap();
+        assert_ne!(deserialized, annotations_2)
     }
 }

--- a/fe2o3-amqp-types/src/messaging/format/annotations.rs
+++ b/fe2o3-amqp-types/src/messaging/format/annotations.rs
@@ -1,0 +1,55 @@
+use std::{borrow::Borrow, collections::BTreeMap};
+
+use serde_amqp::{primitives::{ULong, Symbol, SymbolRef}, Value};
+
+pub type Annotations = BTreeMap<OwnedKey, Value>;
+
+#[derive(Debug)]
+pub enum OwnedKey {
+    Symbol(Symbol),
+    ULong(ULong),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BorrowedKey<'k> {
+    Symbol(SymbolRef<'k>),
+    ULong(&'k u64)
+}
+
+pub trait AnnotationKey {
+    fn key<'k>(&'k self) -> BorrowedKey<'k>;
+}
+
+impl<'a> AnnotationKey for BorrowedKey<'a> {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        self.clone()
+    }
+}
+
+impl AnnotationKey for OwnedKey {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        match self {
+            OwnedKey::Symbol(Symbol(s)) => BorrowedKey::Symbol(SymbolRef(s)),
+            OwnedKey::ULong(v) => BorrowedKey::ULong(v),
+        }
+    }
+}
+
+impl AnnotationKey for u64 {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::ULong(self)
+    }
+}
+
+impl AnnotationKey for str {
+    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+        BorrowedKey::Symbol(SymbolRef(self))
+    }
+}
+
+impl<'a> Borrow<dyn AnnotationKey + 'a> for OwnedKey {
+    fn borrow(&self) -> &(dyn AnnotationKey + 'a) {
+        self
+    }
+}
+

--- a/fe2o3-amqp-types/src/messaging/format/map_builder.rs
+++ b/fe2o3-amqp-types/src/messaging/format/map_builder.rs
@@ -2,14 +2,13 @@
 
 use std::{hash::Hash, marker::PhantomData};
 
-use serde_amqp::{
-    primitives::{OrderedMap},
-    Value,
-};
+use serde_amqp::{primitives::OrderedMap, Value};
 
 use crate::primitives::SimpleValue;
 
-use super::{ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotations, annotations::OwnedKey};
+use super::{
+    annotations::OwnedKey, ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotations,
+};
 
 /// Builder for types that are simply a wrapper around map
 /// ([`DeliveryAnnotations`], [`MessageAnnotations`], [`Footer`], [`ApplicationProperties`])

--- a/fe2o3-amqp-types/src/messaging/format/map_builder.rs
+++ b/fe2o3-amqp-types/src/messaging/format/map_builder.rs
@@ -3,13 +3,13 @@
 use std::{hash::Hash, marker::PhantomData};
 
 use serde_amqp::{
-    primitives::{OrderedMap, Symbol},
+    primitives::{OrderedMap},
     Value,
 };
 
 use crate::primitives::SimpleValue;
 
-use super::{ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotations};
+use super::{ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotations, annotations::OwnedKey};
 
 /// Builder for types that are simply a wrapper around map
 /// ([`DeliveryAnnotations`], [`MessageAnnotations`], [`Footer`], [`ApplicationProperties`])
@@ -48,21 +48,21 @@ where
     }
 }
 
-impl MapBuilder<Symbol, Value, DeliveryAnnotations> {
+impl MapBuilder<OwnedKey, Value, DeliveryAnnotations> {
     /// Build [`DeliveryAnnotations`]
     pub fn build(self) -> DeliveryAnnotations {
         DeliveryAnnotations(self.map)
     }
 }
 
-impl MapBuilder<Symbol, Value, MessageAnnotations> {
+impl MapBuilder<OwnedKey, Value, MessageAnnotations> {
     /// Build [`MessageAnnotations`]
     pub fn build(self) -> MessageAnnotations {
         MessageAnnotations(self.map)
     }
 }
 
-impl MapBuilder<Symbol, Value, Footer> {
+impl MapBuilder<OwnedKey, Value, Footer> {
     /// Build [`Footer`]
     pub fn build(self) -> Footer {
         Footer(self.map)

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -13,6 +13,8 @@ use crate::{definitions::Milliseconds, primitives::SimpleValue};
 
 pub mod map_builder;
 
+mod annotations;
+
 /// 3.2.1 Header
 /// Transport headers for a message.
 /// <type name="header" class="composite" source="list" provides="section">

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -68,10 +68,25 @@ impl From<Priority> for UByte {
     }
 }
 
-/// 3.2.2 Delivery Annotations
-/// <type name="delivery-annotations" class="restricted" source="annotations" provides="section">
-///     <descriptor name="amqp:delivery-annotations:map" code="0x00000000:0x00000071"/>
+/// 3.2.2 Delivery Annotations 
+/// 
+/// <type name="delivery-annotations" class="restricted" source="annotations" provides="section"> 
+///     <descriptor name="amqp:delivery-annotations:map" code="0x00000000:0x00000071"/> 
 /// </type>
+/// 
+/// The delivery-annotations section is used for delivery-specific non-standard properties at the
+/// head of the message. Delivery annotations convey information from the sending peer to the
+/// receiving peer. If the recipient does not understand the annotation it cannot be acted upon and
+/// its effects (such as any implied propagation) cannot be acted upon. Annotations might be
+/// specific to one implementation, or common to multiple implementations. The capabilities
+/// negotiated on link attach and on the source and target SHOULD be used to establish which anno-
+/// tations a peer supports. A registry of defined annotations and their meanings is maintained
+/// [AMQPDELANN]. The symbolic key “rejected” is reserved for the use of communicating error
+/// information regarding rejected messages. Any values associated with the “rejected” key MUST be
+/// of type error.
+/// 
+/// If the delivery-annotations section is omitted, it is equivalent to a delivery-annotations
+/// section containing an empty map of annotations.
 #[derive(Debug, Clone, Default, DeserializeComposite, SerializeComposite)]
 #[amqp_contract(
     name = "amqp:delivery-annotations:map",
@@ -101,10 +116,25 @@ impl DerefMut for DeliveryAnnotations {
     }
 }
 
-/// 3.2.3 Message Annotations
-/// <type name="message-annotations" class="restricted" source="annotations" provides="section">
-///     <descriptor name="amqp:message-annotations:map" code="0x00000000:0x00000072"/>
-/// </type>
+/// 3.2.3 Message Annotations <type name="message-annotations" class="restricted"
+/// source="annotations" provides="section"> <descriptor name="amqp:message-annotations:map"
+///     code="0x00000000:0x00000072"/> </type>
+/// 
+/// The message-annotations section is used for properties of the message which are aimed at the
+/// infrastructure and SHOULD be propagated across every delivery step. Message annotations convey
+/// information about the message. Intermediaries MUST propagate the annotations unless the
+/// annotations are explicitly augmented or modified (e.g., by the use of the modified outcome).
+///
+/// The capabilities negotiated on link attach and on the source and target can be used to establish
+/// which annotations a peer understands; however, in a network of AMQP intermediaries it might
+/// not be possible to know if every intermediary will understand the annotation. Note that for some
+/// annotations it might not be necessary for the intermediary to understand their purpose, i.e.,
+/// they could be used purely as an attribute which can be filtered on.
+///
+/// A registry of defined annotations and their meanings is maintained [AMQPMESSANN].
+///
+/// If the message-annotations section is omitted, it is equivalent to a message-annotations section
+/// containing an empty map of annotations.
 #[derive(Debug, Clone, Default, SerializeComposite, DeserializeComposite)]
 #[amqp_contract(
     name = "amqp:message-annotations:map",

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_amqp::{
     macros::{DeserializeComposite, SerializeComposite},
-    primitives::{Boolean, OrderedMap, Symbol, UByte, UInt},
+    primitives::{Boolean, OrderedMap, UByte, UInt},
     value::Value,
 };
 use std::ops::{Deref, DerefMut};
@@ -10,7 +10,8 @@ use crate::{definitions::Milliseconds, primitives::SimpleValue};
 
 pub mod map_builder;
 
-mod annotations;
+pub mod annotations;
+pub use annotations::Annotations;
 
 /// 3.2.1 Header
 /// Transport headers for a message.
@@ -96,7 +97,7 @@ pub struct DeliveryAnnotations(pub Annotations);
 
 impl DeliveryAnnotations {
     /// Creates a builder for [`DeliveryAnnotations`]
-    pub fn builder() -> MapBuilder<Symbol, Value, Self> {
+    pub fn builder() -> MapBuilder<OwnedKey, Value, Self> {
         MapBuilder::new()
     }
 }
@@ -144,7 +145,7 @@ pub struct MessageAnnotations(pub Annotations);
 
 impl MessageAnnotations {
     /// Creates a builder for [`MessageAnnotations`]
-    pub fn builder() -> MapBuilder<Symbol, Value, Self> {
+    pub fn builder() -> MapBuilder<OwnedKey, Value, Self> {
         MapBuilder::new()
     }
 }
@@ -166,7 +167,7 @@ impl DerefMut for MessageAnnotations {
 pub mod properties;
 pub use properties::Properties;
 
-use self::map_builder::MapBuilder;
+use self::{map_builder::MapBuilder, annotations::OwnedKey};
 
 /// 3.2.5 Application Properties
 /// <type name="application-properties" class="restricted" source="map" provides="section">
@@ -225,7 +226,7 @@ pub struct Footer(pub Annotations);
 
 impl Footer {
     /// Creates a builder for [`Footer`]
-    pub fn builder() -> MapBuilder<Symbol, Value, Self> {
+    pub fn builder() -> MapBuilder<OwnedKey, Value, Self> {
         MapBuilder::new()
     }
 }
@@ -243,16 +244,6 @@ impl DerefMut for Footer {
         &mut self.0
     }
 }
-
-/// 3.2.10 Annotations
-///
-/// <type name="annotations" class="restricted" source="map"/>
-///
-/// The annotations type is a map where the keys are restricted to be of type symbol or of type ulong. All ulong
-/// keys, and all symbolic keys except those beginning with “x-” are reserved. Keys beginning with “x-opt-” MUST be
-/// ignored if not understood. On receiving an annotation key which is not understood, and which does not begin with
-/// “x-opt”, the receiving AMQP container MUST detach the link with a not-implemented error.
-pub type Annotations = OrderedMap<Symbol, Value>;
 
 mod message_id;
 pub use message_id::*;

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -68,12 +68,12 @@ impl From<Priority> for UByte {
     }
 }
 
-/// 3.2.2 Delivery Annotations 
-/// 
-/// <type name="delivery-annotations" class="restricted" source="annotations" provides="section"> 
-///     <descriptor name="amqp:delivery-annotations:map" code="0x00000000:0x00000071"/> 
+/// 3.2.2 Delivery Annotations
+///
+/// <type name="delivery-annotations" class="restricted" source="annotations" provides="section">
+///     <descriptor name="amqp:delivery-annotations:map" code="0x00000000:0x00000071"/>
 /// </type>
-/// 
+///
 /// The delivery-annotations section is used for delivery-specific non-standard properties at the
 /// head of the message. Delivery annotations convey information from the sending peer to the
 /// receiving peer. If the recipient does not understand the annotation it cannot be acted upon and
@@ -84,7 +84,7 @@ impl From<Priority> for UByte {
 /// [AMQPDELANN]. The symbolic key “rejected” is reserved for the use of communicating error
 /// information regarding rejected messages. Any values associated with the “rejected” key MUST be
 /// of type error.
-/// 
+///
 /// If the delivery-annotations section is omitted, it is equivalent to a delivery-annotations
 /// section containing an empty map of annotations.
 #[derive(Debug, Clone, Default, DeserializeComposite, SerializeComposite)]
@@ -119,7 +119,7 @@ impl DerefMut for DeliveryAnnotations {
 /// 3.2.3 Message Annotations <type name="message-annotations" class="restricted"
 /// source="annotations" provides="section"> <descriptor name="amqp:message-annotations:map"
 ///     code="0x00000000:0x00000072"/> </type>
-/// 
+///
 /// The message-annotations section is used for properties of the message which are aimed at the
 /// infrastructure and SHOULD be propagated across every delivery step. Message annotations convey
 /// information about the message. Intermediaries MUST propagate the annotations unless the
@@ -167,7 +167,7 @@ impl DerefMut for MessageAnnotations {
 pub mod properties;
 pub use properties::Properties;
 
-use self::{map_builder::MapBuilder, annotations::OwnedKey};
+use self::{annotations::OwnedKey, map_builder::MapBuilder};
 
 /// 3.2.5 Application Properties
 /// <type name="application-properties" class="restricted" source="map" provides="section">


### PR DESCRIPTION
Changed `Annotations` map key type to `OwnedKey`. Uses trait object `dyn AnnotationKey` to allow looking up the map using different types