### PR TITLE
fix(ws): remove the TLS feature gate from the connect_tls_* functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
         run: (cd fe2o3-amqp-management && cargo make test)
       - name: test fe2o3-amqp-ws
         run: (cd fe2o3-amqp-ws && cargo make test)
+      - name: test fe2o3-amqp-ws without a TLS feature
+        run: cargo test -p fe2o3-amqp-ws --no-default-features
+      - name: check fe2o3-amqp-ws with each TLS feature
+        run: |
+          cargo check -p fe2o3-amqp-ws --no-default-features --features native-tls --all-targets
+          cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-native-roots --all-targets
+          cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-webpki-roots --all-targets
       - name: check examples
         run: (cd examples && cargo make check)
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,16 @@ cd fe2o3-amqp
 cargo make feature_check
 ```
 
+`fe2o3-amqp-ws` has no `Makefile.toml`. Its TLS features must not gate the connect functions, so
+CI also runs the commands below from the repository root. Run them after a change to that crate:
+
+```bash
+cargo test -p fe2o3-amqp-ws --no-default-features
+cargo check -p fe2o3-amqp-ws --no-default-features --features native-tls --all-targets
+cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-native-roots --all-targets
+cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-webpki-roots --all-targets
+```
+
 Run the following to check if all examples build:
 
 ```bash

