### PR TITLE
fix(deps)!: remove the ring dependency on every target (0.16.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Thank you for your interest in contributing to the FE2O3 (Iron Oxide) library.
 
 #### Pre-requisites
 
-`rust` stable toolchain newer than 1.75.0 is required to build the project, and the nightly
+`rust` stable toolchain newer than 1.85.0 is required to build the project, and the nightly
 toolchain is required for building the documentation locally. Please follow the instruction on the
 [Rust website](https://www.rust-lang.org/tools/install) to install the toolchain. `cargo` is
 included in the installation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ exclude = [
 
 [workspace.dependencies]
 # Local deps
-fe2o3-amqp = { path = "fe2o3-amqp", version = "0.15" }
-fe2o3-amqp-cbs = { path = "fe2o3-amqp-cbs", version = "0.15" }
-fe2o3-amqp-ext = { path = "fe2o3-amqp-ext", version = "0.14" }
-fe2o3-amqp-management = { path = "fe2o3-amqp-management", version = "0.15" }
-fe2o3-amqp-types = { path = "fe2o3-amqp-types", version = "0.14" }
-fe2o3-amqp-ws = { path = "fe2o3-amqp-ws", version = "0.14" }
-serde_amqp_derive = { path = "serde_amqp_derive", version = "0.3.0" }
-serde_amqp = { path = "serde_amqp", version = "0.14" }
+fe2o3-amqp = { path = "fe2o3-amqp", version = "0.16" }
+fe2o3-amqp-cbs = { path = "fe2o3-amqp-cbs", version = "0.16" }
+fe2o3-amqp-ext = { path = "fe2o3-amqp-ext", version = "0.16" }
+fe2o3-amqp-management = { path = "fe2o3-amqp-management", version = "0.16" }
+fe2o3-amqp-types = { path = "fe2o3-amqp-types", version = "0.16" }
+fe2o3-amqp-ws = { path = "fe2o3-amqp-ws", version = "0.16" }
+serde_amqp_derive = { path = "serde_amqp_derive", version = "0.3.1" }
+serde_amqp = { path = "serde_amqp", version = "0.16" }
 
 # External deps
 bytes = "1"
@@ -84,11 +84,12 @@ stringprep = "0.1"
 hmac = "0.12"
 pbkdf2 = { version = "0.12", default-features = false }
 webpki-roots = "1"
-tokio-rustls = { version = "0.26", default-features = false }
-librustls = { package = "rustls", version = "0.23", default-features = false }
+# Default features are on so that `rustls` selects its own default crypto
+# provider (`aws-lc-rs`). This crate does not pin a provider. See issue #333.
+tokio-rustls = "0.26"
+librustls = { package = "rustls", version = "0.23" }
 libnative-tls = { package = "native-tls", version = "0.2" }
 tokio-native-tls = "0.3"
-ring = { version = "0.17", default-features = false }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 trait-variant = "0.1.1"

--- a/fe2o3-amqp-cbs/Cargo.toml
+++ b/fe2o3-amqp-cbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-cbs"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 CBS extension"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-cbs/Changelog.md
+++ b/fe2o3-amqp-cbs/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.16.0
+
+1. Bumped version to "0.16.0" to track `fe2o3-amqp` 0.16.0, which drops the `ring`
+   dependency entirely (issue
+   [#333](https://github.com/minghuaw/fe2o3-amqp/issues/333)).
+
 ## 0.15.0
 
 1. Bumped version to "0.15.0" to track `fe2o3-amqp` 0.15.0, which drops the

--- a/fe2o3-amqp-ext/Cargo.toml
+++ b/fe2o3-amqp-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ext"
-version = "0.14.0"
+version = "0.16.0"
 edition = "2021"
 description = "Extension types to fe2o3-amqp"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-ext/Changelog.md
+++ b/fe2o3-amqp-ext/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0
+
+1. Bumped version to "0.16.0" to match other `fe2o3-amqp` crates, so that a
+   downstream crate does not pull two versions of the family. This crate has no
+   source change.
+
 ## 0.14.0
 
 1. Bumped version to "0.14.0" to match other `fe2o3-amqp` crates

--- a/fe2o3-amqp-management/Cargo.toml
+++ b/fe2o3-amqp-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-management"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 management extension"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-management/Changelog.md
+++ b/fe2o3-amqp-management/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0
+
+1. Bumped version to "0.16.0" to track `fe2o3-amqp` 0.16.0, which drops the `ring`
+   dependency entirely (issue
+   [#333](https://github.com/minghuaw/fe2o3-amqp/issues/333)).
+
 ## 0.15.0
 
 1. Bumped version to "0.15.0" to track `fe2o3-amqp` 0.15.0, which drops the

--- a/fe2o3-amqp-types/Cargo.toml
+++ b/fe2o3-amqp-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-types"
-version = "0.14.0"
+version = "0.16.0"
 edition = "2021"
 description = "Implementation of AMQP1.0 data types"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-types/Changelog.md
+++ b/fe2o3-amqp-types/Changelog.md
@@ -1,8 +1,10 @@
 # Change Log
 
-## Unreleased
+## 0.16.0
 
-1. Marked all `multiple` (`Option<Array<T>>`) fields with
+1. Bumped version to "0.16.0" to match other `fe2o3-amqp` crates, so that a
+   downstream crate does not pull two versions of the family.
+2. Marked all `multiple` (`Option<Array<T>>`) fields with
    `#[amqp_contract(multiple)]` so that a zero-length array deserializes to
    `None`, identical to null, as required by the AMQP spec (issue
    [#111](https://github.com/minghuaw/fe2o3-amqp/issues/111)). Affects `Open`,

--- a/fe2o3-amqp-ws/Cargo.toml
+++ b/fe2o3-amqp-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ws"
-version = "0.14.0"
+version = "0.16.0"
 edition = "2021"
 description = "WebSocket binding stream for AMQP1.0"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-ws/Changelog.md
+++ b/fe2o3-amqp-ws/Changelog.md
@@ -1,5 +1,12 @@
 # fe2o3-amqp-ws
 
+## 0.16.0
+
+1. Bumped version to "0.16.0" to track `fe2o3-amqp` 0.16.0, which drops the `ring`
+   dependency entirely (issue
+   [#333](https://github.com/minghuaw/fe2o3-amqp/issues/333)). This crate has no
+   source change.
+
 ## 0.14.0
 
 1. Put wrapped type of `Error::Http(_)` behind `Box` to avoid `clippy::result-large-err` (PR #313)

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"
@@ -30,7 +30,10 @@ default = [
 transaction = ["fe2o3-amqp-types/transaction", "uuid"]
 
 # TLS related features
-rustls = ["tokio-rustls", "librustls", "webpki-roots", "ring"]
+#
+# Neither feature does anything on `wasm32` targets. A browser cannot open a raw
+# socket, so it terminates TLS itself. Use `wss://` with `fe2o3-amqp-ws` instead.
+rustls = ["tokio-rustls", "librustls", "webpki-roots"]
 native-tls = ["tokio-native-tls", "libnative-tls"]
 
 # Listener implementation
@@ -66,30 +69,23 @@ base64 = { workspace = true, optional = true } # TODO: replace with base64-simd?
 stringprep = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 pbkdf2 = { workspace = true, optional = true }
-webpki-roots = { workspace = true, optional = true }
-# The rustls crypto provider is selected per-target below: aws-lc-rs off-wasm
-# (rustls' own default), ring on wasm32. See issue #333.
-tokio-rustls = { workspace = true, features = ["logging", "tls12"], optional = true }
-librustls = { workspace = true, features = ["logging", "std", "tls12"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { workspace = true, features = ["v4"], optional = true }
 tokio = { workspace = true, features = ["sync", "io-util", "net", "rt", "macros", "time"] }
 libnative-tls = { workspace = true, optional = true }
 tokio-native-tls = { workspace = true, optional = true }
-# Off-wasm, rustls uses the aws-lc-rs provider (its own default) rather than ring.
-tokio-rustls = { workspace = true, features = ["aws_lc_rs"], optional = true }
-librustls = { workspace = true, features = ["aws_lc_rs"], optional = true }
+# TLS is off-wasm only. `rustls` keeps its default features, so it selects its own
+# default crypto provider (`aws-lc-rs`). This crate does not pin a provider, and it
+# does not depend on `ring`. See issue #333.
+webpki-roots = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true }
+librustls = { workspace = true, optional = true }
 tokio-stream = { workspace = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["v4", "rng-getrandom"], optional = true }
 tokio = { workspace = true, features = ["sync", "io-util", "rt", "macros"] } # "net" feature doesn't support wasm32
-# aws-lc-rs does not support wasm32, so rustls keeps the ring provider here. The
-# explicit ring dep applies ring's wasm getrandom backend to the copy rustls pulls in.
-tokio-rustls = { workspace = true, features = ["ring"], optional = true }
-librustls = { workspace = true, features = ["ring"], optional = true }
-ring = { workspace = true, default-features = false, features = ["wasm32_unknown_unknown_js"], optional = true }
 getrandom = { workspace = true, features = ["wasm_js"] }
 wasmtimer.workspace = true
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## 0.16.0
+
+1. **Breaking**: This crate no longer depends on `ring` on any target. The `rustls`
+   feature let `ring` back in through the `wasm32` target, so a `cargo tree --target
+   all` still showed it (issue
+   [#333](https://github.com/minghuaw/fe2o3-amqp/issues/333)). The `tokio-rustls` and
+   `librustls` dependencies now keep their default features, so the crypto provider
+   follows the `rustls` default instead of a name in this manifest. That default is
+   `aws-lc-rs`, the same provider that 0.15.1 selected off-`wasm32`. To use a different
+   provider, install it with `rustls::crypto::CryptoProvider::install_default` and
+   supply your own `tokio_rustls::TlsConnector` to the connection builder.
+2. The default features of `rustls` include `prefer-post-quantum`, which the explicit
+   feature lists in 0.15.1 left out. `rustls` puts `X25519MLKEM768` first in
+   `DEFAULT_KX_GROUPS` under that flag, and last without it. A client therefore sends
+   the hybrid key share in the first ClientHello instead of an `X25519` key share. This
+   grows the ClientHello by about 1.2 KB, and a small number of old middleboxes reject
+   it. To get the previous order, build the config with
+   `ClientConfig::builder_with_provider`. Pass a `CryptoProvider` whose `kx_groups`
+   field starts with `X25519`, then supply the resulting
+   `tokio_rustls::TlsConnector` to the connection builder. A plain
+   `ClientConfig::builder()` is not enough, because it takes the key exchange order
+   from the default provider.
+3. **Breaking**: The `rustls` feature does nothing on a `wasm32` target, because
+   `aws-lc-rs` does not support `wasm32-unknown-unknown`. `Builder::rustls_connector`
+   and `Builder::tls_connector` are no longer available there, and an `amqps://` URL
+   returns `OpenError::TlsConnectorNotFound`. A browser cannot open a raw socket, so it
+   terminates TLS itself; use a `wss://` URL with `fe2o3-amqp-ws` instead. The
+   `native-tls` feature already behaved this way.
+4. The `wasm32` feature checks for `rustls` are enabled again in CI. They were disabled
+   because `ring` failed to build for that target.
+
 ## 0.15.2
 
 1. Fix SASL acceptor wrongly accepting an Open frame after rejecting invalid SASL credentials [#344](https://github.com/minghuaw/fe2o3-amqp/pull/344)

--- a/fe2o3-amqp/Makefile.toml
+++ b/fe2o3-amqp/Makefile.toml
@@ -27,12 +27,12 @@ dependencies = [
   "check_feature_group5_wasm32",
   "check_feature_group6_wasm32",
 
-  # # rustls has problem with wasm target
-  # "check_feature_rustls_wasm32",
-  # "check_feature_group1_wasm32",
-  # "check_feature_group3_wasm32",
-  # "check_feature_group7_wasm32",
-  # "check_all_features_wasm32",
+  # The "rustls" feature does nothing on wasm32, so these checks pass again.
+  "check_feature_rustls_wasm32",
+  "check_feature_group1_wasm32",
+  "check_feature_group3_wasm32",
+  "check_feature_group7_wasm32",
+  "check_all_features_wasm32",
 ]
 
 [tasks.check_all_features]

--- a/fe2o3-amqp/Readme.md
+++ b/fe2o3-amqp/Readme.md
@@ -27,6 +27,26 @@ default = []
 |`"tracing"`| enables logging with `tracing` |
 |`"log"`| enables logging with `log` |
 
+### The crypto provider for `"rustls"`
+
+This crate does not name a crypto provider. It takes the default features of
+`rustls`, so the provider follows the `rustls` default. That default is
+`aws-lc-rs`.
+
+To use a different provider, install it with
+`rustls::crypto::CryptoProvider::install_default` and supply your own
+`tokio_rustls::TlsConnector` to the connection builder.
+
+The default features also include `prefer-post-quantum`. A client therefore sends
+an `X25519MLKEM768` key share in the first ClientHello. To send an `X25519` key
+share instead, build the config with `ClientConfig::builder_with_provider` and pass
+a `CryptoProvider` whose `kx_groups` field starts with `X25519`. A plain
+`ClientConfig::builder()` does not change the order, because it takes the order
+from the default provider.
+
+Neither TLS feature does anything on a `wasm32` target. See [WebAssembly
+support](#webassembly-support).
+
 ## Quick start
 
 1. [Client](#client)
@@ -163,6 +183,11 @@ Experimental support for `wasm32-unknown-unknown` target is added since "0.8.11"
 `fe2o3-amqp-ws` to establish WebSocket connection to the broker. An example of sending and
 receiving message in a browser tab can be found
 [examples/wasm32-in-browser](https://github.com/minghuaw/fe2o3-amqp/tree/main/examples/wasm32-in-browser).
+
+The `"rustls"` and `"native-tls"` features do nothing on a `wasm32` target. A browser
+cannot open a raw socket, so it terminates TLS itself. Use a `wss://` URL with
+`fe2o3-amqp-ws` to get an encrypted connection. If you enable a TLS feature and then
+open an `amqps://` URL on `wasm32`, the call returns `OpenError::TlsConnectorNotFound`.
 
 ## Components
 

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -326,8 +326,22 @@ impl<'a, Tls> Builder<'a, mode::ConnectorNoId, Tls> {
 #[allow(clippy::needless_lifetimes)]
 impl<'a, Mode, Tls> Builder<'a, Mode, Tls> {
     /// Alias for [`rustls_connector`](#method.rustls_connector) if only `"rustls"` is enabled
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rustls", not(feature = "native-tls")))))]
-    #[cfg(any(docsrs, all(feature = "rustls", not(feature = "native-tls"))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "rustls",
+            not(feature = "native-tls"),
+            not(target_arch = "wasm32")
+        )))
+    )]
+    #[cfg(any(
+        docsrs,
+        all(
+            feature = "rustls",
+            not(feature = "native-tls"),
+            not(target_arch = "wasm32")
+        )
+    ))]
     pub fn tls_connector(
         self,
         tls_connector: tokio_rustls::TlsConnector,
@@ -755,7 +769,11 @@ impl<Tls> Builder<'_, mode::ConnectorWithId, Tls> {
 /* -------------------------------------------------------------------------- */
 
 impl Builder<'_, mode::ConnectorWithId, ()> {
-    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+    #[cfg(all(
+        feature = "rustls",
+        not(feature = "native-tls"),
+        not(target_arch = "wasm32")
+    ))]
     async fn connect_tls_with_rustls_default<Io, F>(
         self,
         stream: Io,
@@ -1011,33 +1029,10 @@ cfg_wasm32! {
                     };
                     self.connect_with_stream(stream, spawn_engine_fn).await
                 }
-                "amqps" => {
-                    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
-                    {
-                        let domain = self.domain.ok_or(OpenError::InvalidDomain)?;
-                        let spawn_engine_fn = |engine, control_tx, outgoing_tx| {
-                            spawn_engine_on_current_local_set(engine, control_tx, outgoing_tx)
-                        };
-                        return self
-                            .connect_tls_with_rustls_default(stream, domain, spawn_engine_fn)
-                            .await;
-                    }
-
-                    #[cfg(all(
-                        feature = "native-tls",
-                        not(feature = "rustls"),
-                        not(target_arch = "wasm32")
-                    ))]
-                    {
-                        let domain = self.domain.ok_or_else(|| OpenError::InvalidDomain)?;
-                        return self
-                            .connect_tls_with_native_tls_default(stream, domain, spawn_engine)
-                            .await;
-                    }
-
-                    #[allow(unused)]
-                    Err(OpenError::TlsConnectorNotFound)
-                }
+                // A wasm32 target has no TLS connector. A browser cannot open a raw
+                // socket, so it terminates TLS itself. Use `wss://` with
+                // `fe2o3-amqp-ws` instead.
+                "amqps" => Err(OpenError::TlsConnectorNotFound),
                 _ => Err(OpenError::InvalidScheme),
             }
         }
@@ -1058,33 +1053,10 @@ cfg_wasm32! {
                     };
                     self.connect_with_stream(stream, spawn_engine_fn).await
                 }
-                "amqps" => {
-                    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
-                    {
-                        let domain = self.domain.ok_or(OpenError::InvalidDomain)?;
-                        let spawn_engine_fn = |engine, control_tx, outgoing_tx| {
-                            spawn_engine_on_local_set(engine, control_tx, outgoing_tx, local_set)
-                        };
-                        return self
-                            .connect_tls_with_rustls_default(stream, domain, spawn_engine_fn)
-                            .await;
-                    }
-
-                    #[cfg(all(
-                        feature = "native-tls",
-                        not(feature = "rustls"),
-                        not(target_arch = "wasm32")
-                    ))]
-                    {
-                        let domain = self.domain.ok_or_else(|| OpenError::InvalidDomain)?;
-                        return self
-                            .connect_tls_with_native_tls_default(stream, domain, spawn_engine)
-                            .await;
-                    }
-
-                    #[allow(unused)]
-                    Err(OpenError::TlsConnectorNotFound)
-                }
+                // A wasm32 target has no TLS connector. A browser cannot open a raw
+                // socket, so it terminates TLS itself. Use `wss://` with
+                // `fe2o3-amqp-ws` instead.
+                "amqps" => Err(OpenError::TlsConnectorNotFound),
                 _ => Err(OpenError::InvalidScheme),
             }
         }

--- a/fe2o3-amqp/src/lib.rs
+++ b/fe2o3-amqp/src/lib.rs
@@ -29,6 +29,26 @@
 //! |`"tracing"`| enables logging with `tracing` |
 //! |`"log"`| enables logging with `log` |
 //!
+//! ## The crypto provider for `"rustls"`
+//!
+//! This crate does not name a crypto provider. It takes the default features of
+//! `rustls`, so the provider follows the `rustls` default. That default is
+//! `aws-lc-rs`.
+//!
+//! To use a different provider, install it with
+//! `rustls::crypto::CryptoProvider::install_default` and supply your own
+//! `tokio_rustls::TlsConnector` to the connection builder.
+//!
+//! The default features also include `prefer-post-quantum`. A client therefore
+//! sends an `X25519MLKEM768` key share in the first ClientHello. To send an
+//! `X25519` key share instead, build the config with
+//! `ClientConfig::builder_with_provider` and pass a `CryptoProvider` whose
+//! `kx_groups` field starts with `X25519`. A plain `ClientConfig::builder()` does
+//! not change the order, because it takes the order from the default provider.
+//!
+//! Neither TLS feature does anything on a `wasm32` target. See [WebAssembly
+//! support](#webassembly-support).
+//!
 //! # Quick start
 //!
 //! 1. [Client](#client)
@@ -166,6 +186,12 @@
 //! receiving message in a browser tab can be found
 //! [examples/wasm32-in-browser](https://github.com/minghuaw/fe2o3-amqp/tree/main/examples/wasm32-in-browser).
 //!
+//! The `"rustls"` and `"native-tls"` features do nothing on a `wasm32` target. A browser
+//! cannot open a raw socket, so it terminates TLS itself. Use a `wss://` URL with
+//! `fe2o3-amqp-ws` to get an encrypted connection. If you enable a TLS feature and then
+//! open an `amqps://` URL on `wasm32`, the call returns
+//! [`connection::OpenError::TlsConnectorNotFound`].
+//!
 //! # Components
 //!
 //! | Name | Description |
@@ -181,7 +207,7 @@
 //!
 //! # Minimum rust version supported
 //!
-//! 1.75.0
+//! 1.85.0
 
 #[macro_use]
 mod macros;

--- a/fe2o3-amqp/src/macros.rs
+++ b/fe2o3-amqp/src/macros.rs
@@ -62,10 +62,12 @@ macro_rules! cfg_native_tls {
     }
 }
 
