### PR TITLE
cleanup: remove unused tokio-stream dep and AtomicU32 import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ tokio-rustls = "0.26"
 librustls = { package = "rustls", version = "0.23" }
 libnative-tls = { package = "native-tls", version = "0.2" }
 tokio-native-tls = "0.3"
-tokio-stream = "0.1"
 tokio-test = "0.4"
 trait-variant = "0.1.1"
 serde_repr = "0.1"

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -81,7 +81,6 @@ tokio-native-tls = { workspace = true, optional = true }
 webpki-roots = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 librustls = { workspace = true, optional = true }
-tokio-stream = { workspace = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["v4", "rng-getrandom"], optional = true }

--- a/fe2o3-amqp/src/acceptor/local_receiver_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_receiver_link.rs
@@ -2,7 +2,7 @@
 
 use std::{
     marker::PhantomData,
-    sync::{atomic::AtomicU32, Arc},
+    sync::Arc,
 };
 
 use fe2o3_amqp_types::{


### PR DESCRIPTION
Removed unused dep `tokio-stream`. Cleaned up unused imports