### PR TITLE
Fix `SizeSerializer` not creating new instance of `SizeSerializer` for nested types

### DIFF
--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.12.2
+
+1. Fixed bug caused by not creating new `SizeSerializer` in `SerializeSeq::serialize_element` (issue #279)
+
 ## 0.12.1
 
 1. Fixed empty `Array` not deserialized properly (issue #277)

--- a/serde_amqp/src/size_ser.rs
+++ b/serde_amqp/src/size_ser.rs
@@ -134,7 +134,7 @@ impl<'a> ser::Serializer for &'a mut SizeSerializer {
                 IsArrayElement::FirstElement => Ok(9),
                 IsArrayElement::OtherElement => Ok(8),
             },
-            _ => unreachable!(),
+            _ => unreachable!("serialize_i64 is only used for Long and Timestamp"),
         }
     }
 
@@ -221,15 +221,15 @@ impl<'a> ser::Serializer for &'a mut SizeSerializer {
                     U8_MAX..=U32_MAX_MINUS_4 => Ok(5 + v.len()),
                     _ => Err(Error::too_long()),
                 },
-                _ => unreachable!(),
+                _ => unreachable!("serialize_str is only used for Symbol and String"),
             },
             IsArrayElement::FirstElement => match self.new_type {
                 NewType::Symbol | NewType::SymbolRef | NewType::None => Ok(5 + v.len()),
-                _ => unreachable!(),
+                _ => unreachable!("serialize_str is only used for Symbol and String"),
             },
             IsArrayElement::OtherElement => match self.new_type {
                 NewType::Symbol | NewType::SymbolRef | NewType::None => Ok(4 + v.len()),
-                _ => unreachable!(),
+                _ => unreachable!("serialize_str is only used for Symbol and String"),
             },
         }
     }
@@ -270,7 +270,7 @@ impl<'a> ser::Serializer for &'a mut SizeSerializer {
             | NewType::Array
             | NewType::Symbol
             | NewType::SymbolRef
-            | NewType::TransparentVec => unreachable!(),
+            | NewType::TransparentVec => unreachable!("serialize_bytes is only used for Binary, Decimal32, Decimal64, Decimal128, and Uuid"),
         }
     }
 
@@ -452,7 +452,8 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
     {
         match self.se.new_type {
             NewType::None => {
-                self.cumulated_size += value.serialize(&mut *self.se)?;
+                let mut serializer = SizeSerializer::new();
+                self.cumulated_size += value.serialize(&mut serializer)?;
             }
             NewType::Array => {
                 let mut serializer = SizeSerializer::new();
@@ -472,7 +473,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
             | NewType::Symbol
             | NewType::SymbolRef
             | NewType::Timestamp
-            | NewType::Uuid => unreachable!(),
+            | NewType::Uuid => unreachable!("SeqSerializer is only used for List, Array, and TransparentVec"),
         }
 
         self.idx += 1;
@@ -495,7 +496,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
             | NewType::Symbol
             | NewType::SymbolRef
             | NewType::Timestamp
-            | NewType::Uuid => unreachable!(),
+            | NewType::Uuid => unreachable!("SeqSerializer is only used for List, Array, and TransparentVec"),
         }
     }
 }
@@ -702,7 +703,7 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
                     self.cumulated_size += value.serialize(&mut serializer)?;
                     Ok(())
                 }
-                StructEncoding::DescribedMap => unreachable!(),
+                StructEncoding::DescribedMap => unreachable!("TupleStructSerializer is NOT used for DescribedMap"),
             },
         }
     }
@@ -720,7 +721,7 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
                 let _ = self.se.struct_encoding.pop();
                 Ok(self.cumulated_size)
             }
-            StructEncoding::DescribedMap => unreachable!(),
+            StructEncoding::DescribedMap => unreachable!("TupleStructSerializer is NOT used for DescribedMap"),
         }
     }
 }
