### PR TITLE
0.10 dev

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -14,6 +14,7 @@ do
     elif [ "$entry" == "$wasm32_in_browser" ]; then
         echo "Ignored"
     elif [ -d "$entry" ]; then
+        cargo update
         cargo check --manifest-path "$entry/Cargo.toml" --all-targets --all-features
     fi
 done

--- a/fe2o3-amqp-cbs/Cargo.toml
+++ b/fe2o3-amqp-cbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-cbs"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 CBS extension"
 license = "MIT/Apache-2.0"
@@ -13,5 +13,6 @@ readme = "Readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe2o3-amqp = { version = "0.9.0", path = "../fe2o3-amqp" }
-fe2o3-amqp-management = { version = "0.9.0", path = "../fe2o3-amqp-management" }
+fe2o3-amqp = { version = "0.10.0", path = "../fe2o3-amqp" }
+fe2o3-amqp-management = { version = "0.10.0", path = "../fe2o3-amqp-management" }
+trait-variant = "0.1.1"

--- a/fe2o3-amqp-cbs/Changelog.md
+++ b/fe2o3-amqp-cbs/Changelog.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## 0.9.0 
+## 0.10.0
+
+- Updated `fe2o3-amqp` to "0.10.0"
+- Replace GAT with async fn in trait for `AsyncCbsTokenProvider` trait
+
+## 0.9.0
 
 - Unified versioning with other `fe2o3-amqp` crates
 

--- a/fe2o3-amqp-cbs/src/lib.rs
+++ b/fe2o3-amqp-cbs/src/lib.rs
@@ -5,8 +5,6 @@
 //! Please note that because the CBS protocol is still in draft, this crate is expected to see
 //! breaking changes in all future releases until the draft becomes stable.
 
-use std::future::Future;
-
 use token::CbsToken;
 
 pub mod client;
@@ -29,20 +27,16 @@ pub trait CbsTokenProvider {
 }
 
 /// An async version of `CbsTokenProvider`
