### PR TITLE
Implemented public `dispose` and `dispose_all` methods in Receiver

### DIFF
--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -534,7 +534,7 @@ impl Receiver {
         self.inner.dispose(delivery_info, None, state).await
     }
 
-    /// Dispose the message by sending one or more disposition(s)  with the provided state
+    /// Dispose the message by sending one or more disposition(s) with the provided state
     ///
     /// Only deliveries that are found in the local unsettled map will be included in the disposition frame(s).
     pub async fn dispose_all(

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -529,8 +529,9 @@ impl Receiver {
     pub async fn dispose(
         &self,
         delivery_info: impl Into<DeliveryInfo>,
-        state: TerminalDeliveryState,
+        state: impl Into<TerminalDeliveryState>,
     ) -> Result<(), DispositionError> {
+        let state: TerminalDeliveryState = state.into();
         self.inner.dispose(delivery_info, None, state.into()).await
     }
 
@@ -540,8 +541,9 @@ impl Receiver {
     pub async fn dispose_all(
         &self,
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
-        state: TerminalDeliveryState,
+        state: impl Into<TerminalDeliveryState>,
     ) -> Result<(), DispositionError> {
+        let state: TerminalDeliveryState = state.into();
         let delivery_infos = deliveries.into_iter().map(|d| d.into()).collect();
         self.inner.dispose_all(delivery_infos, None, state.into()).await
     }
@@ -575,7 +577,7 @@ impl From<TerminalDeliveryState> for DeliveryState {
 }
 
 impl TryFrom<DeliveryState> for TerminalDeliveryState {
-    type Error = ();
+    type Error = DeliveryState;
 
     fn try_from(value: DeliveryState) -> Result<Self, Self::Error> {
         match value {
@@ -583,8 +585,32 @@ impl TryFrom<DeliveryState> for TerminalDeliveryState {
             DeliveryState::Rejected(val) => Ok(Self::Rejected(val)),
             DeliveryState::Released(val) => Ok(Self::Released(val)),
             DeliveryState::Modified(val) => Ok(Self::Modified(val)),
-            _ => Err(()),
+            _ => Err(value),
         }
+    }
+}
+
+impl From<Accepted> for TerminalDeliveryState {
+    fn from(value: Accepted) -> Self {
+        Self::Accepted(value)
+    }
+}
+
+impl From<Rejected> for TerminalDeliveryState {
+    fn from(value: Rejected) -> Self {
+        Self::Rejected(value)
+    }
+}
+
+impl From<Released> for TerminalDeliveryState {
+    fn from(value: Released) -> Self {
+        Self::Released(value)
+    }
+}
+
+impl From<Modified> for TerminalDeliveryState {
+    fn from(value: Modified) -> Self {
+        Self::Modified(value)
     }
 }
 

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -43,6 +43,7 @@ cfg_transaction! {
 
 #[cfg(docsrs)]
 use fe2o3_amqp_types::messaging::{AmqpSequence, AmqpValue, Batch, Body};
+use fe2o3_amqp_types::messaging::Outcome;
 
 /// Credit mode for the link
 #[derive(Debug, Clone)]
@@ -417,8 +418,8 @@ impl Receiver {
         &self,
         delivery_info: impl Into<DeliveryInfo>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Accepted(Accepted {});
-        self.dispose(delivery_info, state).await
+        let outcome = Outcome::Accepted(Accepted {});
+        self.dispose(delivery_info, outcome).await
     }
 
     /// Accept the message by sending one or more disposition(s) with the `delivery_state` field set
@@ -439,8 +440,8 @@ impl Receiver {
         &self,
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Accepted(Accepted {});
-        self.dispose_all(deliveries, state).await
+        let outcome = Outcome::Accepted(Accepted {});
+        self.dispose_all(deliveries, outcome).await
     }
 
     /// Reject the message by sending a disposition with the `delivery_state` field set
@@ -452,10 +453,10 @@ impl Receiver {
         delivery_info: impl Into<DeliveryInfo>,
         error: impl Into<Option<definitions::Error>>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Rejected(Rejected {
+        let outcome = Outcome::Rejected(Rejected {
             error: error.into(),
         });
-        self.dispose(delivery_info, state).await
+        self.dispose(delivery_info, outcome).await
     }
 
     /// Reject the message by sending one or more disposition(s) with the `delivery_state` field set
@@ -467,10 +468,10 @@ impl Receiver {
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
         error: impl Into<Option<definitions::Error>>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Rejected(Rejected {
+        let outcome = Outcome::Rejected(Rejected {
             error: error.into(),
         });
-        self.dispose_all(deliveries, state).await
+        self.dispose_all(deliveries, outcome).await
     }
 
     /// Release the message by sending a disposition with the `delivery_state` field set
@@ -481,8 +482,8 @@ impl Receiver {
         &self,
         delivery_info: impl Into<DeliveryInfo>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Released(Released {});
-        self.dispose(delivery_info, state).await
+        let outcome = Outcome::Released(Released {});
+        self.dispose(delivery_info, outcome).await
     }
 
     /// Release the message by sending one or more disposition(s) with the `delivery_state` field set
@@ -493,8 +494,8 @@ impl Receiver {
         &self,
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Released(Released {});
-        self.dispose_all(deliveries, state).await
+        let outcome = Outcome::Released(Released {});
+        self.dispose_all(deliveries, outcome).await
     }
 
     /// Modify the message by sending a disposition with the `delivery_state` field set
@@ -506,8 +507,8 @@ impl Receiver {
         delivery_info: impl Into<DeliveryInfo>,
         modified: Modified,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Modified(modified);
-        self.dispose(delivery_info, state).await
+        let outcome = Outcome::Modified(modified);
+        self.dispose(delivery_info, outcome).await
     }
 
     /// Modify the message by sending one or more disposition(s) with the `delivery_state` field set
@@ -519,8 +520,8 @@ impl Receiver {
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
         modified: Modified,
     ) -> Result<(), DispositionError> {
-        let state = DeliveryState::Modified(modified);
-        self.dispose_all(deliveries, state).await
+        let outcome = Outcome::Modified(modified);
+        self.dispose_all(deliveries, outcome).await
     }
 
     /// Dispose the message by sending a disposition with the provided state
@@ -529,9 +530,9 @@ impl Receiver {
     pub async fn dispose(
         &self,
         delivery_info: impl Into<DeliveryInfo>,
-        state: DeliveryState,
+        outcome: Outcome,
     ) -> Result<(), DispositionError> {
-        self.inner.dispose(delivery_info, None, state).await
+        self.inner.dispose(delivery_info, None, outcome.into()).await
     }
 
     /// Dispose the message by sending one or more disposition(s) with the provided state
@@ -540,10 +541,10 @@ impl Receiver {
     pub async fn dispose_all(
         &self,
         deliveries: impl IntoIterator<Item = impl Into<DeliveryInfo>>,
-        state: DeliveryState,
+        outcome: Outcome,
     ) -> Result<(), DispositionError> {
         let delivery_infos = deliveries.into_iter().map(|d| d.into()).collect();
-        self.inner.dispose_all(delivery_infos, None, state).await
+        self.inner.dispose_all(delivery_infos, None, outcome.into()).await
     }
 }
 

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -548,10 +548,18 @@ impl Receiver {
 }
 
 #[derive(Debug, Clone)]
+/// Terminal delivery states that can be used by the receiver to dispose of a delivery
 pub enum TerminalDeliveryState {
+    /// 3.4.2 Accepted
     Accepted(Accepted),
+
+    /// 3.4.2 Rejected
     Rejected(Rejected),
+
+    /// 3.4.4 Released
     Released(Released),
+
+    /// 3.4.5 Modified
     Modified(Modified),
 }
 


### PR DESCRIPTION
This PR will make it easier to implement the approach discussed in #22 and #225 by exposing a method that does all types of disposition, instead of one for each type `accept`/`reject`/`release`/`modify`.

With this, it will be possible to have a single `mpsc::channel::<(DeliveryInfo, DeliveryState)>` that handles all types of disposition without having to implement a `switch` by ourselves, considering that, under the hood, the method called in `inner` will always be the same (`dispose` or `dispose_all`).