### PR TITLE
Add support for external sasl

### DIFF
--- a/examples/sasl_connection/Cargo.toml
+++ b/examples/sasl_connection/Cargo.toml
@@ -13,9 +13,7 @@ scram = ["fe2o3-amqp/scram"]
 [dependencies]
 tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "macros"] }
 fe2o3-amqp = { features = ["rustls"], path = "../../fe2o3-amqp" }
-#tokio-rustls = {version = "0.26", default-features = false, features = ["ring", "tls12"] }
 tokio-rustls = { version = "0.26.0", default-features = false }
-#rustls = { version = "0.23.36", optional = true }
 rustls = { version = "0.23.36", default-features = false, optional = true }
 webpki-roots = "0.26"
 

--- a/examples/sasl_connection/Cargo.toml
+++ b/examples/sasl_connection/Cargo.toml
@@ -6,13 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["scram"]
+default = ["scram","rustls"]
 
 scram = ["fe2o3-amqp/scram"]
 
 [dependencies]
 tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "macros"] }
-fe2o3-amqp = { path = "../../fe2o3-amqp" }
+fe2o3-amqp = { features = ["rustls"], path = "../../fe2o3-amqp" }
+#tokio-rustls = {version = "0.26", default-features = false, features = ["ring", "tls12"] }
+tokio-rustls = { version = "0.26.0", default-features = false }
+#rustls = { version = "0.23.36", optional = true }
+rustls = { version = "0.23.36", default-features = false, optional = true }
+webpki-roots = "0.26"
 
 [[bin]]
 name = "sasl_scram_sha_1"
@@ -28,3 +33,9 @@ required-features = ["scram"]
 name = "sasl_scram_sha_512"
 path = "src/bin/sasl_scram_sha_512.rs"
 required-features = ["scram"]
+
+[[bin]]
+name = "sasl_external"
+path = "src/bin/sasl_external.rs"
+required-features = ["rustls"]
+

--- a/examples/sasl_connection/Cargo.toml
+++ b/examples/sasl_connection/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "macros"] }
 fe2o3-amqp = { features = ["rustls"], path = "../../fe2o3-amqp" }
 tokio-rustls = { version = "0.26.0", default-features = false }
 rustls = { version = "0.23.36", default-features = false, optional = true }
+url = "2"
 webpki-roots = "0.26"
 
 [[bin]]

--- a/examples/sasl_connection/Readme.md
+++ b/examples/sasl_connection/Readme.md
@@ -17,3 +17,8 @@ cargo run --bin sasl_scram_sha_256 --features "scram"
 ```sh
 cargo run --bin sasl_scram_sha_512 --features "scram"
 ```
+
+```sh
+cargo run --bin sasl_external --features "rustls"
+```
+

--- a/examples/sasl_connection/src/bin/sasl_external.rs
+++ b/examples/sasl_connection/src/bin/sasl_external.rs
@@ -1,7 +1,7 @@
 use rustls::{ClientConfig, RootCertStore};