--- a/fe2o3-amqp-ws/Cargo.toml
+++ b/fe2o3-amqp-ws/Cargo.toml
@@ -53,5 +53,12 @@ web-sys = { workspace = true, features = [
 fe2o3-amqp = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = ["net", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+
+# This dev-dependency reproduces Cargo feature unification in the test build: it turns on a TLS
+# feature of `tokio-tungstenite` while this crate itself has no TLS feature enabled. The tests in
+# `tests/connector_api.rs` then guard that a `wss://` address still fails instead of connecting
+# with a TLS stack that this crate never asked for. See issue #356. It uses `rustls` rather than
+# `native-tls`, because `rustls` is pure Rust and needs no system library.
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 

--- a/fe2o3-amqp-ws/Changelog.md
+++ b/fe2o3-amqp-ws/Changelog.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 1. Updated `tungstenite` and `tokio-tungstenite` from `0.26` to `0.30`.
+2. Removed the TLS feature gate from `WebSocketStream::connect_tls_with_config`, `WebSocketStream::connect_tls_with_stream`, and `WebSocketStream::connect_tls_with_stream_and_config` (issue [#356](https://github.com/minghuaw/fe2o3-amqp/issues/356)). The three functions now exist in every feature build, so a library crate can depend on `fe2o3-amqp-ws` with no TLS feature and let the application select the TLS stack. With a TLS feature enabled, their behavior does not change. With no TLS feature enabled, a `ws://` address connects in plaintext, and a `wss://` address returns `tungstenite::error::UrlError::TlsFeatureNotEnabled` before this crate opens a socket. This crate never downgrades a `wss://` address to a plaintext connection. `WebSocketStream::connect` and `WebSocketStream::connect_with_config` keep their current behavior, because they take no connector.
+3. Relaxed the bound on `impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<S>>>` and dropped `Sync`, which `tokio_tungstenite::client_async_tls_with_config` never required.
 
 ### Breaking Changes
 

--- a/fe2o3-amqp-ws/Readme.md
+++ b/fe2o3-amqp-ws/Readme.md
@@ -5,9 +5,22 @@ WebSocket adapter for AMQP 1.0 websocket binding
 This provides a thin wrapper over `tokio_tungstenite::WebSocketStream`, and the wrapper performs
 the WebSocket handshake with the "Sec-WebSocket-Protocol" HTTP header set to "amqp".
 
-The wrapper type [`WebSocketStream`] could also be used for non-AMQP applications; however, the
-user should establish websocket stream with raw `tokio_tungstenite` API and then wrap the stream
-with the wrapper by `fe2o3_amqp_ws::WebSocketStream::from(ws_stream)`.
+Every public constructor of `WebSocketStream` sets the "Sec-WebSocket-Protocol" header to
+"amqp" and rejects a handshake response that does not return the same value. To do the
+handshake over a stream that you open yourself, use `WebSocketStream::connect_with_stream` or
+`WebSocketStream::connect_with_stream_and_config`. This crate has no public constructor that
+wraps a `tokio_tungstenite::WebSocketStream` that you built with the raw `tokio_tungstenite`
+API.
+
+## Re-exports
+
+This crate re-exports `tungstenite` and `tokio_tungstenite` so that downstream
+users can reference the same versions used internally:
+
+```rust
+use fe2o3_amqp_ws::tungstenite;
+use fe2o3_amqp_ws::tokio_tungstenite;
+```
 
 ## Feature flags
 
@@ -21,6 +34,33 @@ default = []
 | `native-tls-vendored` | Enables "tokio-tungstenite/native-tls-vendored" |
 | `rustls-tls-native-roots` | Enables "tokio-tungstenite/rustls-tls-native-roots" |
 | `rustls-tls-webpki-roots` | Enables "tokio-tungstenite/rustls-tls-webpki-roots" |
+
+## TLS
+
+These three connect functions are not feature gated:
+`WebSocketStream::connect_tls_with_config`, `WebSocketStream::connect_tls_with_stream_and_config`,
+and `WebSocketStream::connect_tls_with_stream`. The first two take a TLS `connector`. The third
+is a shorthand that supplies no connector. A library crate can depend on `fe2o3-amqp-ws` with
+`default-features = false`, call these functions, and let the application that builds the final
+binary select the TLS stack.
+
+The four features above select which TLS stack `tokio-tungstenite` links. They do not control
+whether the connect functions exist. Enable the feature on `fe2o3-amqp-ws` itself. A TLS
+feature that another crate enables on `tokio-tungstenite` does not enable the TLS code path of
+this crate, because a crate cannot read the features of its dependency.
+
+With none of the four features enabled, these three functions have no TLS stack. A `ws://`
+address connects in plaintext. A `wss://` address returns
+`Error::Tungstenite(tungstenite::Error::Url(tungstenite::error::UrlError::TlsFeatureNotEnabled))`
+before a socket is opened, for every value of `connector`. A `wss://` address is never
+downgraded to a plaintext connection.
+
+`WebSocketStream::connect` and `WebSocketStream::connect_with_config` behave differently. They
+take no connector and pass `None` to `tokio-tungstenite`, which then selects the TLS stack from
+its own enabled features. Cargo unifies features over the whole dependency graph, so another
+crate can change that selection. These two functions can therefore make a TLS connection when
+`fe2o3-amqp-ws` has no TLS feature enabled. Call `WebSocketStream::connect_tls_with_config` with
+`Some(connector)` for a deterministic TLS stack.
 
 ## Example
 

--- a/fe2o3-amqp-ws/src/lib.rs
+++ b/fe2o3-amqp-ws/src/lib.rs
@@ -6,9 +6,12 @@
 //! This provides a thin wrapper over `tokio_tungstenite::WebSocketStream`, and the wrapper performs
 //! the WebSocket handshake with the "Sec-WebSocket-Protocol" HTTP header set to "amqp".
 //!
-//! The wrapper type [`WebSocketStream`] could also be used for non-AMQP applications; however, the
-//! user should establish websocket stream with raw `tokio_tungstenite` API and then wrap the stream
-//! with the wrapper by `fe2o3_amqp_ws::WebSocketStream::new(ws_stream, response)`.
+//! Every public constructor of [`WebSocketStream`] sets the "Sec-WebSocket-Protocol" header to
+//! "amqp" and rejects a handshake response that does not return the same value. To do the
+//! handshake over a stream that you open yourself, use `WebSocketStream::connect_with_stream` or
+//! `WebSocketStream::connect_with_stream_and_config`. This crate has no public constructor that
+//! wraps a `tokio_tungstenite::WebSocketStream` that you built with the raw `tokio_tungstenite`
+//! API.
 //!
 //! # Re-exports
 //!
@@ -32,6 +35,33 @@
 //! | `native-tls-vendored` | Enables "tokio-tungstenite/native-tls-vendored" |
 //! | `rustls-tls-native-roots` | Enables "tokio-tungstenite/rustls-tls-native-roots" |
 //! | `rustls-tls-webpki-roots` | Enables "tokio-tungstenite/rustls-tls-webpki-roots" |
+//!
+//! # TLS
+//!
+//! These three connect functions are not feature gated:
+//! `WebSocketStream::connect_tls_with_config`, `WebSocketStream::connect_tls_with_stream_and_config`,
+//! and `WebSocketStream::connect_tls_with_stream`. The first two take a TLS `connector`. The third
+//! is a shorthand that supplies no connector. A library crate can depend on `fe2o3-amqp-ws` with
+//! `default-features = false`, call these functions, and let the application that builds the final
+//! binary select the TLS stack.
+//!
+//! The four features above select which TLS stack `tokio-tungstenite` links. They do not control
+//! whether the connect functions exist. Enable the feature on `fe2o3-amqp-ws` itself. A TLS
+//! feature that another crate enables on `tokio-tungstenite` does not enable the TLS code path of
+//! this crate, because a crate cannot read the features of its dependency.
+//!
+//! With none of the four features enabled, these three functions have no TLS stack. A `ws://`
+//! address connects in plaintext. A `wss://` address returns
+//! `Error::Tungstenite(tungstenite::Error::Url(tungstenite::error::UrlError::TlsFeatureNotEnabled))`
+//! before a socket is opened, for every value of `connector`. A `wss://` address is never
+//! downgraded to a plaintext connection.
+//!
+//! `WebSocketStream::connect` and `WebSocketStream::connect_with_config` behave differently. They
+//! take no connector and pass `None` to `tokio-tungstenite`, which then selects the TLS stack from
+//! its own enabled features. Cargo unifies features over the whole dependency graph, so another
+//! crate can change that selection. These two functions can therefore make a TLS connection when
+//! `fe2o3-amqp-ws` has no TLS feature enabled. Call `WebSocketStream::connect_tls_with_config` with
+//! `Some(connector)` for a deterministic TLS stack.
 //!
 //! # Example
 //!

--- a/fe2o3-amqp-ws/src/macros.rs
+++ b/fe2o3-amqp-ws/src/macros.rs
@@ -1,6 +1,7 @@
 macro_rules! cfg_wasm32 {
     ($($item:item)*) => {
         $(
+            #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
             #[cfg(target_arch = "wasm32")]
             $item
         )*
@@ -10,6 +11,7 @@ macro_rules! cfg_wasm32 {
 macro_rules! cfg_not_wasm32 {
     ($($item:item)*) => {
         $(
+            #[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
             #[cfg(not(target_arch = "wasm32"))]
             $item
         )*

--- a/fe2o3-amqp-ws/src/native.rs
+++ b/fe2o3-amqp-ws/src/native.rs
@@ -119,9 +119,9 @@ impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>> {
 
     /// Calls [`tokio_tungstenite::connect_async_with_config`] internally with
     /// `"Sec-WebSocket-Protocol"` HTTP header of the `req` set to `"amqp"`
-    /// 
-    /// `disable_nagle` specifies if the Nagle’s algorithm must be disabled,
-    /// i.e. `set_nodelay(true)`. If you don’t know what the Nagle’s algorithm is,
+    ///
+    /// `disable_nagle` specifies if the Nagle's algorithm must be disabled,
+    /// i.e. `set_nodelay(true)`. If you don't know what the Nagle's algorithm is,
     /// better leave it set to `false`.
     ///
     /// This function takes no TLS connector. For a `wss://` address, `tokio_tungstenite` selects

--- a/fe2o3-amqp-ws/src/native.rs
+++ b/fe2o3-amqp-ws/src/native.rs
@@ -98,6 +98,12 @@ where
 impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>> {
     /// Calls [`tokio_tungstenite::connect_async`] internally with `"Sec-WebSocket-Protocol"` HTTP
     /// header of the `req` set to `"amqp"`
+    ///
+    /// This function takes no TLS connector. For a `wss://` address, `tokio_tungstenite` selects
+    /// the TLS stack from its own enabled features, and it prefers `native-tls` over `rustls`.
+    /// Cargo unifies features over the whole dependency graph, so another crate can change that
+    /// selection. Call [`Self::connect_tls_with_config`] with `Some(connector)` to select the TLS
+    /// stack yourself.
     pub async fn connect(addr: impl AsRef<str>) -> Result<Self, Error> {
         let req = addr.as_ref();
         let request = map_amqp_websocket_request(req)?;
@@ -114,9 +120,15 @@ impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>> {
     /// Calls [`tokio_tungstenite::connect_async_with_config`] internally with
     /// `"Sec-WebSocket-Protocol"` HTTP header of the `req` set to `"amqp"`
     /// 
-    /// `disable_nagle` specifies if the Nagle’s algorithm must be disabled, 
-    /// i.e. `set_nodelay(true)`. If you don’t know what the Nagle’s algorithm is, 
+    /// `disable_nagle` specifies if the Nagle’s algorithm must be disabled,
+    /// i.e. `set_nodelay(true)`. If you don’t know what the Nagle’s algorithm is,
     /// better leave it set to `false`.
+    ///
+    /// This function takes no TLS connector. For a `wss://` address, `tokio_tungstenite` selects
+    /// the TLS stack from its own enabled features, and it prefers `native-tls` over `rustls`.
+    /// Cargo unifies features over the whole dependency graph, so another crate can change that
+    /// selection. Call [`Self::connect_tls_with_config`] with `Some(connector)` to select the TLS
+    /// stack yourself.
     pub async fn connect_with_config(
         addr: impl AsRef<str>,
         config: Option<WebSocketConfig>,
@@ -125,6 +137,58 @@ impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>> {
         let req = addr.as_ref();
         let request = map_amqp_websocket_request(req)?;
         let (mut ws_stream, response) = connect_async_with_config(request, config, disable_nagle).await?;
+        match verify_response(response) {
+            Ok(response) => Ok(Self::from(TokioWebSocketStream::new(ws_stream, response))),
+            Err(error) => {
+                ws_stream.close(None).await?;
+                Err(error)
+            }
+        }
+    }
+
+    /// Connects to `addr` with an explicit TLS `connector`, with the `"Sec-WebSocket-Protocol"`
+    /// HTTP header of the request set to `"amqp"`.
+    ///
+    /// This function is not feature gated. A library crate can call it with no TLS feature of this
+    /// crate enabled, and the application that builds the final binary selects the TLS stack. See
+    /// issue [#356](https://github.com/minghuaw/fe2o3-amqp/issues/356).
+    ///
+    /// `disable_nagle` specifies if the Nagle's algorithm must be disabled, i.e.
+    /// `set_nodelay(true)`. If you do not know what the Nagle's algorithm is, leave it set to
+    /// `false`.
+    ///
+    /// # With a TLS feature of this crate enabled
+    ///
+    /// This calls `tokio_tungstenite::connect_async_tls_with_config` internally.
+    /// `Some(connector)` uses that connector. `None` lets `tokio_tungstenite` select the TLS stack
+    /// from its own enabled features, and Cargo feature unification can change that selection.
+    /// Pass `Some(connector)` for a deterministic TLS stack.
+    ///
+    /// # With no TLS feature of this crate enabled
+    ///
+    /// This crate has no TLS stack, so it cannot make a TLS connection.
+    ///
+    /// - A `ws://` address connects in plaintext. The `connector` is unused, which is also what
+    ///   `tokio_tungstenite` does for a `ws://` address.
+    /// - A `wss://` address returns
+    ///   `Error::Tungstenite(tungstenite::Error::Url(tungstenite::error::UrlError::TlsFeatureNotEnabled))`
+    ///   for every value of `connector`, and no socket is opened. A `wss://` address is never
+    ///   downgraded to a plaintext connection.
+    ///
+    /// Enable one of `native-tls`, `native-tls-vendored`, `rustls-tls-native-roots`, or
+    /// `rustls-tls-webpki-roots` on `fe2o3-amqp-ws` to make a TLS connection. A TLS feature
+    /// enabled on `tokio-tungstenite` alone is not sufficient, because a crate cannot read the
+    /// features of its dependency.
+    pub async fn connect_tls_with_config(
+        addr: impl AsRef<str>,
+        config: Option<WebSocketConfig>,
+        disable_nagle: bool,
+        connector: Option<tokio_tungstenite::Connector>,
+    ) -> Result<Self, Error> {
+        let req = addr.as_ref();
+        let request = map_amqp_websocket_request(req)?;
+        let (mut ws_stream, response) =
+            connect_async_with_connector(request, config, disable_nagle, connector).await?;
         match verify_response(response) {
             Ok(response) => Ok(Self::from(TokioWebSocketStream::new(ws_stream, response))),
             Err(error) => {
@@ -182,46 +246,57 @@ where
     }
 }
 
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "native-tls",
-        feature = "native-tls-vendored",
-        feature = "rustls-tls-native-roots",
-        feature = "rustls-tls-webpki-roots"
-    )))
-)]
-#[cfg(any(
-    feature = "native-tls",
-    feature = "native-tls-vendored",
-    feature = "rustls-tls-native-roots",
-    feature = "rustls-tls-webpki-roots"
-))]
 impl<S> WebSocketStream<TokioWebSocketStream<MaybeTlsStream<S>>>
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    /// Calls [`tokio_tungstenite::client_async_tls`] internally with `"Sec-WebSocket-Protocol"` HTTP
-    /// header of the `req` set to `"amqp"`
-    pub async fn connect_tls_with_stream(
-        addr: impl AsRef<str>,
-        stream: S,
-    ) -> Result<Self, Error> {
-        let req = addr.as_ref();
-        let request = map_amqp_websocket_request(req)?;
-        let (mut ws_stream, response) =
-            tokio_tungstenite::client_async_tls(request, stream).await?;
-        match verify_response(response) {
-            Ok(response) => Ok(Self::from(TokioWebSocketStream::new(ws_stream, response))),
-            Err(error) => {
-                ws_stream.close(None).await?;
-                Err(error)
-            }
-        }
+    /// Performs the WebSocket handshake over `stream`, upgrading it to TLS if `addr` is a `wss://`
+    /// address, with the `"Sec-WebSocket-Protocol"` HTTP header of the request set to `"amqp"`.
+    ///
+    /// This is the same as `connect_tls_with_stream_and_config(addr, stream, None, None)`. It
+    /// takes no connector, so `tokio_tungstenite` selects the TLS stack from its own enabled
+    /// features. A library crate should prefer [`Self::connect_tls_with_stream_and_config`] and
+    /// let the application supply the connector.
+    ///
+    /// This function is not feature gated. With no TLS feature of this crate enabled, a `wss://`
+    /// address returns
+    /// `Error::Tungstenite(tungstenite::Error::Url(tungstenite::error::UrlError::TlsFeatureNotEnabled))`
+    /// and drops `stream`. See [`Self::connect_tls_with_stream_and_config`].
+    pub async fn connect_tls_with_stream(addr: impl AsRef<str>, stream: S) -> Result<Self, Error> {
+        Self::connect_tls_with_stream_and_config(addr, stream, None, None).await
     }
 
-    /// Calls [`tokio_tungstenite::client_async_tls_with_config`] internally with
-    /// `"Sec-WebSocket-Protocol"` HTTP header of the `req` set to `"amqp"`
+    /// Performs the WebSocket handshake over `stream` with an explicit TLS `connector`, with the
+    /// `"Sec-WebSocket-Protocol"` HTTP header of the request set to `"amqp"`.
+    ///
+    /// This function is not feature gated. A library crate can call it with no TLS feature of this
+    /// crate enabled, and the application that builds the final binary selects the TLS stack. See
+    /// issue [#356](https://github.com/minghuaw/fe2o3-amqp/issues/356).
+    ///
+    /// # With a TLS feature of this crate enabled
+    ///
+    /// This calls `tokio_tungstenite::client_async_tls_with_config` internally.
+    /// `Some(connector)` uses that connector. `None` lets `tokio_tungstenite` select the TLS stack
+    /// from its own enabled features, and Cargo feature unification can change that selection.
+    /// Pass `Some(connector)` for a deterministic TLS stack.
+    ///
+    /// # With no TLS feature of this crate enabled
+    ///
+    /// This crate has no TLS stack, so it cannot make a TLS connection.
+    ///
+    /// - A `ws://` address wraps `stream` in `tokio_tungstenite::MaybeTlsStream::Plain` and
+    ///   completes the handshake in plaintext. The `connector` is unused, which is also what
+    ///   `tokio_tungstenite` does for a `ws://` address.
+    /// - A `wss://` address returns
+    ///   `Error::Tungstenite(tungstenite::Error::Url(tungstenite::error::UrlError::TlsFeatureNotEnabled))`
+    ///   for every value of `connector`, and no byte goes to `stream`. This function owns `stream`
+    ///   and drops it, which closes it. A `wss://` address is never downgraded to a plaintext
+    ///   handshake.
+    ///
+    /// Enable one of `native-tls`, `native-tls-vendored`, `rustls-tls-native-roots`, or
+    /// `rustls-tls-webpki-roots` on `fe2o3-amqp-ws` to make a TLS connection. A TLS feature
+    /// enabled on `tokio-tungstenite` alone is not sufficient, because a crate cannot read the
+    /// features of its dependency.
     pub async fn connect_tls_with_stream_and_config(
         addr: impl AsRef<str>,
         stream: S,
@@ -231,8 +306,7 @@ where
         let req = addr.as_ref();
         let request = map_amqp_websocket_request(req)?;
         let (mut ws_stream, response) =
-            tokio_tungstenite::client_async_tls_with_config(request, stream, config, connector)
-                .await?;
+            client_async_with_connector(request, stream, config, connector).await?;
         match verify_response(response) {
             Ok(response) => Ok(Self::from(TokioWebSocketStream::new(ws_stream, response))),
             Err(error) => {
@@ -243,45 +317,142 @@ where
     }
 }
 
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "native-tls",
-        feature = "native-tls-vendored",
-        feature = "rustls-tls-native-roots",
-        feature = "rustls-tls-webpki-roots"
-    )))
-)]
+// A TLS feature of this crate is enabled, so it is forwarded to `tokio-tungstenite` and the TLS
+// entry points are exported. Delegate to them unchanged.
 #[cfg(any(
     feature = "native-tls",
     feature = "native-tls-vendored",
     feature = "rustls-tls-native-roots",
     feature = "rustls-tls-webpki-roots"
 ))]
-impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>> {
-    /// Calls [`tokio_tungstenite::connect_async_tls_with_config`] internally with
-    /// `"Sec-WebSocket-Protocol"` HTTP header of the `req` set to `"amqp"`
-    /// 
-    /// `disable_nagle` specifies if the Nagle’s algorithm must be disabled, 
-    /// i.e. `set_nodelay(true)`. If you don’t know what the Nagle’s algorithm is, 
-    /// better leave it to `false`
-    pub async fn connect_tls_with_config(
-        addr: impl AsRef<str>,
-        config: Option<WebSocketConfig>,
-        disable_nagle: bool,
-        connector: Option<tokio_tungstenite::Connector>,
-    ) -> Result<Self, Error> {
-        let req = addr.as_ref();
-        let request = map_amqp_websocket_request(req)?;
-        let (mut ws_stream, response) =
-            tokio_tungstenite::connect_async_tls_with_config(request, config, disable_nagle, connector).await?;
-        match verify_response(response) {
-            Ok(response) => Ok(Self::from(TokioWebSocketStream::new(ws_stream, response))),
-            Err(error) => {
-                ws_stream.close(None).await?;
-                Err(error)
-            }
+#[allow(
+    clippy::result_large_err,
+    reason = "large error is inherent to tungstenite"
+)]
+async fn connect_async_with_connector(
+    request: Request,
+    config: Option<WebSocketConfig>,
+    disable_nagle: bool,
+    connector: Option<tokio_tungstenite::Connector>,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
+        Response,
+    ),
+    tungstenite::Error,
+> {
+    tokio_tungstenite::connect_async_tls_with_config(request, config, disable_nagle, connector)
+        .await
+}
+
+// No TLS feature of this crate is enabled, so `tokio_tungstenite` does not export
+// `connect_async_tls_with_config` and this crate has no TLS stack.
+//
+// `tokio_tungstenite` takes the mode from the URI scheme, never from the connector. Every one of
+// its `wrap_stream` implementations returns `MaybeTlsStream::Plain` for `Mode::Plain` and ignores
+// the connector. This function therefore forwards a `ws://` address unchanged.
+// `connect_async_with_config` passes `connector: None` down, but `Mode::Plain` never starts a TLS
+// handshake, so that is safe.
+//
+// A `wss://` address is different. This crate cannot serve it, and the connector cannot change
+// that, so this function rejects the address before it opens a socket. If it forwarded the
+// address instead, a `tokio-tungstenite` TLS feature that another crate enabled would complete the
+// handshake with a stack this crate never asked for.
+#[cfg(not(any(
+    feature = "native-tls",
+    feature = "native-tls-vendored",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+)))]
+#[allow(
+    clippy::result_large_err,
+    reason = "large error is inherent to tungstenite"
+)]
+async fn connect_async_with_connector(
+    request: Request,
+    config: Option<WebSocketConfig>,
+    disable_nagle: bool,
+    _connector: Option<tokio_tungstenite::Connector>,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
+        Response,
+    ),
+    tungstenite::Error,
+> {
+    use tungstenite::{client::uri_mode, error::UrlError, stream::Mode};
+
+    match uri_mode(request.uri())? {
+        Mode::Plain => connect_async_with_config(request, config, disable_nagle).await,
+        Mode::Tls => Err(tungstenite::Error::Url(UrlError::TlsFeatureNotEnabled)),
+    }
+}
+
+// A TLS feature of this crate is enabled. See `connect_async_with_connector` above.
+#[cfg(any(
+    feature = "native-tls",
+    feature = "native-tls-vendored",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+))]
+#[allow(
+    clippy::result_large_err,
+    reason = "large error is inherent to tungstenite"
+)]
+async fn client_async_with_connector<S>(
+    request: Request,
+    stream: S,
+    config: Option<WebSocketConfig>,
+    connector: Option<tokio_tungstenite::Connector>,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<MaybeTlsStream<S>>,
+        Response,
+    ),
+    tungstenite::Error,
+>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    tokio_tungstenite::client_async_tls_with_config(request, stream, config, connector).await
+}
+
+// No TLS feature of this crate is enabled. This function reproduces what
+// `tokio_tungstenite::client_async_tls_with_config` does when `tokio-tungstenite` itself has no TLS
+// feature: `Mode::Plain` wraps the stream as `MaybeTlsStream::Plain`, and `Mode::Tls` is an error.
+// See `connect_async_with_connector` above for why it rejects `Mode::Tls`.
+#[cfg(not(any(
+    feature = "native-tls",
+    feature = "native-tls-vendored",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+)))]
+#[allow(
+    clippy::result_large_err,
+    reason = "large error is inherent to tungstenite"
+)]
+async fn client_async_with_connector<S>(
+    request: Request,
+    stream: S,
+    config: Option<WebSocketConfig>,
+    _connector: Option<tokio_tungstenite::Connector>,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<MaybeTlsStream<S>>,
+        Response,
+    ),
+    tungstenite::Error,
+>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    use tungstenite::{client::uri_mode, error::UrlError, stream::Mode};
+
+    match uri_mode(request.uri())? {
+        Mode::Plain => {
+            client_async_with_config(request, MaybeTlsStream::Plain(stream), config).await
         }
+        Mode::Tls => Err(tungstenite::Error::Url(UrlError::TlsFeatureNotEnabled)),
     }
 }
 

