### PR TITLE
Mark `OrderedMap::remove` and `remove_entry` as deprecated

### DIFF
--- a/fe2o3-amqp-types/src/messaging/format/annotations.rs
+++ b/fe2o3-amqp-types/src/messaging/format/annotations.rs
@@ -390,23 +390,23 @@ mod tests {
         let mut annotations = create_annotations();
 
         let key = String::from(STRING_KEY);
-        let val = annotations.remove(&key as &dyn AnnotationKey);
+        let val = annotations.shift_remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(string_val()));
 
         let key = STR_KEY;
-        let val = annotations.remove(&key as &dyn AnnotationKey);
+        let val = annotations.shift_remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(str_val()));
 
         let key = Symbol::from(SYMBOL_KEY);
-        let val = annotations.remove(&key as &dyn AnnotationKey);
+        let val = annotations.shift_remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(symbol_val()));
 
         let key = SymbolRef(SYMBOL_REF_KEY);
-        let val = annotations.remove(&key as &dyn AnnotationKey);
+        let val = annotations.shift_remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(symbol_ref_val()));
 
         let key = U64_KEY;
-        let val = annotations.remove(&key as &dyn AnnotationKey);
+        let val = annotations.shift_remove(&key as &dyn AnnotationKey);
         assert_eq!(val, Some(u64_val()));
 
         assert!(annotations.is_empty())

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -27,7 +27,7 @@
 
 ## 0.9.0
 
-1. Unified versioning with other `fe2o3-amqp` crates
+1. Unified minor versioning with other `fe2o3-amqp` crates
 2. Updated `tokio-rustls` to "0.25"
 3. Updated `rustls` to "0.22"
 4. Updated `webpkit-roots` to "0.26"

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.9.1
+
+1. Mark `remove` and `remove_entry` as deprecated in `OrderedMap`
+2. Added `swap_remove` and `swap_remove_entry` in `OrderedMap`
+3. Added `shift_remove` and `shift_remove_entry` in `OrderedMap`
+
 ## 0.9.0
 
 1. Unified versioning with other `fe2o3-amqp` crates

--- a/serde_amqp/src/primitives/map.rs
+++ b/serde_amqp/src/primitives/map.rs
@@ -145,23 +145,59 @@ where
         self.0.get_mut(key)
     }
 
+    /// Calls [`IndexMap::swap_remove`] internally
+    pub fn swap_remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        self.0.swap_remove(key)
+    }
+
+    /// Calls [`IndexMap::shift_remove`] internally
+    pub fn shift_remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        self.0.shift_remove(key)
+    }
+
     /// Remove the key-value pair equivalent to key and return its value.
     ///
     /// Calls [`IndexMap::remove`] internally
+    #[deprecated(note = "Use `swap_remove` or `shift_remove` instead.")]
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
         Q: Hash + Equivalent<K>,
     {
+        #[allow(deprecated)]
         self.0.remove(key)
+    }
+
+    /// Calls [`IndexMap::swap_remove_entry`] internally
+    pub fn swap_remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        self.0.swap_remove_entry(key)
+    }
+
+    /// Calls [`IndexMap::shift_remove_entry`] internally
+    pub fn shift_remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        self.0.shift_remove_entry(key)
     }
 
     /// Remove and return the key-value pair equivalent to key.
     ///
     /// Calls [`IndexMap::remove_entry`] internally
+    #[deprecated(note = "Use `swap_remove_entry` or `shift_remove_entry` instead.")]
     pub fn remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
     where
         Q: Hash + Equivalent<K>,
     {
+        #[allow(deprecated)]
         self.0.remove_entry(key)
     }
 


### PR DESCRIPTION
1. Mark `remove` and `remove_entry` as deprecated in `OrderedMap`
2. Added `swap_remove` and `swap_remove_entry` in `OrderedMap`
3. Added `shift_remove` and `shift_remove_entry` in `OrderedMap`