### PR TITLE
Minor bug fix, bump version to 0.7.12

### DIFF
--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -3,6 +3,7 @@
 ## 0.7.12
 
 1. Added `credit_mode()` getter to `Receiver`
+2. Removed unused generic type parameter from `Receiver::modify` and `Receiver::release`
 
 ## 0.7.11
 

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -409,7 +409,7 @@ impl Receiver {
     /// to `Release`
     ///
     /// This will not send disposition if the delivery is not found in the local unsettled map.
-    pub async fn release<T>(
+    pub async fn release(
         &self,
         delivery_info: impl Into<DeliveryInfo>,
     ) -> Result<(), DispositionError> {
@@ -434,7 +434,7 @@ impl Receiver {
     /// to `Modify`
     ///
     /// This will not send disposition if the delivery is not found in the local unsettled map.
-    pub async fn modify<T>(
+    pub async fn modify(
         &self,
         delivery_info: impl Into<DeliveryInfo>,
         modified: Modified,


### PR DESCRIPTION
1. Added `credit_mode()` getter to `Receiver`
2. Removed unused generic type parameter from `Receiver::modify` and `Receiver::release`