-pub trait AsyncCbsTokenProvider {
+#[trait_variant::make(AsyncCbsTokenProvider: Send)]
+pub trait LocalAsyncCbsTokenProvider {
     /// The associated error type
     type Error;
 
-    /// The associated future type
-    type Fut<'a>: Future<Output = Result<CbsToken<'a>, Self::Error>>
-    where
-        Self: 'a;
-
     /// Get a CBS token
-    fn get_token_async(
+    async fn get_token_async(
         &mut self,
         container_id: impl AsRef<str>,
         resource_id: impl AsRef<str>,
         claims: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Self::Fut<'_>;
+    ) -> Result<CbsToken<'_>, Self::Error>;
 }

--- a/fe2o3-amqp-ext/Cargo.toml
+++ b/fe2o3-amqp-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ext"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Extension types to fe2o3-amqp"
 license = "MIT/Apache-2.0"
@@ -12,5 +12,5 @@ readme = "Readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_amqp = { version = "0.9.0", path = "../serde_amqp", features = ["derive"] }
-fe2o3-amqp-types = { version = "0.9.0", path = "../fe2o3-amqp-types" }
+serde_amqp = { version = "0.10.0", path = "../serde_amqp", features = ["derive"] }
+fe2o3-amqp-types = { version = "0.10.0", path = "../fe2o3-amqp-types" }

--- a/fe2o3-amqp-ext/Changelog.md
+++ b/fe2o3-amqp-ext/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+1. Unified versioning with other `fe2o3-amqp` crates
+
 ## 0.9.0
 
 1. Unified versioning with other `fe2o3-amqp` crates

--- a/fe2o3-amqp-management/Cargo.toml
+++ b/fe2o3-amqp-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-management"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 management extension"
 license = "MIT/Apache-2.0"
@@ -13,8 +13,8 @@ readme = "Readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe2o3-amqp = { version = "0.9.3", path = "../fe2o3-amqp" }
-fe2o3-amqp-types =  { version = "0.9.1", path = "../fe2o3-amqp-types/" }
+fe2o3-amqp = { version = "0.10.0", path = "../fe2o3-amqp" }
+fe2o3-amqp-types =  { version = "0.10.0", path = "../fe2o3-amqp-types/" }
 serde = "1"
 thiserror = "1"
 

--- a/fe2o3-amqp-management/Changelog.md
+++ b/fe2o3-amqp-management/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+1. Unified versioning with other `fe2o3-amqp` crates
+
 ## 0.2.3
 
 1. Backported 0.9.1

--- a/fe2o3-amqp-types/Cargo.toml
+++ b/fe2o3-amqp-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-types"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "Implementation of AMQP1.0 data types"
 license = "MIT/Apache-2.0"
@@ -33,7 +33,7 @@ transaction = ["primitive", "messaging"]
 security = ["primitive"]
 
 [dependencies]
-serde_amqp = { version = "0.9.1", path = "../serde_amqp", features = ["derive", "extensions"] }
+serde_amqp = { version = "0.10.0", path = "../serde_amqp", features = ["derive", "extensions"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 ordered-float = { version = "4", features = ["serde"] }

--- a/fe2o3-amqp-types/Changelog.md
+++ b/fe2o3-amqp-types/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.10.0
+
+1. Unified versioning with other `fe2o3-amqp` crates
+
 ## 0.7.2
 
 1. (Backporting 0.9.1) Updated `serde_amqp` to "0.5.10"

--- a/fe2o3-amqp-ws/Cargo.toml
+++ b/fe2o3-amqp-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ws"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "WebSocket binding stream for AMQP1.0"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-ws/Changelog.md
+++ b/fe2o3-amqp-ws/Changelog.md
@@ -1,5 +1,9 @@
 # fe2o3-amqp-ws
 
+## 0.10.0
+
+1. Unified versioning with other `fe2o3-amqp` crates
+
 ## 0.9.0
 
 1. Unified versioning with other `fe2o3-amqp` crates

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.9.8"
+version = "0.10.0"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"
@@ -40,8 +40,8 @@ acceptor = []
 scram = ["sha-1", "sha2", "rand", "base64", "stringprep", "hmac", "pbkdf2"]
 
 [dependencies]
-serde_amqp = { version = "0.9.1", path = "../serde_amqp" }
-fe2o3-amqp-types = { version = "0.9.1", path = "../fe2o3-amqp-types" }
+serde_amqp = { version = "0.10.0", path = "../serde_amqp" }
+fe2o3-amqp-types = { version = "0.10.0", path = "../fe2o3-amqp-types" }
 
 bytes = "1"
 tokio-util = { version = "0.7", features = ["codec"] } # tokio-rs/tokio#4816
@@ -85,7 +85,7 @@ fluvio-wasm-timer = "0.2"
 [dev-dependencies]
 tokio-test = { version = "0.4" }
 testcontainers = "0.15"
-fe2o3-amqp-ext = { version = "0.9.0", path = "../fe2o3-amqp-ext" }
+fe2o3-amqp-ext = { version = "0.10.0", path = "../fe2o3-amqp-ext" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "parking_lot"] }

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -2,8 +2,9 @@
 
 ## 0.10.0
 
-1. Changed `RecvError::MessageDecodeError` to `RecvError::MessageDecodeError {info: DeliveryInfo,
-   source: serde_amqp::Error}`. This would allow user to dispose the delivery.
+1. Changed `RecvError::MessageDecodeError` to `RecvError::MessageDecode(MessageDecodeError)`.
+2. Added `MessageDecodeError` which carries the source `serde_amqp::Error` when deserializing the
+   message body fails and the delivery info that can be used to dispose the message.
 
 ## 0.9.8
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.10.0
+
+1. Changed `RecvError::MessageDecodeError` to `RecvError::MessageDecodeError {info: DeliveryInfo,
+   source: serde_amqp::Error}`. This would allow user to dispose the delivery.
+
 ## 0.9.8
 
 1. Fixed bug with reattaching session with sender.

--- a/fe2o3-amqp/src/link/delivery.rs
+++ b/fe2o3-amqp/src/link/delivery.rs
@@ -30,7 +30,7 @@ pub struct DeliveryInfo {
     /// Receiver settle mode that is carried by the transfer frame
     pub(crate) rcv_settle_mode: Option<ReceiverSettleMode>,
 
-    _sealed: Sealed,
+    pub(crate) _sealed: Sealed,
 }
 
 impl DeliveryInfo {

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -211,7 +211,10 @@ where
                     rcv_settle_mode: mode,
                     _sealed: Sealed {},
                 };
-                return Err(ReceiverTransferError::MessageDecodeError{info, source});
+                return Err(MessageDecodeError {
+                    source,
+                    info,
+                }.into());
             }
         };
 

--- a/fe2o3-amqp/src/transaction/coordinator.rs
+++ b/fe2o3-amqp/src/transaction/coordinator.rs
@@ -223,7 +223,7 @@ impl TxnCoordinator {
             }
             RecvError::DeliveryIdIsNone
             | RecvError::DeliveryTagIsNone
-            | RecvError::MessageDecodeError
+            | RecvError::MessageDecode(_)
             | RecvError::IllegalRcvSettleModeInTransfer
             | RecvError::InconsistentFieldInMultiFrameDelivery
             | RecvError::TransactionalAcquisitionIsNotImeplemented => {

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.10.0
+
+1. Unified versioning with other `fe2o3-amqp` crates
+
 ## 0.5.10
 
 1. Backported `0.9.1`


### PR DESCRIPTION
## `fe2o3-amqp`

1. Changed `RecvError::MessageDecodeError` to `RecvError::MessageDecode(MessageDecodeError)`.
2. Added `MessageDecodeError` which carries the source `serde_amqp::Error` when deserializing the
   message body fails and the delivery info that can be used to dispose the message.

## `fe2o3-amqp-cbs`

1. Replace GAT with async fn in trait for `AsyncCbsTokenProvider` trait