@@ -1287,5 +1288,24 @@ mod tests {
         let ssize = serialized_size(&value).unwrap();
         let buf = to_vec(&value).unwrap();
         assert_eq!(ssize, buf.len());
+    }
+
+    #[test]
+    fn serialized_size_of_described_list_of_timestamps() {
+        use crate::{primitives::*, Value, described::Described, descriptor::Descriptor};
+
+        let timestamp = Timestamp::from_milliseconds(12345);
+        let mut list = List::new();
+        list.push(Value::Timestamp(timestamp));
+    
+        let described = Described {
+            descriptor: Descriptor::Code(0x73),
+            value: Value::List(list),
+        };
+    
+        let value = Value::Described(Box::new(described));
+    
+        let size_result = serialized_size(&value);
+        assert!(size_result.is_ok());
     }
 }

--- a/serde_amqp/src/size_ser.rs
+++ b/serde_amqp/src/size_ser.rs
@@ -473,7 +473,9 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
             | NewType::Symbol
             | NewType::SymbolRef
             | NewType::Timestamp
-            | NewType::Uuid => unreachable!("SeqSerializer is only used for List, Array, and TransparentVec"),
+            | NewType::Uuid => {
+                unreachable!("SeqSerializer is only used for List, Array, and TransparentVec")
+            }
         }
 
         self.idx += 1;
@@ -496,7 +498,9 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
             | NewType::Symbol
             | NewType::SymbolRef
             | NewType::Timestamp
-            | NewType::Uuid => unreachable!("SeqSerializer is only used for List, Array, and TransparentVec"),
+            | NewType::Uuid => {
+                unreachable!("SeqSerializer is only used for List, Array, and TransparentVec")
+            }
         }
     }
 }
@@ -703,7 +707,9 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
                     self.cumulated_size += value.serialize(&mut serializer)?;
                     Ok(())
                 }
-                StructEncoding::DescribedMap => unreachable!("TupleStructSerializer is NOT used for DescribedMap"),
+                StructEncoding::DescribedMap => {
+                    unreachable!("TupleStructSerializer is NOT used for DescribedMap")
+                }
             },
         }
     }
@@ -721,7 +727,9 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
                 let _ = self.se.struct_encoding.pop();
                 Ok(self.cumulated_size)
             }
-            StructEncoding::DescribedMap => unreachable!("TupleStructSerializer is NOT used for DescribedMap"),
+            StructEncoding::DescribedMap => {
+                unreachable!("TupleStructSerializer is NOT used for DescribedMap")
+            }
         }
     }
 }
@@ -1294,19 +1302,19 @@ mod tests {
 
     #[test]
     fn serialized_size_of_described_list_of_timestamps() {
-        use crate::{primitives::*, Value, described::Described, descriptor::Descriptor};
+        use crate::{described::Described, descriptor::Descriptor, primitives::*, Value};
 
         let timestamp = Timestamp::from_milliseconds(12345);
         let mut list = List::new();
         list.push(Value::Timestamp(timestamp));
-    
+
         let described = Described {
             descriptor: Descriptor::Code(0x73),
             value: Value::List(list),
         };
-    
+
         let value = Value::Described(Box::new(described));
-    
+
         let size_result = serialized_size(&value);
         assert!(size_result.is_ok());
     }

--- a/serde_amqp/src/size_ser.rs
+++ b/serde_amqp/src/size_ser.rs
@@ -775,7 +775,8 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
                     Ok(())
                 }
                 StructEncoding::DescribedBasic => {
-                    self.cumulated_size += value.serialize(&mut *self.se)?;
+                    let mut serializer = SizeSerializer::new();
+                    self.cumulated_size += value.serialize(&mut serializer)?;
                     Ok(())
                 }
             }
@@ -830,7 +831,8 @@ impl<'a> ser::SerializeTupleVariant for VariantSerializer<'a> {
     where
         T: ser::Serialize + ?Sized,
     {
-        self.cumulated_size += value.serialize(&mut *self.se)?;
+        let mut serializer = SizeSerializer::new();
+        self.cumulated_size += value.serialize(&mut serializer)?;
         Ok(())
     }
 


### PR DESCRIPTION
Related issue: #279 