### PR TITLE
0.9.1

### DIFF
--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 0.9.1
+
+1. Ported 0.7.31
+
+## 0.8.25
+
+1. Ported 0.7.31
+
+## 0.7.31
+
+1. Fixed problem with closing/ending of `Connection`/`Session` where the error found during the
+   handshake is not propagated to the user.
+
 ## 0.9.0
 
 1. Unified versioning with other `fe2o3-amqp` crates

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -169,7 +169,7 @@ impl<R> ConnectionHandle<R> {
     /// [`on_close`](#method.on_close). This will cause the JoinHandle to be polled after
     /// completion, which causes a panic.
     pub async fn on_close(&mut self) -> Result<(), Error> {
-        if self.is_closed() {
+        if self.is_closed {
             return Err(Error::IllegalState);
         }
         match (&mut self.outcome).await {

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -171,7 +171,7 @@ impl<R> SessionHandle<R> {
     /// [`end_with_error`](#method.end_with_error), [`on_end`](#on_end) has beend executed. This
     /// will cause the JoinHandle to be polled after completion, which causes a panic.
     pub async fn on_end(&mut self) -> Result<(), Error> {
-        if self.is_ended() {
+        if self.is_ended {
             return Err(Error::IllegalState);
         }
 


### PR DESCRIPTION
1. Fixed problem with closing/ending of `Connection`/`Session` where the error found during the
   handshake is not propagated to the user.