--- a/fe2o3-amqp-ws/tests/connector_api.rs
+++ b/fe2o3-amqp-ws/tests/connector_api.rs
@@ -1,0 +1,137 @@
+//! The connector-taking connect functions must exist in every feature build of this crate.
+//!
+//! A library crate depends on `fe2o3-amqp-ws` with no TLS feature and lets the application select
+//! the TLS stack, so these functions must never be feature gated. See issue
+//! <https://github.com/minghuaw/fe2o3-amqp/issues/356>.
+//!
+//! The dev-dependency on `tokio-tungstenite` turns on the `rustls-tls-webpki-roots` feature of
+//! `tokio-tungstenite` for the test build. Cargo unifies that feature with the feature set of the
+//! same dependency in the library build, so the tests below run in a build where
+//! `tokio-tungstenite` has a TLS stack and this crate does not. That is the second case in issue
+//! #356, and `rustls_variant_is_visible` fails to compile if the unification ever stops.
+//!
+//! CI compiles and runs this file with `cargo test -p fe2o3-amqp-ws --no-default-features`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use fe2o3_amqp_ws::{
+    native::TokioWebSocketStream,
+    tokio_tungstenite::{Connector, MaybeTlsStream},
+    Error, WebSocketStream,
+};
+use tokio::net::TcpStream;
+
+/// The snippet from issue #356. It must resolve with no TLS feature enabled.
+#[allow(dead_code)]
+async fn issue_356_snippet_resolves() {
+    let _ = WebSocketStream::connect_tls_with_config("wss://example.com", None, false, None).await;
+}
+
+#[allow(dead_code)]
+async fn an_explicit_connector_is_accepted() {
+    let _ = WebSocketStream::connect_tls_with_config(
+        "wss://example.com",
+        None,
+        false,
+        Some(Connector::Plain),
+    )
+    .await;
+}
+
+/// The two stream forms must also resolve with no TLS feature enabled.
+///
+/// This function is never called, so it opens no connection. A function pointer to either form
+/// does not compile, because the `addr: impl AsRef<str>` parameter makes the function item
+/// generic and the type cannot be inferred, so the test calls them instead.
+#[allow(dead_code)]
+async fn the_stream_forms_resolve(stream: TcpStream, another_stream: TcpStream) {
+    let _: Result<WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>>, Error> =
+        WebSocketStream::connect_tls_with_stream("wss://example.com", stream).await;
+    let _: Result<WebSocketStream<TokioWebSocketStream<MaybeTlsStream<TcpStream>>>, Error> =
+        WebSocketStream::connect_tls_with_stream_and_config(
+            "wss://example.com",
+            another_stream,
+            None,
+            Some(Connector::Plain),
+        )
+        .await;
+}
+
+/// The `Connector::Rustls` variant exists only when `tokio-tungstenite` has a `rustls` feature
+/// enabled. This function therefore fails to compile if the dev-dependency stops unifying that
+/// feature into the test build, which would make the tests below stop guarding issue #356.
+#[allow(dead_code)]
+fn rustls_variant_is_visible(connector: &Connector) -> bool {
+    matches!(connector, Connector::Rustls(_))
+}
+
+/// A `wss://` address must fail with `TlsFeatureNotEnabled` when this crate has no TLS stack. It
+/// must never fall back to a plaintext connection, and it must not open a socket.
+///
+/// `tokio-tungstenite` has a TLS stack in this build, so this test also guards the second case in
+/// issue #356: a TLS feature that another crate enables must not make this crate connect with a
+/// stack that it never asked for.
+///
+/// The test is compiled out when a TLS feature of this crate is enabled, because the call would
+/// then reach the network.
+#[cfg(not(any(
+    feature = "native-tls",
+    feature = "native-tls-vendored",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+)))]
+#[tokio::test]
+async fn wss_without_a_tls_feature_is_an_error() {
+    use fe2o3_amqp_ws::tungstenite::{error::UrlError, Error as WsError};
+
+    // Port 1 on the loopback address refuses a connection at once. If a call ever forwards to
+    // `tokio_tungstenite` instead of failing first, the test fails fast with an IO error rather
+    // than hanging.
+    //
+    // `None` is the value that lets `tokio_tungstenite` select the TLS stack, and
+    // `Some(Connector::Plain)` is an explicit request for no TLS. Neither may reach a peer.
+    for connector in [None, Some(Connector::Plain)] {
+        let result =
+            WebSocketStream::connect_tls_with_config("wss://127.0.0.1:1", None, false, connector)
+                .await;
+
+        match result {
+            Err(fe2o3_amqp_ws::Error::Tungstenite(WsError::Url(
+                UrlError::TlsFeatureNotEnabled,
+            ))) => {}
+            Err(other) => panic!("expected TlsFeatureNotEnabled, got {other}"),
+            Ok(_) => panic!("expected TlsFeatureNotEnabled, got a connection"),
+        }
+    }
+}
+
+/// A `ws://` address must still connect in plaintext when this crate has no TLS stack, and the
+/// connector must be ignored, which is what `tokio_tungstenite` also does.
+#[cfg(not(any(
+    feature = "native-tls",
+    feature = "native-tls-vendored",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+)))]
+#[tokio::test]
+async fn ws_without_a_tls_feature_reaches_the_socket() {
+    use fe2o3_amqp_ws::tungstenite::{error::UrlError, Error as WsError};
+
+    let result = WebSocketStream::connect_tls_with_config(
+        "ws://127.0.0.1:1",
+        None,
+        false,
+        Some(Connector::Plain),
+    )
+    .await;
+
+    // The connection is refused, so this is an IO error. The point is that it is NOT
+    // `TlsFeatureNotEnabled`: a `ws://` address is forwarded, not rejected.
+    match result {
+        Err(fe2o3_amqp_ws::Error::Tungstenite(WsError::Url(UrlError::TlsFeatureNotEnabled))) => {
+            panic!("a ws:// address must not be rejected as a TLS request")
+        }
+        Err(_) => {}
+        Ok(_) => panic!("expected the connection to be refused"),
+    }
+}