-use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 use std::sync::Arc;
+use url::Url;
 use fe2o3_amqp::{
     sasl_profile::SaslProfile, types::primitives::Value, Connection, Receiver, Sender,
     Session,
@@ -16,18 +16,15 @@ async fn main() {
                               .with_root_certificates(root_store)
                               .with_no_client_auth();
     let tls_connector = TlsConnector::from(Arc::new(config));
-
-    let stream = TcpStream::connect("localhost:5671").await.unwrap();
+    let addr = format!("amqps://localhost:5671");
+    let url = Url::parse(&addr).unwrap();
 
     let mut connection = Connection::builder()
         .container_id("connection-1")
         .tls_connector(tls_connector)
         .sasl_profile(SaslProfile::External)
-        .domain("localhost")
-        .hostname("localhost")
-        .scheme("amqps")
         .alt_tls_establishment(true)
-        .open_with_stream(stream).await.unwrap();
+        .open(url).await.unwrap();
     let mut session = Session::begin(&mut connection).await.unwrap();
     let mut sender = Sender::attach(&mut session, "rust-sender-link-1", "q1")
         .await

--- a/examples/sasl_connection/src/bin/sasl_external.rs
+++ b/examples/sasl_connection/src/bin/sasl_external.rs
@@ -1,13 +1,5 @@
-//use rustls::crypto::{CryptoProvider, ring};
 use rustls::{ClientConfig, RootCertStore};
 use tokio::net::TcpStream;
-//use rustls_pemfile::{certs, read_one, Item};
-//use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-//use rustls::pki_types::pem::PemObject;
-//use rustls::pki_types::PrivatePkcs8KeyDer;
-//use tokio::net::TcpStream;
-//use tokio::time::sleep;
-//use serde::{Deserialize, Serialize};
 use tokio_rustls::TlsConnector;
 use std::sync::Arc;
 use fe2o3_amqp::{

--- a/examples/sasl_connection/src/bin/sasl_external.rs
+++ b/examples/sasl_connection/src/bin/sasl_external.rs
@@ -24,7 +24,7 @@ async fn main() {
         .tls_connector(tls_connector)
         .sasl_profile(SaslProfile::External)
         .domain("localhost")
-        .hostname("localhost:5671")
+        .hostname("localhost")
         .scheme("amqps")
         .alt_tls_establishment(true)
         .open_with_stream(stream).await.unwrap();

--- a/examples/sasl_connection/src/bin/sasl_external.rs
+++ b/examples/sasl_connection/src/bin/sasl_external.rs
@@ -1,0 +1,60 @@
+//use rustls::crypto::{CryptoProvider, ring};
+use rustls::{ClientConfig, RootCertStore};
+use tokio::net::TcpStream;
+//use rustls_pemfile::{certs, read_one, Item};
+//use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+//use rustls::pki_types::pem::PemObject;
+//use rustls::pki_types::PrivatePkcs8KeyDer;
+//use tokio::net::TcpStream;
+//use tokio::time::sleep;
+//use serde::{Deserialize, Serialize};
+use tokio_rustls::TlsConnector;
+use std::sync::Arc;
+use fe2o3_amqp::{
+    sasl_profile::SaslProfile, types::primitives::Value, Connection, Receiver, Sender,
+    Session,
+};
+
+#[tokio::main]
+async fn main() {
+
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let config = ClientConfig::builder()
+                              .with_root_certificates(root_store)
+                              .with_no_client_auth();
+    let tls_connector = TlsConnector::from(Arc::new(config));
+
+    let stream = TcpStream::connect("localhost:5671").await.unwrap();
+
+    let mut connection = Connection::builder()
+        .container_id("connection-1")
+        .tls_connector(tls_connector)
+        .sasl_profile(SaslProfile::External)
+        .domain("localhost")
+        .hostname("localhost:5671")
+        .scheme("amqps")
+        .alt_tls_establishment(true)
+        .open_with_stream(stream).await.unwrap();
+    let mut session = Session::begin(&mut connection).await.unwrap();
+    let mut sender = Sender::attach(&mut session, "rust-sender-link-1", "q1")
+        .await
+        .unwrap();
+    sender
+        .send("hello AMQP")
+        .await
+        .unwrap()
+        .accepted_or_else(|outcome| outcome)
+        .unwrap();
+
+    let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
+        .await
+        .unwrap();
+    let delivery = receiver.recv::<Value>().await.unwrap();
+    receiver.accept(&delivery).await.unwrap();
+
+    sender.close().await.unwrap();
+    receiver.close().await.unwrap();
+    session.end().await.unwrap();
+    connection.close().await.unwrap();
+}

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -957,7 +957,13 @@ cfg_not_wasm32! {
             Io: AsyncRead + AsyncWrite + std::fmt::Debug + SendBound + Unpin + 'static,
         {
             match self.scheme {
-                "amqp" => self.connect_with_stream(stream, spawn_engine).await,
+                "amqp" => {
+                    // If EXTERNAL is chosen, we should error out here
+                    if matches!(self.sasl_profile, Some(SaslProfile::External)) {
+                        return Err(OpenError::InvalidSchemeForSaslExternal);
+                    }
+                    self.connect_with_stream(stream, spawn_engine).await
+                },
                 "amqps" => {
                     #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
                     {
@@ -1199,7 +1205,13 @@ cfg_not_wasm32! {
                 Io: AsyncRead + AsyncWrite + std::fmt::Debug + SendBound + Unpin + 'static,
             {
                 match self.scheme {
-                    "amqp" => self.connect_with_stream(stream, spawn_engine).await,
+                    "amqp" => {
+                        // If EXTERNAL is chosen, we should error out here
+                        if matches!(self.sasl_profile, Some(SaslProfile::External)) {
+                            return Err(OpenError::InvalidSchemeForSaslExternal);
+                        }
+                        self.connect_with_stream(stream, spawn_engine).await
+                    },
                     "amqps" => {
                         let domain = self.domain.ok_or(OpenError::InvalidDomain)?;
                         let tls_stream = Transport::connect_tls_with_rustls(
@@ -1332,7 +1344,13 @@ cfg_not_wasm32! {
                 Io: AsyncRead + AsyncWrite + std::fmt::Debug + SendBound + Unpin + 'static,
             {
                 match self.scheme {
-                    "amqp" => self.connect_with_stream(stream, spawn_engine).await,
+                    "amqp" => {
+                        // If EXTERNAL is chosen, we should error out here
+                        if matches!(self.sasl_profile, Some(SaslProfile::External)) {
+                            return Err(OpenError::InvalidSchemeForSaslExternal);
+                        }
+                        self.connect_with_stream(stream, spawn_engine).await
+                    },
                     "amqps" => {
                         let domain = self.domain.ok_or(OpenError::InvalidDomain)?;
                         let tls_stream = Transport::connect_tls_with_native_tls(

--- a/fe2o3-amqp/src/connection/error.rs
+++ b/fe2o3-amqp/src/connection/error.rs
@@ -35,6 +35,10 @@ pub enum OpenError {
     #[error(r#"Invalid scheme. Only "amqp" and "amqps" are supported."#)]
     InvalidScheme,
 
+    /// Scheme is invalid for SaslProfile::External
+    #[error(r#"SASL EXTERNAL mechanism requires "amqps" scheme."#)]
+    InvalidSchemeForSaslExternal,
+
     /// Protocol negotiation failed due to protocol header mismatch
     #[error("Protocol header mismatch. Found {0:?}")]
     ProtocolHeaderMismatch(Bytes),

--- a/fe2o3-amqp/src/sasl_profile/mod.rs
+++ b/fe2o3-amqp/src/sasl_profile/mod.rs
@@ -26,7 +26,7 @@ cfg_scram! {
     pub(crate) const SCRAM_SHA_512: &str = "SCRAM-SHA-512";
 }
 
-// pub const EXTERN: Symbol = Symbol::from("EXTERNAL");
+pub(crate) const EXTERNAL: &str = "EXTERNAL";
 pub(crate) const ANONYMOUS: &str = "ANONYMOUS";
 pub(crate) const PLAIN: &str = "PLAIN";
 
@@ -50,6 +50,9 @@ pub enum SaslProfile {
         /// Password
         password: String,
     },
+
+    /// SASL profile for EXTERNAL mechanism
+    External,
 
     /// SASL-SCRAM-SHA-1
     #[cfg_attr(docsrs, doc(cfg(feature = "scram")))]
@@ -110,6 +113,7 @@ impl SaslProfile {
                 username: _,
                 password: _,
             } => PLAIN,
+            SaslProfile::External => EXTERNAL,
             #[cfg(feature = "scram")]
             SaslProfile::ScramSha1(_) => SCRAM_SHA_1,
             #[cfg(feature = "scram")]
@@ -123,6 +127,8 @@ impl SaslProfile {
     pub(crate) fn initial_response(&mut self) -> Option<Binary> {
         match self {
             SaslProfile::Anonymous => None,
+            SaslProfile::External => None, // TODO: if this works, keep it
+            //SaslProfile::External => Some(Binary::from("")), // TODO: otherwise keep this one
             SaslProfile::Plain { username, password } => {
                 let username = username.as_bytes();
                 let password = password.as_bytes();
@@ -175,8 +181,8 @@ impl SaslProfile {
                 }
             }
             Frame::Challenge(challenge) => match self {
-                SaslProfile::Anonymous | SaslProfile::Plain { .. } => Err(Error::NotImplemented(
-                    Some("SASL Challenge is not implemented for ANONYMOUS or PLAIN.".to_string()),
+                SaslProfile::Anonymous | SaslProfile::Plain { .. } | SaslProfile::External => Err(Error::NotImplemented(
+                    Some("SASL Challenge is not implemented for ANONYMOUS, PLAIN, or EXTERNAL.".to_string()),
                 )),
                 #[cfg(feature = "scram")]
                 SaslProfile::ScramSha1(SaslScramSha1 { client })
@@ -194,7 +200,7 @@ impl SaslProfile {
             },
             Frame::Outcome(outcome) => {
                 match self {
-                    SaslProfile::Anonymous | SaslProfile::Plain { .. } => {}
+                    SaslProfile::Anonymous | SaslProfile::Plain { .. } | SaslProfile::External => {}
                     #[cfg(feature = "scram")]
                     SaslProfile::ScramSha1(SaslScramSha1 { client })
                     | SaslProfile::ScramSha256(SaslScramSha256 { client })

--- a/fe2o3-amqp/src/sasl_profile/mod.rs
+++ b/fe2o3-amqp/src/sasl_profile/mod.rs
@@ -127,8 +127,7 @@ impl SaslProfile {
     pub(crate) fn initial_response(&mut self) -> Option<Binary> {
         match self {
             SaslProfile::Anonymous => None,
-            SaslProfile::External => None, // TODO: if this works, keep it
-            //SaslProfile::External => Some(Binary::from("")), // TODO: otherwise keep this one
+            SaslProfile::External => None,
             SaslProfile::Plain { username, password } => {
                 let username = username.as_bytes();
                 let password = password.as_bytes();


### PR DESCRIPTION
Only SaslProfile::Plain and SaslProfile::Anonymous were implemented, not Sasl::External. 
So,now it's added.