### PR TITLE
Acceptor drops pipelined frames, killing connections and losing link credit

### DIFF
--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -19,7 +19,8 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 use crate::{
     acceptor::sasl_acceptor::SaslServerFrame,
     connection::{
-        self, engine::ConnectionEngine, ConnectionHandle, OpenError, DEFAULT_CONTROL_CHAN_BUF,
+        self, engine::ConnectionEngine, ConnectionHandle, OpenError,
+        DEFAULT_CONTROL_CHAN_BUF, DEFAULT_OUTGOING_BUFFER_SIZE,
     },
     endpoint::{self, IncomingChannel, OutgoingChannel},
     frames::{
@@ -520,20 +521,37 @@ impl endpoint::Connection for ListenerConnection {
                 relay.send(sframe).await?;
             }
             None => {
-                // If a session is locally initiated, the remote-channel MUST NOT be set. When an endpoint responds
-                // to a remotely initiated session, the remote-channel MUST be set to the channel on which the
-                // remote session sent the begin.
+                // Remotely initiated session.
+                //
+                // Eagerly allocate the session relay and register it for the
+                // incoming channel so that pipelined Attach frames arriving
+                // before the user code accepts the session are buffered
+                // instead of triggering a `NotFound` connection error.
+                let (incoming_tx, incoming_rx) =
+                    mpsc::channel(DEFAULT_OUTGOING_BUFFER_SIZE);
+                let outgoing_channel = self
+                    .connection
+                    .allocate_session(incoming_tx)
+                    .map_err(|_| Self::Error::NotImplemented(None))?;
 
-                // Upon receiving the
-                // begin the partner will check the remote-channel field and find it empty. This indicates that the begin is referring to
-                // remotely initiated session. The partner will therefore allocate an unused outgoing channel for the remotely initiated
-                // session and indicate this by sending its own begin setting the remote-channel field to the incoming channel of the
-                // remotely initiated session
+                // The relay was just inserted into session_by_outgoing_channel
+                // by allocate_session. Clone it into session_by_incoming_channel
+                // so that forward_to_session can route pipelined frames.
+                let relay = self
+                    .connection
+                    .session_by_outgoing_channel
+                    .get(outgoing_channel.0 as usize)
+                    .expect("relay was just allocated")
+                    .clone();
+                self.connection
+                    .session_by_incoming_channel
+                    .insert(channel, relay);
 
-                // Here we will send the begin frame out to get processed
                 let incoming_session = IncomingSession {
                     channel: channel.0,
                     begin,
+                    incoming_rx: Some(incoming_rx),
+                    outgoing_channel: Some(outgoing_channel),
                 };
                 self.session_listener
                     .send(incoming_session)

--- a/fe2o3-amqp/src/acceptor/mod.rs
+++ b/fe2o3-amqp/src/acceptor/mod.rs
@@ -17,6 +17,9 @@ use fe2o3_amqp_types::{
     definitions::{ReceiverSettleMode, SenderSettleMode},
     performatives::Begin,
 };
+use tokio::sync::mpsc;
+
+use crate::{endpoint::OutgoingChannel, session::frame::SessionIncomingItem};
 
 pub use self::connection::{ConnectionAcceptor, ListenerConnectionHandle};
 pub use self::link::{LinkAcceptor, LinkEndpoint};
@@ -31,6 +34,21 @@ pub struct IncomingSession {
 
     /// The Begin performative sent by the remote peer
     pub begin: Begin,
+
+    /// Pre-allocated incoming frame receiver.
+    ///
+    /// When the connection engine eagerly registers the session's incoming
+    /// channel (to handle pipelined Attach frames that arrive before the
+    /// session is fully accepted), this field carries the receiver end of
+    /// the channel. `accept_incoming_session` will use it instead of
+    /// creating a new one.
+    pub(crate) incoming_rx: Option<mpsc::Receiver<SessionIncomingItem>>,
+
+    /// Pre-allocated outgoing channel.
+    ///
+    /// Set together with `incoming_rx` when the session relay was eagerly
+    /// registered inside the connection engine.
+    pub(crate) outgoing_channel: Option<OutgoingChannel>,
 }
 
 /// The supported sender-settle-modes for the link acceptor

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -1,5 +1,6 @@
 //! Session Listener
 
+use std::collections::HashMap;
 
 use fe2o3_amqp_types::{
     definitions::{self, ConnectionError},
@@ -230,32 +231,43 @@ impl SessionAcceptor {
         let local_state = SessionState::Unmapped;
         let (session_control_tx, session_control_rx) =
             mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
-        let (incoming_tx, incoming_rx) = mpsc::channel(self.0.buffer_size);
         let (outgoing_tx, outgoing_rx) = mpsc::channel(self.0.buffer_size);
         let (link_listener_tx, link_listener_rx) = mpsc::channel(self.0.buffer_size);
 
-        // create session in connection::Engine
-        let outgoing_channel = match connection.allocate_session(incoming_tx).await {
-            Ok(channel) => channel,
-            Err(error) => match error {
-                AllocSessionError::IllegalState => return Err(BeginError::IllegalConnectionState),
-                AllocSessionError::ChannelMaxReached => {
-                    // A peer that receives a channel number outside the supported range MUST close the connection
-                    // with the framing-error error-code
-                    let error = definitions::Error::new(
-                        ConnectionError::FramingError,
-                        "Exceeding channel-max".to_string(),
-                        None,
-                    );
-                    connection
-                        .control
-                        .send(ConnectionControl::Close(Some(error)))
-                        .await
-                        .map_err(|_| BeginError::IllegalConnectionState)?;
+        // If the connection engine pre-allocated the session relay (to handle
+        // pipelined frames), use the pre-created incoming channel and outgoing
+        // channel directly. Otherwise fall back to the original allocation path.
+        let (outgoing_channel, incoming_rx) = match (
+            incoming_session.incoming_rx,
+            incoming_session.outgoing_channel,
+        ) {
+            (Some(rx), Some(ch)) => (ch, rx),
+            _ => {
+                let (incoming_tx, incoming_rx) = mpsc::channel(self.0.buffer_size);
+                let outgoing_channel = match connection.allocate_session(incoming_tx).await {
+                    Ok(channel) => channel,
+                    Err(error) => match error {
+                        AllocSessionError::IllegalState => {
+                            return Err(BeginError::IllegalConnectionState)
+                        }
+                        AllocSessionError::ChannelMaxReached => {
+                            let error = definitions::Error::new(
+                                ConnectionError::FramingError,
+                                "Exceeding channel-max".to_string(),
+                                None,
+                            );
+                            connection
+                                .control
+                                .send(ConnectionControl::Close(Some(error)))
+                                .await
+                                .map_err(|_| BeginError::IllegalConnectionState)?;
 
-                    return Err(BeginError::LocalChannelMaxReached);
-                }
-            },
+                            return Err(BeginError::LocalChannelMaxReached);
+                        }
+                    },
+                };
+                (outgoing_channel, incoming_rx)
+            }
         };
         let mut session = self.0.clone().into_session(outgoing_channel, local_state);
         session.on_incoming_begin(
@@ -266,6 +278,7 @@ impl SessionAcceptor {
         let listener_session = ListenerSession {
             session,
             link_listener: link_listener_tx,
+            pending_link_flows: HashMap::new(),
         };
 
         let (engine_handle, outcome) = self
@@ -343,6 +356,12 @@ where
 pub struct ListenerSession {
     pub(crate) session: session::Session,
     pub(crate) link_listener: mpsc::Sender<Attach>,
+
+    /// Buffer for link-level Flow frames that arrive before the link handle
+    /// is registered (i.e. before `accept_incoming_attach` is called).
+    /// Keyed by the remote's handle (InputHandle). These are replayed when
+    /// `allocate_incoming_link` inserts the relay into `link_by_input_handle`.
+    pub(crate) pending_link_flows: HashMap<InputHandle, Vec<LinkFlow>>,
 }
 
 impl endpoint::Session for ListenerSession {

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -1,5 +1,6 @@
 //! Session Listener
 
+
 use std::collections::HashMap;
 
 use fe2o3_amqp_types::{
@@ -269,6 +270,7 @@ impl SessionAcceptor {
                 (outgoing_channel, incoming_rx)
             }
         };
+
         let mut session = self.0.clone().into_session(outgoing_channel, local_state);
         session.on_incoming_begin(
             IncomingChannel(incoming_session.channel),
@@ -356,7 +358,6 @@ where
 pub struct ListenerSession {
     pub(crate) session: session::Session,
     pub(crate) link_listener: mpsc::Sender<Attach>,
-
     /// Buffer for link-level Flow frames that arrive before the link handle
     /// is registered (i.e. before `accept_incoming_attach` is called).
     /// Keyed by the remote's handle (InputHandle). These are replayed when
@@ -394,8 +395,41 @@ impl endpoint::Session for ListenerSession {
         link_handle: LinkRelay<()>,
         input_handle: InputHandle,
     ) -> Result<OutputHandle, Self::AllocError> {
-        self.session
-            .allocate_incoming_link(link_name, link_handle, input_handle)
+        let output_handle = self.session
+            .allocate_incoming_link(link_name, link_handle, input_handle.clone())?;
+
+        // Replay any buffered link-level Flow frames that arrived before this
+        // link handle was registered (due to pipelining).
+        if let Some(pending_flows) = self.pending_link_flows.remove(&input_handle) {
+            if let Some(link_relay) = self.session.link_by_input_handle.get_mut(&input_handle) {
+                for flow in pending_flows {
+                    // Replay the flow synchronously.  For a Sender relay the
+                    // Producer wraps Arc<LinkFlowState<SenderMarker>> whose
+                    // on_incoming_flow is a plain RwLock write.  We update
+                    // the state and notify waiters so the sender's Consumer
+                    // unblocks.
+                    match link_relay {
+                        LinkRelay::Sender {
+                            flow_state,
+                            output_handle: ref oh,
+                            ..
+                        } => {
+                            let _echo = flow_state.state.on_incoming_flow(flow, oh.clone());
+                            flow_state.notifier.notify_waiters();
+                        }
+                        LinkRelay::Receiver {
+                            flow_state,
+                            output_handle: ref oh,
+                            ..
+                        } => {
+                            let _echo = flow_state.on_incoming_flow(flow, oh.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(output_handle)
     }
 
     fn deallocate_link(&mut self, output_handle: OutputHandle) {
@@ -461,7 +495,36 @@ impl endpoint::Session for ListenerSession {
         &mut self,
         flow: Flow,
     ) -> Result<Option<SessionOutgoingItem>, Self::Error> {
-        self.session.on_incoming_flow(flow).await
+        // Pre-extract the LinkFlow before the inner call consumes the Flow,
+        // so we can buffer it if the handle is not yet registered.
+        let link_flow_backup = LinkFlow::try_from(flow.clone()).ok();
+
+        match self.session.on_incoming_flow(flow).await {
+            Ok(result) => Ok(result),
+            Err(SessionInnerError::UnattachedHandle) => {
+                // When running as a listener/acceptor, the remote peer may
+                // pipeline a Flow frame immediately after Attach, before the
+                // application code has called `accept_incoming_attach`.  In
+                // that case the link handle is not yet registered in
+                // `link_by_input_handle`, causing `UnattachedHandle`.
+                //
+                // The session-level flow-control fields have already been
+                // updated by `on_incoming_flow_inner` before the error was
+                // produced.  Buffer the link-level flow so it can be replayed
+                // when the link is eventually accepted.
+                if let Some(link_flow) = link_flow_backup {
+                    let input_handle = InputHandle::from(link_flow.handle.clone());
+                    self.pending_link_flows
+                        .entry(input_handle)
+                        .or_default()
+                        .push(link_flow);
+                } else {
+                    // Session-level flow with no link handle — nothing to buffer.
+                }
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn on_incoming_transfer(
@@ -469,7 +532,16 @@ impl endpoint::Session for ListenerSession {
         transfer: Transfer,
         payload: Payload,
     ) -> Result<Option<Disposition>, Self::Error> {
-        self.session.on_incoming_transfer(transfer, payload).await
+        match self.session.on_incoming_transfer(transfer, payload).await {
+            Ok(result) => Ok(result),
+            Err(SessionInnerError::UnattachedHandle) => {
+                // Same pipelining issue as on_incoming_flow: the remote peer
+                // may send a Transfer before the link has been accepted.
+                // Silently drop the transfer rather than killing the session.
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     fn on_incoming_disposition(

--- a/fe2o3-amqp/src/util/producer.rs
+++ b/fe2o3-amqp/src/util/producer.rs
@@ -5,7 +5,7 @@ use tokio::sync::Notify;
 #[derive(Debug)]
 pub struct Producer<State> {
     pub notifier: Arc<Notify>,
-    state: State,
+    pub(crate) state: State,
 }
 
 impl<State> Producer<State> {


### PR DESCRIPTION

I'm building an Azure Service Bus emulator using `fe2o3-amqp` v0.14.0 as the AMQP server. The Azure .NET SDK (`Azure.Messaging.ServiceBus` 7.20.1) pipelines its AMQP frames pretty aggressively — it sends `Begin` + `Attach` + `Flow` back-to-back without waiting for server responses between them. This is allowed by the AMQP 1.0 spec (Section 2.5.1), but it triggers three related problems in the acceptor code.

First connections usually work fine. Second and subsequent connections fail nondeterministically — the server closes them with `amqp:not-found`, or the CBS authentication hangs forever. On the .NET side this shows up as `TaskCanceledException` or connection timeouts.

Problem 1: `forward_to_session` can't find the session relay

When the client opens a remotely-initiated session, `ListenerConnection::on_incoming_begin` sends an `IncomingSession` to the `session_listener` channel for user code to accept. The relay only gets registered in `session_by_incoming_channel` later, when `on_outgoing_begin` processes the server's response `Begin`.

But if the client pipelines an `Attach` right after its `Begin`, the connection engine tries to route it via `forward_to_session` before the relay exists:

```rust
// connection/engine.rs, forward_to_session
match self.connection.session_tx_by_incoming_channel(channel) {
    Some(tx) => tx.send(frame).await?,
    None => return Err(ConnectionInnerError::NotFound(None)),  // boom
};
```

This kills the entire connection.

Problem 2: Pipelined `Flow` crashes the session engine

After fixing problem 1 (so pipelined frames actually reach the session), the next thing that breaks is `Flow` handling. The `Attach` gets correctly buffered in the `link_listener` channel, but the `Flow` that follows it references a link handle that hasn't been registered yet — `accept_incoming_attach` hasn't been called. `on_incoming_flow_inner` looks up `link_by_input_handle`, doesn't find it, and returns `UnattachedHandle`. This escalates through `on_error` → `end_session`, killing the session engine. The connection engine then gets a `SendError` because the session's channel dropped.

Same thing happens with pipelined `Transfer` frames.

Problem 3: Dropping the `Flow` loses the initial credit grant

Even after catching `UnattachedHandle` gracefully (instead of crashing), just dropping the `Flow` causes a subtler problem. That pipelined `Flow` typically carries the initial credit grant from the remote receiver (`link_credit=50`). The sender link on the server side starts with zero credit and waits for a `Flow` to grant some. If the only credit-granting `Flow` was dropped, the sender blocks forever on `flow_state.consume(1)`.

In my case this manifested as the CBS response path deadlocking — the CBS receiver task would get the `put-token` request fine, but `send_response()` would hang because the CBS sender link had no credit.

1. Eagerly register the session relay

In `on_incoming_begin`, allocate the session relay and register it in `session_by_incoming_channel` immediately, before handing off to user code. Pass the pre-allocated `incoming_rx` and `outgoing_channel` through `IncomingSession` so `accept_incoming_session` reuses them.

2. Buffer and replay pipelined link-level Flows

Override `on_incoming_flow` in `ListenerSession` to catch `UnattachedHandle` — instead of propagating the error, buffer the `LinkFlow` in a `HashMap<InputHandle, Vec<LinkFlow>>`. Do the same for `on_incoming_transfer` (drop rather than crash). Then override `allocate_incoming_link` to replay buffered flows after the relay is inserted into `link_by_input_handle`, so credit is available immediately. This requires making `Producer.state` `pub(crate)` for synchronous access to the flow state during replay.