### PR DESCRIPTION
## Summary

`fe2o3-amqp-ws` put all three `connect_tls_*` functions behind a feature gate. The gate tested the four TLS features of the crate itself. A crate that depended on `fe2o3-amqp-ws` with no TLS feature compiled. A call to `connect_tls_with_config` then failed with E0599.

```toml
[dependencies]
fe2o3-amqp-ws = { version = "0.16", default-features = false }
```

```rust
use fe2o3_amqp_ws::WebSocketStream;

pub async fn open() {
    let _ = WebSocketStream::connect_tls_with_config("wss://example.com", None, false, None).await;
}
```

```
error[E0599]: no associated function or constant named `connect_tls_with_config` found for struct `fe2o3_amqp_ws::WebSocketStream<S>` in the current scope
 --> src/lib.rs:4:30
  |
4 |     let _ = WebSocketStream::connect_tls_with_config("wss://example.com", None, false, None).await;
  |                              ^^^^^^^^^^^^^^^^^^^^^^^ associated function or constant not found in `fe2o3_amqp_ws::WebSocketStream<_>`
```

This change removes that gate. The three functions now exist in every feature build, and the snippet above compiles unchanged.

Closes #356.

## Motivation

A library crate that offers an AMQP-over-WebSockets transport must let the application select the TLS stack. `reqwest` uses this model. The old layout did not allow it. The library had to select a stack for all of its users. The alternative was a feature that could not build on its own. `azure_core_amqp` in the Azure SDK for Rust meets this in Azure/azure-sdk-for-rust#4596.