+/// TLS with `rustls` is not supported in wasm32 targets
 macro_rules! cfg_rustls {
     ($($item:item)*) => {
         $(
             #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
+            #[cfg(not(target_arch = "wasm32"))]
             #[cfg(feature = "rustls")]
             $item
         )*

--- a/fe2o3-amqp/src/transport/mod.rs
+++ b/fe2o3-amqp/src/transport/mod.rs
@@ -359,7 +359,10 @@ where
 }
 
 #[allow(unused)]
-#[cfg(any(feature = "rustls", feature = "native-tls"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "rustls", feature = "native-tls")
+))]
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "SEND", skip_all))]
 async fn send_tls_proto_header<Io>(stream: &mut Io) -> Result<(), io::Error>
 where
@@ -373,7 +376,10 @@ where
 }
 
 #[allow(unused)]
-#[cfg(any(feature = "rustls", feature = "native-tls"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "rustls", feature = "native-tls")
+))]
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "RECV", skip_all))]
 pub(crate) async fn recv_tls_proto_header<Io>(
     stream: &mut Io,

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.14.1"
+version = "0.16.0"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,11 +1,13 @@
 # Change Log
 
-## Unreleased
+## 0.16.0
 
-1. Implemented `Display` for `Value` (issue #82). `Timestamp` renders as a
+1. Bumped version to "0.16.0" to match other `fe2o3-amqp` crates, so that a
+   downstream crate does not pull two versions of the family.
+2. Implemented `Display` for `Value` (issue #82). `Timestamp` renders as a
    lossless ISO-8601 / RFC-3339 UTC datetime with millisecond precision.
-2. Added a borrowing `as_inner()` accessor to `Dec32`, `Dec64`, and `Dec128`
-3. Added `Array::len` and `Array::is_empty`
+3. Added a borrowing `as_inner()` accessor to `Dec32`, `Dec64`, and `Dec128`
+4. Added `Array::len` and `Array::is_empty`
 
 ## 0.14.1
 

--- a/serde_amqp_derive/Cargo.toml
+++ b/serde_amqp_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp_derive"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Custom derive macros for serde_amqp"
 license = "MIT/Apache-2.0"

--- a/serde_amqp_derive/Changelog.md
+++ b/serde_amqp_derive/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.1
 
 1. Added a `#[amqp_contract(multiple)]` field attribute. On a `multiple`
    (`Option<Array<T>>`) field, a zero-length array is normalized to `None` on


### PR DESCRIPTION
## Summary

`fe2o3-amqp` 0.15.2 still depends on `ring`. PR #335 moved the off-`wasm32` targets to `aws-lc-rs`. It did not change the `wasm32` target. It also left `"ring"` in the `rustls` feature list.

This change removes `ring` from all targets. It closes issue #333.

Before:

```
$ cargo tree --target all --all-features -i ring
ring v0.17.14
├── fe2o3-amqp v0.15.2
├── rustls v0.23.43
```

After:

```
$ cargo tree --target all --all-features -i ring
warning: nothing to print.
```

## Motivation

Two declarations put `ring` in the dependency graph. The `rustls` feature list contains `"ring"`. That name refers to the optional `ring` dependency in the `wasm32` target block. The same block gives `librustls` and `tokio-rustls` their `ring` feature. It also declares `ring` directly, for the `wasm32_unknown_unknown_js` backend.

A lockfile does not record targets. Both declarations therefore reach every downstream crate, for every target.

`aws-lc-rs` does not support `wasm32-unknown-unknown`. The [platform support page](https://aws.github.io/aws-lc-rs/platform_support.html) lists only `wasm32-unknown-emscripten`. A `wasm32` target cannot use the default provider.

The `wasm32` `rustls` path was already unsupported. `fe2o3-amqp/Makefile.toml` held five disabled `wasm32` tasks, with the note `# rustls has problem with wasm target`. CI never built that combination.

A browser cannot open a raw socket. A `wasm32` client connects through `fe2o3-amqp-ws`. The browser does the TLS work for a `wss://` URL. The `wasm32` `rustls` path is therefore unusable code, and it keeps `ring` in every lockfile.

## Changes

- Removes `ring` from the workspace dependencies and from `fe2o3-amqp`. Removes `"ring"` from the `rustls` feature list.
- Gives `librustls` and `tokio-rustls` their default features. The crypto provider now follows the `rustls` default, instead of a name in this manifest. That default is `aws-lc-rs`, the same provider that 0.15.1 selected off-`wasm32`.
- Moves `librustls`, `tokio-rustls`, and `webpki-roots` into the `cfg(not(target_arch = "wasm32"))` block. The `rustls` feature now does nothing on `wasm32`, the same as `native-tls`.
- Adds `not(target_arch = "wasm32")` to `cfg_rustls!` and to the other `rustls` cfg attributes. Removes the two unusable `rustls` arms from the `wasm32` `open_with_stream_on_*_local_set` methods.
- Enables the five `wasm32` tasks in `fe2o3-amqp/Makefile.toml`, including `check_all_features_wasm32`.
- Updates the feature table and the WebAssembly section in `lib.rs`. Makes the same two updates in `fe2o3-amqp/Readme.md`, which repeats that content. crates.io renders that file, and the root `Readme.md` is a symlink to it.
- Corrects the MSRV from `1.75.0` to `1.85.0`, to agree with `rust-version`. The crate docs in `lib.rs` and the pre-requisites in `CONTRIBUTING.md` both held the old number.
- Bumps the six `fe2o3-amqp` crates and `serde_amqp` to 0.16.0: `fe2o3-amqp`, `fe2o3-amqp-types`, `fe2o3-amqp-ext`, `fe2o3-amqp-ws`, `fe2o3-amqp-management`, `fe2o3-amqp-cbs`, and `serde_amqp`. A downstream crate that depends on several of them then pulls one version of the family, rather than a mix of 0.14 and 0.16.
- Bumps `serde_amqp_derive` to 0.3.1, and raises the version requirement to match. PR #343 added the `#[amqp_contract(multiple)]` attribute to `serde_amqp_derive`, and applied that attribute across `fe2o3-amqp-types`. The published `serde_amqp_derive` 0.3.0 does not parse the attribute, so `fe2o3-amqp-types` 0.16.0 cannot build from crates.io until a new macro crate ships. `serde_amqp_derive` keeps its own version track, because it has never matched the family.

### Breaking changes

- `Builder::rustls_connector` and `Builder::tls_connector` are no longer available on `wasm32`.
- An `amqps://` URL on `wasm32` returns `OpenError::TlsConnectorNotFound`. Use a `wss://` URL with `fe2o3-amqp-ws` instead.
- To keep `ring`, install it with `rustls::crypto::CryptoProvider::install_default`. Then supply your own `tokio_rustls::TlsConnector` to the connection builder.
- The default features of `rustls` include `prefer-post-quantum`. The explicit feature lists in 0.15.1 left that flag out. `rustls` puts `X25519MLKEM768` first in `DEFAULT_KX_GROUPS` under the flag, and last without it. A client therefore sends the hybrid key share in the first ClientHello. This grows the ClientHello by about 1.2 KB, and a small number of old middleboxes reject it.
- To get the previous key exchange order, build the config with `ClientConfig::builder_with_provider`. Pass a `CryptoProvider` whose `kx_groups` field starts with `X25519`. A plain `ClientConfig::builder()` is not enough, because it takes the order from the default provider.

## Test plan

- `cargo tree --target all --all-features -i ring` prints `warning: nothing to print.` for the workspace.
- The same command gives that result for `examples/rustls_connection`, `examples/sasl_connection`, and `examples/service_bus_over_websocket`. For those examples, `-i aws-lc-rs` shows `aws-lc-rs v1.17.3` below `rustls v0.23.43`.
- `cargo check` gives no error for the 14 feature combinations in `Makefile.toml`, on the host and on `wasm32-unknown-unknown`. That is 28 builds. It includes the five `wasm32` combinations that CI disabled.
- `cargo fmt --all -- --check` is clean.
- `cargo clippy --all -- --deny warnings` is clean.
- `cargo test --workspace --lib` passes 344 tests.
- `cargo check --all-targets --all-features` gives no error for the 29 examples that CI builds.
- `tests/broker_connection_compat.rs` fails in the same way before and after this change. The ActiveMQ Artemis container causes that failure.
