### PR TITLE
chore: Bump fe2o3-amqp version to 0.15.2

### DIFF
--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.15.2
+
+1. Fix SASL acceptor wrongly accepting an Open frame after rejecting invalid SASL credentials [#344](https://github.com/minghuaw/fe2o3-amqp/pull/344)
+
 ## 0.15.1
 
 1. The `rustls` feature no longer forces the `ring` crypto provider. On non-`wasm32`


### PR DESCRIPTION
Bump fe2o3-amqp version to 0.15.2 and update changelog.