The library now names no TLS crate, and it enables no TLS feature of `fe2o3-amqp-ws`. It accepts the connector that the application passes to it.

```toml
# The library.
[dependencies]
fe2o3-amqp-ws = { version = "0.16", default-features = false }
```

```rust
use fe2o3_amqp_ws::tokio_tungstenite::Connector;
use fe2o3_amqp_ws::WebSocketStream;

pub async fn connect(addr: &str, connector: Option<Connector>) {
    let _ = WebSocketStream::connect_tls_with_config(addr, None, false, connector).await;
}
```

The application selects the stack and builds the connector. The re-export of `tokio_tungstenite` from #353 lets both crates name `Connector` without a separate dependency.

```toml
# The application.
[dependencies]
my-amqp-lib = "1"
fe2o3-amqp-ws = { version = "0.16", default-features = false, features = ["native-tls"] }
native-tls = "0.2"
```

```rust
use fe2o3_amqp_ws::tokio_tungstenite::Connector;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let tls = native_tls::TlsConnector::new()?;
    my_amqp_lib::connect("wss://example.com", Some(Connector::NativeTls(tls))).await;
    Ok(())
}
```

The gating of `tokio-tungstenite` 0.30 constrains the fix. `tokio-tungstenite` exports `Connector` under its `connect` default feature, so this crate can always name it. `tokio-tungstenite` gates `connect_async_tls_with_config` and `client_async_tls_with_config` behind its own TLS features. A crate cannot `cfg` on the features of a dependency. An ungated wrapper therefore cannot forward to those two functions in every build.

