### PR TITLE
Wrap `next_incoming_id` and `next_outgoing_id` ...

### DIFF
--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -446,7 +446,7 @@ impl endpoint::Session for Session {
         // match the implicit transfer-id of the incoming transfer plus one, as well as decrementing the
         // remote-outgoing-window, and MAY (depending on policy) decrement its incoming-window.
 
-        self.next_incoming_id += 1;
+        self.next_incoming_id = self.next_incoming_id.wrapping_add(1);
         self.remote_outgoing_window -= 1;
 
         let input_handle = InputHandle::from(transfer.handle.clone());
@@ -723,7 +723,7 @@ impl endpoint::Session for Session {
             }
         }
 
-        self.next_outgoing_id += 1;
+        self.next_outgoing_id = self.next_outgoing_id.wrapping_add(1);
 
         // The remote-incoming-window reflects the maximum number of outgoing transfers that can
         // be sent without exceeding the remote endpoint’s incoming-window. This value MUST be


### PR DESCRIPTION
... as demanded by RFC1982.

Per the standard:
> The next-outgoing-id MAY be initialized to an arbitrary value and is incremented after each successive [transfer](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-transfer) according to RFC-1982 [[RFC1982](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html#anchor-RFC1982)] serial number arithmetic

Otherwise, a sender that initializes their `next-outgoing-id` to a value close to `u32::MAX` when communicating with a fe2o3-amqp receiver would see the receiver panic after a few messages.