### PR TITLE
fix: treat null and zero-length array as identical for multiple fields (#111)

### DIFF
--- a/fe2o3-amqp-types/Changelog.md
+++ b/fe2o3-amqp-types/Changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+1. Marked all `multiple` (`Option<Array<T>>`) fields with
+   `#[amqp_contract(multiple)]` so that a zero-length array deserializes to
+   `None`, identical to null, as required by the AMQP spec (issue
+   [#111](https://github.com/minghuaw/fe2o3-amqp/issues/111)). Affects `Open`,
+   `Begin`, `Attach`, `Source`, `Target`, and `Coordinator`.
+
 ## 0.14.0
 
 1. Added `Described` variant to `SimpleValue` (PR #312)

--- a/fe2o3-amqp-types/src/messaging/source.rs
+++ b/fe2o3-amqp-types/src/messaging/source.rs
@@ -65,9 +65,11 @@ pub struct Source {
     pub default_outcome: Option<Outcome>,
 
     /// <field name="outcomes" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub outcomes: Option<Array<Symbol>>,
 
     /// <field name="capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub capabilities: Option<Array<Symbol>>,
 }
 

--- a/fe2o3-amqp-types/src/messaging/target.rs
+++ b/fe2o3-amqp-types/src/messaging/target.rs
@@ -196,6 +196,7 @@ pub struct Target {
     pub dynamic_node_properties: Option<NodeProperties>,
 
     /// <field name="capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub capabilities: Option<Array<Symbol>>,
 }
 

--- a/fe2o3-amqp-types/src/performatives/attach.rs
+++ b/fe2o3-amqp-types/src/performatives/attach.rs
@@ -104,9 +104,11 @@ pub struct Attach {
     pub max_message_size: Option<Ulong>,
 
     /// <field name="offered-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub offered_capabilities: Option<Array<Symbol>>,
 
     /// <field name="desired-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub desired_capabilities: Option<Array<Symbol>>,
 
     /// <field name="properties" type="fields"/>

--- a/fe2o3-amqp-types/src/performatives/begin.rs
+++ b/fe2o3-amqp-types/src/performatives/begin.rs
@@ -37,9 +37,11 @@ pub struct Begin {
     pub handle_max: Handle, // default to 4294967295
 
     /// <field name="offered-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub offered_capabilities: Option<Array<Symbol>>,
 
     /// <field name="desired-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub desired_capabilities: Option<Array<Symbol>>,
 
     /// <field name="properties" type="fields"/>

--- a/fe2o3-amqp-types/src/performatives/open.rs
+++ b/fe2o3-amqp-types/src/performatives/open.rs
@@ -37,15 +37,19 @@ pub struct Open {
     pub idle_time_out: Option<Milliseconds>,
 
     /// <field name="outgoing-locales" type="ietf-language-tag" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub outgoing_locales: Option<Array<IetfLanguageTag>>,
 
     /// <field name="incoming-locales" type="ietf-language-tag" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub incoming_locales: Option<Array<IetfLanguageTag>>,
 
     /// <field name="offered-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub offered_capabilities: Option<Array<Symbol>>,
 
     /// <field name="desired-capabilities" type="symbol" multiple="true"/>
+    #[amqp_contract(multiple)]
     pub desired_capabilities: Option<Array<Symbol>>,
 
     /// <field name="properties" type="fields"/>
@@ -113,5 +117,58 @@ impl From<Ushort> for ChannelMax {
 impl From<ChannelMax> for Ushort {
     fn from(value: ChannelMax) -> Self {
         value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_amqp::{
+        from_slice,
+        primitives::{Array, Symbol},
+        to_vec,
+    };
+
+    use super::Open;
+
+    fn open_with_offered(offered: Option<Array<Symbol>>) -> Open {
+        Open {
+            container_id: String::from("test"),
+            hostname: None,
+            max_frame_size: Default::default(),
+            channel_max: Default::default(),
+            idle_time_out: None,
+            outgoing_locales: None,
+            incoming_locales: None,
+            offered_capabilities: offered,
+            desired_capabilities: None,
+            properties: None,
+        }
+    }
+
+    /// Per AMQP 1.0 Part 1 (Types) section 1.4: for a field with multiplicity
+    /// `multiple`, "a null value and a zero-length array (with a correct type for
+    /// its elements) both describe an absence of a value and MUST be treated as
+    /// semantically identical." A `multiple` field encoded as a zero-length array
+    /// must therefore deserialize the same as one encoded as null, i.e. `None`.
+    #[test]
+    fn zero_length_multiple_field_decodes_as_none() {
+        let open = open_with_offered(Some(Array::from(Vec::<Symbol>::new())));
+        let buf = to_vec(&open).unwrap();
+        let decoded: Open = from_slice(&buf).unwrap();
+
+        // The empty array on the wire is an absence of a value, identical to null.
+        assert_eq!(decoded.offered_capabilities, None);
+    }
+
+    /// The normalization must only collapse the empty case; a `multiple` field
+    /// that actually carries elements has to round-trip unchanged.
+    #[test]
+    fn non_empty_multiple_field_round_trips() {
+        let offered = Array::from(vec![Symbol::from("FOO"), Symbol::from("BAR")]);
+        let open = open_with_offered(Some(offered.clone()));
+        let buf = to_vec(&open).unwrap();
+        let decoded: Open = from_slice(&buf).unwrap();
+
+        assert_eq!(decoded.offered_capabilities, Some(offered));
     }
 }

--- a/fe2o3-amqp-types/src/transaction/mod.rs
+++ b/fe2o3-amqp-types/src/transaction/mod.rs
@@ -33,6 +33,7 @@ pub struct Coordinator {
     /// requirements.
     ///
     /// See txn-capability.
+    #[amqp_contract(multiple)]
     pub capabilities: Option<Array<TxnCapability>>,
 }
 

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -5,6 +5,7 @@
 1. Implemented `Display` for `Value` (issue #82). `Timestamp` renders as a
    lossless ISO-8601 / RFC-3339 UTC datetime with millisecond precision.
 2. Added a borrowing `as_inner()` accessor to `Dec32`, `Dec64`, and `Dec128`
+3. Added `Array::len` and `Array::is_empty`
 
 ## 0.14.1
 

--- a/serde_amqp/src/primitives/array.rs
+++ b/serde_amqp/src/primitives/array.rs
@@ -292,4 +292,15 @@ mod tests {
         let array: Array<String> = from_slice(&buf).unwrap();
         assert_eq!(array, expected);
     }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let empty: Array<i32> = Array(vec![]);
+        assert_eq!(empty.len(), 0);
+        assert!(empty.is_empty());
+
+        let populated = Array(vec![1i32, 2, 3]);
+        assert_eq!(populated.len(), 3);
+        assert!(!populated.is_empty());
+    }
 }

--- a/serde_amqp/src/primitives/array.rs
+++ b/serde_amqp/src/primitives/array.rs
@@ -59,6 +59,16 @@ impl<T> Array<T> {
     pub fn into_inner(self) -> Vec<T> {
         self.0
     }
+
+    /// Returns the number of elements in the array
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the array contains no elements
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<T: ser::Serialize> ser::Serialize for Array<T> {

--- a/serde_amqp/tests/multiple_field.rs
+++ b/serde_amqp/tests/multiple_field.rs
@@ -1,0 +1,66 @@
+//! Tests for the `#[amqp_contract(multiple)]` field attribute (issue #111).
+//!
+//! Per the AMQP 1.0 spec (Part 1 "Types", section 1.4): "a null value and a
+//! zero-length array (with a correct type for its elements) both describe an
+//! absence of a value and MUST be treated as semantically identical." A field
+//! marked `multiple` must therefore decode a zero-length array to the same value
+//! as a null, i.e. `None`.
+//!
+//! These tests use the `list` encoding, which is the path every described-list
+//! performative exercises at runtime. The derive also normalizes in its
+//! `visit_map` path, but that is intentionally not round-trip tested here: the
+//! `map` encoding does not round-trip in `serde_amqp` independently of this
+//! attribute (a plain map-encoded struct fails to decode), so a map test would
+//! fail for reasons unrelated to issue #111.
+#![cfg(feature = "derive")]
+
+use serde_amqp::{
+    from_slice,
+    primitives::{Array, Symbol},
+    to_vec, DeserializeComposite, SerializeComposite,
+};
+
+#[derive(Debug, PartialEq, SerializeComposite, DeserializeComposite)]
+#[amqp_contract(
+    name = "test:multiple:list",
+    code = "0x0000_0000:0x0000_0100",
+    encoding = "list"
+)]
+struct ListMultiple {
+    #[amqp_contract(multiple)]
+    capabilities: Option<Array<Symbol>>,
+}
+
+/// A null and a zero-length array must decode to the same value (`None`).
+#[test]
+fn null_and_empty_array_decode_identically() {
+    let from_null: ListMultiple =
+        from_slice(&to_vec(&ListMultiple { capabilities: None }).unwrap()).unwrap();
+    let from_empty: ListMultiple = from_slice(
+        &to_vec(&ListMultiple {
+            capabilities: Some(Array::from(Vec::<Symbol>::new())),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(from_null.capabilities, None);
+    assert_eq!(from_empty.capabilities, None);
+    assert_eq!(from_null, from_empty);
+}
+
+/// The normalization must only collapse the empty case; a populated `multiple`
+/// field round-trips unchanged.
+#[test]
+fn non_empty_multiple_field_is_preserved() {
+    let capabilities = Some(Array::from(vec![Symbol::from("FOO"), Symbol::from("BAR")]));
+    let decoded: ListMultiple = from_slice(
+        &to_vec(&ListMultiple {
+            capabilities: capabilities.clone(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(decoded.capabilities, capabilities);
+}

--- a/serde_amqp_derive/Changelog.md
+++ b/serde_amqp_derive/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+1. Added a `#[amqp_contract(multiple)]` field attribute. On a `multiple`
+   (`Option<Array<T>>`) field, a zero-length array is normalized to `None` on
+   deserialization so that null and an empty array decode identically, as
+   required by the AMQP spec (issue
+   [#111](https://github.com/minghuaw/fe2o3-amqp/issues/111)).
+
 ## 0.3.0
 
 1. Updated deps

--- a/serde_amqp_derive/src/de.rs
+++ b/serde_amqp_derive/src/de.rs
@@ -465,11 +465,20 @@ fn impl_visit_seq_for_struct(
 ) -> proc_macro2::TokenStream {
     let mut field_impls: Vec<proc_macro2::TokenStream> = vec![];
     for ((id, ty), attr) in field_idents.iter().zip(field_types.iter()).zip(field_attrs) {
-        let token = match attr.default {
-            true => {
+        let token = match (attr.default, attr.multiple) {
+            (true, _) => {
                 quote! { unwrap_or_default!(#id, __seq.next_element::<Option<#ty>>()?.unwrap_or_default(), #ty) }
             }
-            false => {
+            (false, true) => {
+                // A `multiple` field is an `Option<Array<T>>`. Per the AMQP spec a
+                // zero-length array is semantically identical to null, so normalize
+                // an empty array to `None`.
+                quote! {
+                    unwrap_or_none!(#id, __seq.next_element()?, #ty);
+                    let #id = #id.filter(|__arr| !__arr.is_empty());
+                }
+            }
+            (false, false) => {
                 quote! { unwrap_or_none!(#id, __seq.next_element()?, #ty) }
             }
         };
@@ -506,11 +515,19 @@ fn impl_visit_map(
 ) -> proc_macro2::TokenStream {
     let mut field_impls: Vec<proc_macro2::TokenStream> = vec![];
     for ((id, ty), attr) in field_idents.iter().zip(field_types.iter()).zip(field_attrs) {
-        let token = match attr.default {
-            true => {
+        let token = match (attr.default, attr.multiple) {
+            (true, _) => {
                 quote! { unwrap_or_default!(#id, #id, #ty) }
             }
-            false => {
+            (false, true) => {
+                // See the matching note in `impl_visit_seq_for_struct`: a
+                // zero-length `multiple` array is normalized to `None`.
+                quote! {
+                    unwrap_or_none!(#id, #id, #ty);
+                    let #id = #id.filter(|__arr| !__arr.is_empty());
+                }
+            }
+            (false, false) => {
                 quote! { unwrap_or_none!(#id, #id, #ty); }
             }
         };

--- a/serde_amqp_derive/src/lib.rs
+++ b/serde_amqp_derive/src/lib.rs
@@ -36,6 +36,15 @@
 //! AMQP1.0 `null` primitive (`0x40`). During deserialization, an AMQP1.0 `null` primitive or an
 //! empty field will be decoded as the default value of the type.
 //!
+//! Fields with multiplicity `multiple`:
+//!
+//! Fields defined with `multiple="true"` in the specification are represented as
+//! `Option<Array<T>>` and should be marked with `#[amqp_contract(multiple)]`. Per the AMQP1.0 spec
+//! (Part 1 "Types", section 1.4) "a null value and a zero-length array (with a correct type for its
+//! elements) both describe an absence of a value and MUST be treated as semantically identical."
+//! When the attribute is set, a zero-length array is normalized to `None` during deserialization so
+//! that both the AMQP1.0 `null` primitive and an empty array decode to the same value.
+//!
 //! # Example
 //!
 //! The `"list"` encoding will encode the `Attach` struct as a described list (a descriptor followed
@@ -89,10 +98,12 @@
 //!     pub max_message_size: Option<Ulong>,
 //!
 //!     /// <field name="offered-capabilities" type="symbol" multiple="true"/>
-//!     pub offered_capabilities: Option<Vec<Symbol>>,
+//!     #[amqp_contract(multiple)]
+//!     pub offered_capabilities: Option<Array<Symbol>>,
 //!
 //!     /// <field name="desired-capabilities" type="symbol" multiple="true"/>
-//!     pub desired_capabilities: Option<Vec<Symbol>>,
+//!     #[amqp_contract(multiple)]
+//!     pub desired_capabilities: Option<Array<Symbol>>,
 //!
 //!     /// <field name="properties" type="fields"/>
 //!     pub properties: Option<Fields>,
@@ -153,6 +164,16 @@ struct FieldAttr {
     // default: syn::Lit
     #[darling(default)]
     default: bool,
+
+    /// Marks a field with multiplicity `multiple` (an `Option<Array<T>>`).
+    ///
+    /// Per the AMQP 1.0 spec (Part 1 "Types", section 1.4), a null value and a
+    /// zero-length array both describe an absence of a value and MUST be treated
+    /// as semantically identical. When this flag is set, a zero-length array is
+    /// normalized to `None` on deserialization so the two encodings decode to the
+    /// same value.
+    #[darling(default)]
+    multiple: bool,
 }
 
 struct DescribedStructAttr {

--- a/serde_amqp_derive/src/ser.rs
+++ b/serde_amqp_derive/src/ser.rs
@@ -8,7 +8,7 @@ use crate::{
         macro_rules_serialize_if_some, parse_described_struct_attr, parse_named_field_attrs,
         where_serialize,
     },
-    DescribedStructAttr, EncodingType, FieldAttr,
+    DescribedStructAttr, EncodingType,
 };
 
 pub(crate) fn expand_serialize(
@@ -201,7 +201,7 @@ fn expand_serialize_struct(
         EncodingType::Basic | EncodingType::List => {
             let buffer_if_none = macro_rules_buffer_if_none();
 
-            let buffer_if_eq_default = match field_attrs.contains(&FieldAttr { default: true }) {
+            let buffer_if_eq_default = match field_attrs.iter().any(|a| a.default) {
                 true => macro_rules_buffer_if_eq_default(),
                 false => quote! {},
             };

--- a/serde_amqp_derive/src/util.rs
+++ b/serde_amqp_derive/src/util.rs
@@ -118,7 +118,12 @@ pub(crate) fn parse_named_field_attrs<'a>(
                 .iter()
                 .find_map(|a| FieldAttr::from_meta(&a.meta).ok())
         })
-        .map(|o| o.unwrap_or(FieldAttr { default: false }))
+        .map(|o| {
+            o.unwrap_or(FieldAttr {
+                default: false,
+                multiple: false,
+            })
+        })
         .collect()
 }
 


### PR DESCRIPTION
Closes #111.

AMQP 1.0 Part 1 (Types) section 1.4 says that for a field with multiplicity `multiple`, "a null value and a zero-length array (with a correct type for its elements) both describe an absence of a value and MUST be treated as semantically identical." The library did not honor this: a `multiple` field encoded as null decoded to `None`, while the same field encoded as a zero-length array decoded to `Some(Array([]))`, and the two compared unequal.

This adds a `#[amqp_contract(multiple)]` field attribute to `serde_amqp_derive`. On a `multiple` (`Option<Array<T>>`) field it normalizes a zero-length array to `None` during deserialization, so both encodings decode to the same value. Every such field across the performatives and messaging types is annotated: `Open`, `Begin`, `Attach`, `Source`, `Target`, and `Coordinator`.

Serialization is unchanged. The mandatory-and-multiple `sasl-server-mechanisms` field is intentionally untouched: it is a non-optional `Array<Symbol>`, and for a field that is both `multiple` and mandatory the spec says both null and an empty array are invalid, so absence-normalization does not apply (the serialize side already rejects an empty value).

## Test plan

- New round-trip test `zero_length_multiple_field_decodes_as_none` (written first, confirmed failing before the fix): an `Open` with `offered_capabilities: Some(Array([]))` serializes to an empty array and now decodes back to `None`.
- New regression test `non_empty_multiple_field_round_trips`: a non-empty `multiple` field still round-trips unchanged, so the normalization only collapses the empty case.
- `cargo test` green for `serde_amqp`, `serde_amqp_derive`, and `fe2o3-amqp-types`; `fmt` and `clippy --all -- --deny warnings` clean. (The `broker_connection_compat` integration test fails identically with and without this change due to a local ActiveMQ Artemis SASL container issue, unrelated to this PR.)