## Changes

Each entry point now goes through a private helper pair in `fe2o3-amqp-ws/src/native.rs`. One helper carries `cfg(any(<tls features>))`. It delegates to `tokio-tungstenite` unchanged. The other helper carries `cfg(not(any(<tls features>)))`. It takes the mode from the URI scheme, which is what `tokio-tungstenite` also does.

```rust
#[cfg(not(any(
    feature = "native-tls",
    feature = "native-tls-vendored",
    feature = "rustls-tls-native-roots",
    feature = "rustls-tls-webpki-roots"
)))]
async fn connect_async_with_connector(
    request: Request,
    config: Option<WebSocketConfig>,
    disable_nagle: bool,
    _connector: Option<tokio_tungstenite::Connector>,
) -> Result<
    (
        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
        Response,
    ),
    tungstenite::Error,
> {
    use tungstenite::{client::uri_mode, error::UrlError, stream::Mode};

    match uri_mode(request.uri())? {
        Mode::Plain => connect_async_with_config(request, config, disable_nagle).await,
        Mode::Tls => Err(tungstenite::Error::Url(UrlError::TlsFeatureNotEnabled)),
    }
}
```

`Mode::Plain` forwards the request. Every `wrap_stream` arm of `tokio-tungstenite` returns `MaybeTlsStream::Plain` for `Mode::Plain`, so a `ws://` address behaves as before. `Mode::Tls` returns the same error value that `tokio-tungstenite` returns for the same condition, and this crate opens no socket first.

