### PR TITLE
fix(link): preserve properties field across builder methods

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+1. Fixed link builder dropping `properties` in `name()`, `sender()`, `receiver()`,
+   `target()`, and `coordinator()` methods.
+
 ## 0.16.0
 
 1. **Breaking**: This crate no longer depends on `ring` on any target. The `rustls`

--- a/fe2o3-amqp/src/link/builder.rs
+++ b/fe2o3-amqp/src/link/builder.rs
@@ -192,7 +192,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             desired_capabilities: self.desired_capabilities,
             buffer_size: self.buffer_size,
             credit_mode: self.credit_mode,
-            properties: Default::default(),
+            properties: self.properties,
 
             role: self.role,
             name_state: PhantomData,
@@ -219,7 +219,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             desired_capabilities: self.desired_capabilities,
             buffer_size: self.buffer_size,
             credit_mode: self.credit_mode,
-            properties: Default::default(),
+            properties: self.properties,
 
             role: PhantomData,
             name_state: self.name_state,
@@ -246,7 +246,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             desired_capabilities: self.desired_capabilities,
             buffer_size: self.buffer_size,
             credit_mode: self.credit_mode,
-            properties: Default::default(),
+            properties: self.properties,
 
             role: PhantomData,
             name_state: self.name_state,
@@ -315,7 +315,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             desired_capabilities: self.desired_capabilities,
             buffer_size: self.buffer_size,
             credit_mode: self.credit_mode,
-            properties: Default::default(),
+            properties: self.properties,
 
             role: self.role,
             name_state: self.name_state,
@@ -346,7 +346,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
                 desired_capabilities: self.desired_capabilities,
                 buffer_size: self.buffer_size,
                 credit_mode: self.credit_mode,
-                properties: Default::default(),
+                properties: self.properties,
 
                 role: self.role,
                 name_state: self.name_state,


### PR DESCRIPTION
fix: #349 