The helper never reads the connector. A `wss://` address therefore fails for every value of `connector`. This crate never downgrades a `wss://` address to a plaintext connection.

The public functions keep their exact signatures. The change adds no public name, no feature, and no `Error` variant. Removing a feature gate is additive, so the change is not breaking. The bound on `impl WebSocketStream<TokioWebSocketStream<MaybeTlsStream<S>>>` drops `Sync`. `tokio_tungstenite::client_async_tls_with_config` never required `Sync`, so this bound is a relaxation.

Three items go beyond the source fix:

1. `.github/workflows/ci.yml` and `CONTRIBUTING.md` gain the feature-matrix commands. No CI job built this crate with no TLS feature before, so the gate could come back unnoticed.
2. `fe2o3-amqp-ws/src/macros.rs` gains `doc(cfg(...))` on the target macros. The change removed the only two `doc(cfg(...))` attributes in the crate. That left `#![cfg_attr(docsrs, feature(doc_cfg))]` and the docs.rs `rustdoc-args` with no effect.
3. The crate-level docs named `WebSocketStream::from(ws_stream)` as the way to wrap a raw `tokio_tungstenite::WebSocketStream`. A caller cannot reach that path, because the only constructor of the inner `TokioWebSocketStream` is private. The paragraph now points at `connect_with_stream`.

One limit remains. `connect` and `connect_with_config` still select the TLS stack in a way that is not deterministic. Both take no connector and pass `None` down. `tokio-tungstenite` then selects the stack from its own features, and Cargo feature unification can change that selection. A scratch crate shows the split. It depends on `fe2o3-amqp-ws` with no TLS feature, and on `tokio-tungstenite` with `native-tls`, so unification gives `tokio-tungstenite` a TLS stack that this crate cannot reach.

```
connect_tls_with_config wss:// None       -> Some("URL error: TLS support not compiled in")
connect_tls_with_config wss:// Plain      -> Some("URL error: TLS support not compiled in")
connect_tls_with_config wss:// NativeTls  -> Some("URL error: TLS support not compiled in")
connect_tls_with_config ws://  plain      -> Some("IO error: Connection refused (os error 61)")
connect                 wss://            -> Err(HTTP error: 200 OK)
connect_with_config     wss://            -> Err(HTTP error: 200 OK)
```

The last two lines reached `example.com` over TLS and read an HTTP 200 instead of a 101, so the TLS handshake completed. The rustdoc of both functions now states this and points at `connect_tls_with_config`. A full fix needs a signature change, which is out of scope here.

## Test plan

`fe2o3-amqp-ws/tests/connector_api.rs` is new. A dev-dependency turns on `tokio-tungstenite/rustls-tls-webpki-roots` for the test build only. The tests therefore run in the unification case from the issue: `tokio-tungstenite` has a TLS stack and this crate has none. The dev-dependency adds no `ring` and no `aws-lc-rs` to the tree.

- `issue_356_snippet_resolves` holds the snippet from the issue verbatim. It fails to compile if the gate comes back.
- `rustls_variant_is_visible` fails to compile if the dev-dependency stops unifying. The runtime tests would then guard nothing.
- `wss_without_a_tls_feature_is_an_error` asserts `TlsFeatureNotEnabled` for `None` and for `Some(Connector::Plain)`.
- `ws_without_a_tls_feature_reaches_the_socket` asserts that a `ws://` address still reaches the socket.

These commands pass locally:

```
cargo check -p fe2o3-amqp-ws --no-default-features
cargo check -p fe2o3-amqp-ws --no-default-features --features native-tls
cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-native-roots
cargo check -p fe2o3-amqp-ws --no-default-features --features rustls-tls-webpki-roots
cargo check -p fe2o3-amqp-ws --all-features
cargo test -p fe2o3-amqp-ws --no-default-features
cargo test -p fe2o3-amqp-ws --all-features
cargo clippy -p fe2o3-amqp-ws --all-features --all-targets -- -D warnings
cargo clippy -p fe2o3-amqp-ws --no-default-features --all-targets -- -D warnings
cargo fmt --all -- --check
cargo doc -p fe2o3-amqp-ws --all-features --no-deps
cargo check --workspace --all-features
```

Every Rust snippet above comes from a scratch crate outside the workspace. Each one builds against this branch. The two library snippets fail against `main` with the E0599 shown at the top.
