### PR TITLE
refactor: Restructure transaction traits and add per-broker integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all -- --deny warnings
+          args: --all --all-features --all-targets -- --deny warnings
 
   # run tests in each crate with cargo-make
   feature_check_and_test:

--- a/examples/owned_txn_posting/src/main.rs
+++ b/examples/owned_txn_posting/src/main.rs
@@ -1,5 +1,5 @@
 use fe2o3_amqp::{
-    transaction::{OwnedTransaction, TransactionDischarge},
+    transaction::{OwnedTransaction, TransactionDischarge, TransactionPosting},
     Connection, Sender, Session,
 };
 

--- a/examples/owned_txn_retirement/src/main.rs
+++ b/examples/owned_txn_retirement/src/main.rs
@@ -1,5 +1,5 @@
 use fe2o3_amqp::{
-    transaction::{TransactionDischarge, TransactionalRetirement, OwnedTransaction},
+    transaction::{TransactionDischarge, TransactionRetirement, OwnedTransaction},
     types::primitives::Value,
     Connection, Delivery, Receiver, Session,
 };

--- a/examples/protocol_test/src/bin/txn_acquire.rs
+++ b/examples/protocol_test/src/bin/txn_acquire.rs
@@ -1,6 +1,6 @@
 use fe2o3_amqp::{
     sasl_profile::SaslProfile,
-    transaction::{Controller, Transaction},
+    transaction::{Controller, Transaction, TransactionAcquisition},
     types::{messaging::Body, primitives::Value},
     Connection, Delivery, Receiver, Session,
 };

--- a/examples/protocol_test/src/bin/txn_control_init.rs
+++ b/examples/protocol_test/src/bin/txn_control_init.rs
@@ -1,5 +1,5 @@
 use fe2o3_amqp::{
-    transaction::{OwnedTransaction, TransactionDischarge, TransactionalRetirement},
+    transaction::{OwnedTransaction, TransactionDischarge, TransactionRetirement},
     types::{definitions::ReceiverSettleMode, messaging::Body, primitives::Value},
     Connection, Delivery, Receiver, Session,
 };

--- a/examples/protocol_test/src/bin/txn_post.rs
+++ b/examples/protocol_test/src/bin/txn_post.rs
@@ -1,6 +1,6 @@
 use fe2o3_amqp::{
     sasl_profile::SaslProfile,
-    transaction::{Controller, Transaction, TransactionDischarge},
+    transaction::{Controller, Transaction, TransactionDischarge, TransactionPosting},
     Connection, Sender, Session,
 };
 use tokio::net::TcpStream;

--- a/examples/protocol_test/src/bin/txn_retire.rs
+++ b/examples/protocol_test/src/bin/txn_retire.rs
@@ -1,6 +1,6 @@
 use fe2o3_amqp::{
     sasl_profile::SaslProfile,
-    transaction::{Controller, Transaction, TransactionDischarge, TransactionalRetirement},
+    transaction::{Controller, Transaction, TransactionDischarge, TransactionRetirement},
     types::{messaging::Body, primitives::Value},
     Connection, Delivery, Receiver, Session,
 };

--- a/examples/service_bus/src/bin/queue_dlq.rs
+++ b/examples/service_bus/src/bin/queue_dlq.rs
@@ -3,7 +3,7 @@
 use dotenv::dotenv;
 use fe2o3_amqp::connection::ConnectionHandle;
 use fe2o3_amqp::transaction::TransactionDischarge;
-use fe2o3_amqp::transaction::TransactionalRetirement;
+use fe2o3_amqp::transaction::TransactionRetirement;
 use fe2o3_amqp::transaction::{Controller, Transaction};
 use fe2o3_amqp::types::messaging::Body;
 use fe2o3_amqp::types::messaging::Message;

--- a/examples/txn_posting/src/main.rs
+++ b/examples/txn_posting/src/main.rs
@@ -1,5 +1,5 @@
 use fe2o3_amqp::{
-    transaction::{Controller, Transaction, TransactionDischarge},
+    transaction::{Controller, Transaction, TransactionDischarge, TransactionPosting},
     Connection, Sender, Session,
 };
 

--- a/examples/txn_retirement/src/main.rs
+++ b/examples/txn_retirement/src/main.rs
@@ -1,5 +1,5 @@
 use fe2o3_amqp::{
-    transaction::{Controller, Transaction, TransactionDischarge, TransactionalRetirement},
+    transaction::{Controller, Transaction, TransactionDischarge, TransactionRetirement},
     types::primitives::Value,
     Connection, Delivery, Receiver, Session,
 };

--- a/fe2o3-amqp-types/src/messaging/format/mod.rs
+++ b/fe2o3-amqp-types/src/messaging/format/mod.rs
@@ -336,7 +336,7 @@ mod tests {
             delivery_count: 0,
         };
         let serialized = to_vec(&header).unwrap();
-        println!("{:x?}", &serialized);
+        println!("{:x?}", serialized);
     }
 
     #[test]

--- a/fe2o3-amqp-types/src/performatives/end.rs
+++ b/fe2o3-amqp-types/src/performatives/end.rs
@@ -26,7 +26,7 @@ mod tests {
     fn test_serde_end() {
         let end = End { error: None };
         let buf = to_vec(&end).unwrap();
-        println!("{:x?}", &buf);
+        println!("{:x?}", buf);
         let end2: End = from_slice(&buf).unwrap();
         println!("{:?}", end2);
     }

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -2,14 +2,22 @@
 
 ## Unreleased
 
-1. **Breaking**: The `post*` and `acquire` methods of [`Transaction`] and
-   [`OwnedTransaction`] moved from inherent methods onto the new
-   [`TransactionalPosting`] and [`TransactionalAcquisition`] traits, which must now
-   be imported to call them. The `batchable` field of the `Transfer` performative is
-   now set consistently: `post_batchable`/`post_batchable_ref` set it to `true`,
-   while `post`/`post_ref` leave it `false`. Previously `Transaction`'s batchable
-   variants passed `false`, and `OwnedTransaction`'s `post` duplicated the send logic
-   while `Transaction`'s `post` delegated to `post_batchable`.
+1. **Breaking**: Added the [`TransactionBase`] trait, which provides the `txn_id()`
+   accessor for transactions.
+2. **Breaking**: Renamed [`TransactionalPosting`] to [`TransactionPosting`],
+   [`TransactionalRetirement`] to [`TransactionRetirement`], and
+   [`TransactionalAcquisition`] to [`TransactionAcquisition`] for consistent naming.
+   All three now extend [`TransactionBase`] and provide default implementations for
+   the `post*`, `retire`, and `acquire` methods of both [`Transaction`] and
+   [`OwnedTransaction`].
+3. **Breaking**: [`TransactionExt`] is now the aggregate trait of all transaction
+   traits ([`TransactionBase`], [`TransactionDischarge`], [`TransactionPosting`],
+   [`TransactionAcquisition`], and [`TransactionRetirement`]).
+4. The `batchable` field of the `Transfer` performative is now set consistently:
+   `post_batchable`/`post_batchable_ref` set it to `true`, while `post`/`post_ref`
+   leave it `false`. Previously `Transaction`'s batchable variants passed `false`,
+   and `OwnedTransaction`'s `post` duplicated the send logic while `Transaction`'s
+   `post` delegated to `post_batchable`.
 
 ## 0.16.2
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased
+
+1. **Breaking**: The `post*` and `acquire` methods of [`Transaction`] and
+   [`OwnedTransaction`] moved from inherent methods onto the new
+   [`TransactionalPosting`] and [`TransactionalAcquisition`] traits, which must now
+   be imported to call them. The `batchable` field of the `Transfer` performative is
+   now set consistently: `post_batchable`/`post_batchable_ref` set it to `true`,
+   while `post`/`post_ref` leave it `false`. Previously `Transaction`'s batchable
+   variants passed `false`, and `OwnedTransaction`'s `post` duplicated the send logic
+   while `Transaction`'s `post` delegated to `post_batchable`.
+
 ## 0.16.2
 
 1. Updated `sha2` to `0.11`, `hmac` and `pbkdf2` to `0.13`, and replaced the deprecated

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -18,6 +18,11 @@
    leave it `false`. Previously `Transaction`'s batchable variants passed `false`,
    and `OwnedTransaction`'s `post` duplicated the send logic while `Transaction`'s
    `post` delegated to `post_batchable`.
+5. Implemented `From<IllegalLinkStateError>` for [`OwnedDischargeError`], which
+   enables [`TxnAcquisition`]'s `commit` and `rollback` methods with
+   [`OwnedTransaction`].
+6. [`OwnedTransaction`] is now rolled back when dropped without being discharged,
+   matching the behavior of [`Transaction`].
 
 ## 0.16.2
 

--- a/fe2o3-amqp/Makefile.toml
+++ b/fe2o3-amqp/Makefile.toml
@@ -1,5 +1,10 @@
 extend = "../Makefile.toml"
 
+# Override the built-in `test` task so that the transaction integration tests,
+# which are gated behind the `transaction` feature, also run in CI.
+[tasks.test]
+args = ["test", "--features", "transaction"]
+
 [tasks.feature_check]
 dependencies = [
   "check_feature_acceptor",

--- a/fe2o3-amqp/Makefile.toml
+++ b/fe2o3-amqp/Makefile.toml
@@ -1,9 +1,10 @@
 extend = "../Makefile.toml"
 
-# Override the built-in `test` task so that the transaction integration tests,
-# which are gated behind the `transaction` feature, also run in CI.
+# Override the built-in `test` task so that all feature-gated tests (including the
+# transaction integration tests, which are gated behind the `transaction` feature)
+# run in CI.
 [tasks.test]
-args = ["test", "--features", "transaction"]
+args = ["test", "--all-features"]
 
 [tasks.feature_check]
 dependencies = [

--- a/fe2o3-amqp/src/acceptor/local_receiver_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_receiver_link.rs
@@ -225,22 +225,14 @@ where
             (Some(attach_error), _) | (_, Err(attach_error)) => {
                 // Complete attach anyway
                 link.send_attach(&outgoing, &control, false).await?;
-                match attach_error {
-                    // ReceiverAttachError::SndSettleModeNotSupported
-                    ReceiverAttachError::RcvSettleModeNotSupported => {
-                        // FIXME: Ths initiating end should be responsible for checking whether the mode is supported
-                    }
-                    _ => {
-                        return Err(link
-                            .handle_attach_error(
-                                attach_error,
-                                &outgoing,
-                                &mut incoming_rx,
-                                &control,
-                            )
-                            .await)
-                    }
-                }
+                return Err(link
+                    .handle_attach_error(
+                        attach_error,
+                        &outgoing,
+                        &mut incoming_rx,
+                        &control,
+                    )
+                    .await)
             }
             _ => link.send_attach(&outgoing, &control, false).await?,
         }

--- a/fe2o3-amqp/src/acceptor/local_sender_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_sender_link.rs
@@ -173,8 +173,7 @@ where
                 // Complete attach then detach should any error happen
                 link.send_attach(&outgoing, &session.control, false).await?;
                 match attach_error {
-                    SenderAttachError::SndSettleModeNotSupported
-                    | SenderAttachError::RcvSettleModeNotSupported => {
+                    SenderAttachError::SndSettleModeNotSupported => {
                         // FIXME: The initiating side is responsible for checking whether the desired modes are supported?
                     }
                     _ => {

--- a/fe2o3-amqp/src/auth/scram/mod.rs
+++ b/fe2o3-amqp/src/auth/scram/mod.rs
@@ -111,7 +111,7 @@ impl ScramVersion {
         bytes.put_slice(nonce);
 
         let client_first_message = bytes.freeze();
-        let gs2_header_len = GS2_HEADER.as_bytes().len();
+        let gs2_header_len = GS2_HEADER.len();
         let client_first_message_bare = client_first_message.slice(gs2_header_len..);
         (client_first_message, client_first_message_bare)
     }
@@ -432,7 +432,7 @@ mod tests {
             &self.scram_version
         }
 
-        fn get_stored_password(&self, username: &str) -> Option<StoredPassword> {
+        fn get_stored_password(&self, username: &str) -> Option<StoredPassword<'_>> {
             if username == self.username {
                 Some(StoredPassword {
                     salt: &self.salt,

--- a/fe2o3-amqp/src/auth/scram/server.rs
+++ b/fe2o3-amqp/src/auth/scram/server.rs
@@ -93,7 +93,7 @@ impl ScramVersion {
             .and_then(|s| s.strip_prefix(NONCE_KEY))
             .ok_or(ServerScramErrorKind::CannotParseClientFinalMessage)?;
         if nonce.as_bytes() != client_server_nonce {
-            return Err(ServerScramErrorKind::IncorrectClientFinalNonce)?;
+            return Err(ServerScramErrorKind::IncorrectClientFinalNonce);
         }
 
         let client_proof = parts

--- a/fe2o3-amqp/src/auth/scram/server.rs
+++ b/fe2o3-amqp/src/auth/scram/server.rs
@@ -104,7 +104,7 @@ impl ScramVersion {
         let without_proof_message_len =
             client_final.len() - (client_proof.len() + PROOF_KEY.len() + 1);
         let client_final_message_without_proof =
-            &client_final[0..without_proof_message_len].as_bytes();
+            &client_final.as_bytes()[0..without_proof_message_len];
 
         let auth_message = auth_message(
             client_first_message_bare,

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -123,7 +123,7 @@ pub(crate) trait SenderLink: Link + LinkExt {
 
     /// Send message with delivery tag that is obtained by consuming a link credit
     async fn send_payload_with_transfer(
-        &mut self,
+        &self,
         writer: &mpsc::Sender<LinkFrame>,
         message_format: MessageFormat,
         transfer: Transfer,

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -72,19 +72,25 @@ pub enum SenderAttachError {
     #[error("Control link is not implemented without enabling the `transaction` feature")]
     CoordinatorIsNotImplemented,
 
-    /// When set at the sender this indicates the actual settlement mode in use.
+    /// The sender requested a definite settlement mode (`settled` or `unsettled`)
+    /// that conflicts with the receiver's declared *desired* settlement mode in
+    /// the attach response.
     ///
-    /// The sender SHOULD respect the receiver’s desired settlement mode ***if
-    /// the receiver initiates*** the attach exchange and the sender supports the desired mode
-    #[error("When set at the sender this indicates the actual settlement mode in use")]
+    /// The `snd-settle-mode` field in the attach response from the receiver only
+    /// expresses the receiver's desired settlement mode for the sender. When the
+    /// sender initiates the attach, the sender's own choice is the settlement
+    /// mode in use, and the receiver SHOULD respect it. A response of `mixed` is
+    /// tolerated regardless of the sender's choice, so this error is only
+    /// produced when neither side declares `mixed` and the two definite values
+    /// differ, e.g. the sender requests `settled` while the receiver responds
+    /// `unsettled` (or vice versa). Such a conflict signals a receiver that
+    /// expects settlement behavior the sender will not provide, so the attach
+    /// is rejected with this error instead of risking broken settlement at
+    /// delivery time.
+    #[error(
+        "The requested snd-settle-mode conflicts with the remote peer's desired settlement mode"
+    )]
     SndSettleModeNotSupported,
-
-    /// "When set at the receiver this indicates the actual settlement mode in use"
-    ///
-    /// The receiver SHOULD respect the sender’s desired settlement mode ***if
-    /// the sender initiates*** the attach exchange and the receiver supports the desired mode
-    #[error("The desried ReceiverSettleMode is not supported by the remote peer")]
-    RcvSettleModeNotSupported,
 
     /// When set to true by the receiving link endpoint this field indicates creation of a
     /// dynamically created node. In this case the address field will contain the address of the
@@ -233,13 +239,6 @@ pub enum ReceiverAttachError {
     // /// the receiver initiates*** the attach exchange and the sender supports the desired mode
     // #[error("When set at the sender this indicates the actual settlement mode in use")]
     // SndSettleModeNotSupported,
-    /// "When set at the receiver this indicates the actual settlement mode in use"
-    ///
-    /// The receiver SHOULD respect the sender’s desired settlement mode ***if
-    /// the sender initiates*** the attach exchange and the receiver supports the desired mode
-    #[error("The desried ReceiverSettleMode is not supported by the remote peer")]
-    RcvSettleModeNotSupported,
-
     /// When dynamic is set to true by the sending link endpoint, this field constitutes a request
     /// for the receiving peer to dynamically create a node at the target. In this case the address
     /// field MUST NOT be set.

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -632,14 +632,13 @@ impl LinkRelay<OutputHandle> {
                 #[cfg(feature = "transaction")]
                 {
                     use serde_amqp::Value;
-                    match flow.properties.as_ref().and_then(|m| m.get(TXN_ID_KEY)) {
-                        Some(Value::Binary(txn_id)) => {
-                            let frame = LinkFrame::Acquisition(txn_id.clone());
-                            tx.send(frame)
-                                .await
-                                .map_err(|_| LinkRelayError::UnattachedHandle)?;
-                        }
-                        Some(_) | None => {}
+                    if let Some(Value::Binary(txn_id)) =
+                        flow.properties.as_ref().and_then(|m| m.get(TXN_ID_KEY))
+                    {
+                        let frame = LinkFrame::Acquisition(txn_id.clone());
+                        tx.send(frame)
+                            .await
+                            .map_err(|_| LinkRelayError::UnattachedHandle)?;
                     }
                 }
 

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -678,10 +678,12 @@ where
         // delivery is settled
         self.snd_settle_mode = remote_attach.snd_settle_mode;
 
-        // When set at the receiver this indicates the actual settlement mode in use
-        if self.rcv_settle_mode != remote_attach.rcv_settle_mode {
-            return Err(ReceiverAttachError::RcvSettleModeNotSupported);
-        }
+        // The `rcv-settle-mode` field in the attach response from the sender only
+        // expresses the sender's *desired* settlement mode for the receiver ("when set
+        // at the sender this indicates the desired value for the settlement mode at the
+        // receiver"). Since the receiver initiated the attach, its own choice governs,
+        // so no validation is performed here; the local `rcv_settle_mode` is used at
+        // delivery time (falling back to the per-transfer value set by the sender).
 
         // The delivery-count is initialized by the sender when a link endpoint is
         // created, and is incremented whenever a message is sent
@@ -869,8 +871,7 @@ where
             }
 
             // ReceiverAttachError::SndSettleModeNotSupported
-            ReceiverAttachError::RcvSettleModeNotSupported
-            | ReceiverAttachError::IncomingSourceIsNone => {
+            ReceiverAttachError::IncomingSourceIsNone => {
                 // Just send detach immediately
                 let err = self
                     .send_detach(writer, true, None)

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -557,15 +557,18 @@ where
         }
         self.target = target;
 
-        // The sender SHOULD respect the receiver’s desired settlement mode if the receiver
+        // The sender SHOULD respect the receiver's desired settlement mode if the receiver
         // initiates the attach exchange and the sender supports the desired mode
         if self.rcv_settle_mode != remote_attach.rcv_settle_mode {
             return Err(SenderAttachError::RcvSettleModeNotSupported);
         }
 
-        if self.snd_settle_mode != remote_attach.snd_settle_mode {
-            return Err(SenderAttachError::SndSettleModeNotSupported);
-        }
+        // The `snd-settle-mode` field in the attach response from the receiver only
+        // expresses the receiver's *desired* settlement mode for the sender. When the
+        // sender initiates the attach, the sender's own choice is the settlement mode in
+        // use and the receiver SHOULD respect it, failing the attach if it cannot. Some
+        // brokers (e.g. Qpid Broker-J and ActiveMQ Artemis) always respond with their
+        // default `mixed` regardless, so a differing value is not treated as an error here.
 
         self.max_message_size =
             get_max_message_size(self.max_message_size, remote_attach.max_message_size);

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -18,7 +18,7 @@ where
     ///
     /// This is cancel safe because all internal `.await` are cancel safe
     pub(crate) async fn send_transfer_without_modifying_unsettled_map(
-        &mut self,
+        &self,
         writer: &mpsc::Sender<LinkFrame>,
         mut transfer: Transfer,
         mut payload: Payload,
@@ -213,7 +213,7 @@ where
     ///
     /// This is cancel safe because all internal `.await` are cancel safe
     async fn send_payload_with_transfer(
-        &mut self,
+        &self,
         writer: &mpsc::Sender<LinkFrame>,
         message_format: MessageFormat,
         transfer: Transfer,

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -578,12 +578,11 @@ where
         // A definite conflict (neither side is `mixed`) is still treated as an error
         // because it signals a receiver that expects a settlement behavior the sender
         // will not provide; a `mixed` response is tolerated either way.
-        match (&self.snd_settle_mode, &remote_attach.snd_settle_mode) {
-            (SenderSettleMode::Settled, SenderSettleMode::Unsettled)
-            | (SenderSettleMode::Unsettled, SenderSettleMode::Settled) => {
-                return Err(SenderAttachError::SndSettleModeNotSupported);
-            }
-            _ => {}
+        if let (SenderSettleMode::Settled, SenderSettleMode::Unsettled)
+        | (SenderSettleMode::Unsettled, SenderSettleMode::Settled) =
+            (&self.snd_settle_mode, &remote_attach.snd_settle_mode)
+        {
+            return Err(SenderAttachError::SndSettleModeNotSupported);
         }
 
         self.max_message_size =

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -557,18 +557,34 @@ where
         }
         self.target = target;
 
-        // The sender SHOULD respect the receiver's desired settlement mode if the receiver
-        // initiates the attach exchange and the sender supports the desired mode
-        if self.rcv_settle_mode != remote_attach.rcv_settle_mode {
-            return Err(SenderAttachError::RcvSettleModeNotSupported);
-        }
+        // The `rcv-settle-mode` field in the attach response from the receiver is the
+        // receiver's *actual* settlement mode in use ("when set at the receiver this
+        // indicates the actual settlement mode in use"). The sender must adapt its
+        // settlement handshake accordingly: with `second`, the receiver settles only
+        // after receiving the sender's confirming disposition. The session already
+        // propagates the actual mode to the link relay (`SessionInner::on_incoming_attach`),
+        // which drives the confirming echo at delivery time, so no strict validation
+        // is needed here. The local value is still updated with the receiver's actual
+        // mode so that it reflects the negotiated state (e.g. on reattach and through
+        // the `rcv_settle_mode` accessor), mirroring how the receiver side records the
+        // sender's actual `snd-settle-mode`.
+        self.rcv_settle_mode = remote_attach.rcv_settle_mode;
 
         // The `snd-settle-mode` field in the attach response from the receiver only
         // expresses the receiver's *desired* settlement mode for the sender. When the
         // sender initiates the attach, the sender's own choice is the settlement mode in
-        // use and the receiver SHOULD respect it, failing the attach if it cannot. Some
-        // brokers (e.g. Qpid Broker-J and ActiveMQ Artemis) always respond with their
-        // default `mixed` regardless, so a differing value is not treated as an error here.
+        // use and the receiver SHOULD respect it, failing the attach if it cannot.
+        //
+        // A definite conflict (neither side is `mixed`) is still treated as an error
+        // because it signals a receiver that expects a settlement behavior the sender
+        // will not provide; a `mixed` response is tolerated either way.
+        match (&self.snd_settle_mode, &remote_attach.snd_settle_mode) {
+            (SenderSettleMode::Settled, SenderSettleMode::Unsettled)
+            | (SenderSettleMode::Unsettled, SenderSettleMode::Settled) => {
+                return Err(SenderAttachError::SndSettleModeNotSupported);
+            }
+            _ => {}
+        }
 
         self.max_message_size =
             get_max_message_size(self.max_message_size, remote_attach.max_message_size);
@@ -719,7 +735,6 @@ where
             }
 
             SenderAttachError::SndSettleModeNotSupported
-            | SenderAttachError::RcvSettleModeNotSupported
             | SenderAttachError::IncomingTargetIsNone => {
                 // Just send detach immediately
                 let err = self

--- a/fe2o3-amqp/src/link/state.rs
+++ b/fe2o3-amqp/src/link/state.rs
@@ -312,7 +312,7 @@ impl Consume for SenderFlowState {
     /// `Notify` itself is not cancel safe in the way that it would lose its place in the queue.
     /// However, since there can be only one consumer for a producer, losing the place in the queue
     /// does not have any effect. Thus, this IS cancel safe.
-    async fn consume(&mut self, item: Self::Item) -> Self::Outcome {
+    async fn consume(&self, item: Self::Item) -> Self::Outcome {
         loop {
             match consume_link_credit(&self.state().lock, item) {
                 Ok(outcome) => return outcome,
@@ -326,7 +326,7 @@ cfg_transaction! {
     impl crate::util::TryConsume for SenderFlowState {
         type Error = super::error::SenderTryConsumeError;
 
-        fn try_consume(&mut self, item: Self::Item) -> Result<Self::Outcome, Self::Error> {
+        fn try_consume(&self, item: Self::Item) -> Result<Self::Outcome, Self::Error> {
             let mut state = self
                 .state()
                 .lock
@@ -414,7 +414,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sender_flow_state_producer_and_consumer() {
-        let (mut producer, mut consumer) = create_sender_flow_state_producer_and_consumer();
+        let (mut producer, consumer) = create_sender_flow_state_producer_and_consumer();
 
         // .await on notify
         assert_pending!(consumer.consume(1));
@@ -440,7 +440,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawned_flow_state_producer_and_consumer() {
-        let (mut producer, mut consumer) = create_sender_flow_state_producer_and_consumer();
+        let (mut producer, consumer) = create_sender_flow_state_producer_and_consumer();
 
         let handle = tokio::spawn(async move { consumer.consume(1).await });
         let mut fut = Box::pin(handle);
@@ -460,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_consume_fut_before_produce() {
-        let (mut producer, mut consumer) = create_sender_flow_state_producer_and_consumer();
+        let (mut producer, consumer) = create_sender_flow_state_producer_and_consumer();
 
         // Drop before notify
         let fut = consumer.consume(1);
@@ -486,7 +486,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_consume_fut_after_produce() {
-        let (mut producer, mut consumer) = create_sender_flow_state_producer_and_consumer();
+        let (mut producer, consumer) = create_sender_flow_state_producer_and_consumer();
 
         // Drop before notify
         let fut = consumer.consume(1);

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -750,7 +750,12 @@ impl endpoint::Session for Session {
                 // close handshake (e.g. a `Sender`/`Receiver` that was simply dropped).
                 // In that case the frame cannot be forwarded and the detach reply is
                 // discarded; this must not tear down the session.
-                let _ = link.on_incoming_detach(detach).await;
+                if let Err(error) = link.on_incoming_detach(detach).await {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(error = ?error);
+                    #[cfg(feature = "log")]
+                    log::error!("error = {:?}", error);
+                }
                 Ok(())
             }
             None => Err(SessionInnerError::UnattachedHandle),

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -745,10 +745,14 @@ impl endpoint::Session for Session {
             .link_by_input_handle
             .remove(&InputHandle::from(detach.handle.clone()))
         {
-            Some(mut link) => link
-                .on_incoming_detach(detach)
-                .await
-                .map_err(|_| SessionInnerError::UnattachedHandle),
+            Some(mut link) => {
+                // The link endpoint may already have been dropped without an explicit
+                // close handshake (e.g. a `Sender`/`Receiver` that was simply dropped).
+                // In that case the frame cannot be forwarded and the detach reply is
+                // discarded; this must not tear down the session.
+                let _ = link.on_incoming_detach(detach).await;
+                Ok(())
+            }
             None => Err(SessionInnerError::UnattachedHandle),
         }
     }

--- a/fe2o3-amqp/src/transaction/acquisition.rs
+++ b/fe2o3-amqp/src/transaction/acquisition.rs
@@ -12,7 +12,7 @@ use crate::{
     Delivery, Receiver,
 };
 
-use super::{TransactionDischarge, TransactionExt, TransactionalRetirement, TXN_ID_KEY};
+use super::{TransactionBase, TransactionDischarge, TransactionRetirement, TXN_ID_KEY};
 
 /// 4.4.3 Transactional Acquisition
 ///
@@ -23,7 +23,7 @@ use super::{TransactionDischarge, TransactionExt, TransactionalRetirement, TXN_I
 #[derive(Debug)]
 pub struct TxnAcquisition<'r, Txn>
 where
-    Txn: TransactionExt,
+    Txn: TransactionBase + TransactionDischarge + TransactionRetirement,
 {
     /// The transaction context of this acquisition
     pub(super) txn: Txn,
@@ -34,11 +34,7 @@ where
 
 impl<'r, Txn> TxnAcquisition<'r, Txn>
 where
-    Txn: TransactionExt
-        + TransactionDischarge
-        + TransactionalRetirement
-        + Send
-        + Sync,
+    Txn: TransactionBase + TransactionDischarge + TransactionRetirement + Send + Sync,
     <Txn as TransactionDischarge>::Error: From<FlowError>,
 {
     /// Get an immutable reference to the underlying transaction
@@ -104,7 +100,7 @@ where
     }
 
     /// Accept the message
-    pub async fn accept<T>(&mut self, delivery: &Delivery<T>) -> Result<(), <Txn as TransactionalRetirement>::RetireError>
+    pub async fn accept<T>(&mut self, delivery: &Delivery<T>) -> Result<(), <Txn as TransactionRetirement>::RetireError>
     where
         T: Send + Sync,
     {
@@ -116,7 +112,7 @@ where
         &mut self,
         delivery: &Delivery<T>,
         error: impl Into<Option<definitions::Error>>,
-    ) -> Result<(), <Txn as TransactionalRetirement>::RetireError>
+    ) -> Result<(), <Txn as TransactionRetirement>::RetireError>
     where
         T: Send + Sync,
     {
@@ -124,7 +120,7 @@ where
     }
 
     /// Release the message
-    pub async fn release<T>(&mut self, delivery: &Delivery<T>) -> Result<(), <Txn as TransactionalRetirement>::RetireError>
+    pub async fn release<T>(&mut self, delivery: &Delivery<T>) -> Result<(), <Txn as TransactionRetirement>::RetireError>
     where
         T: Send + Sync,
     {
@@ -136,7 +132,7 @@ where
         &mut self,
         delivery: &Delivery<T>,
         modified: Modified,
-    ) -> Result<(), <Txn as TransactionalRetirement>::RetireError>
+    ) -> Result<(), <Txn as TransactionRetirement>::RetireError>
     where
         T: Send + Sync,
     {
@@ -146,7 +142,7 @@ where
 
 impl<'r, T> Drop for TxnAcquisition<'r, T>
 where
-    T: TransactionExt,
+    T: TransactionBase + TransactionDischarge + TransactionRetirement,
 {
     fn drop(&mut self) {
         if !self.txn.is_discharged() {

--- a/fe2o3-amqp/src/transaction/error.rs
+++ b/fe2o3-amqp/src/transaction/error.rs
@@ -187,6 +187,12 @@ impl From<DetachError> for OwnedDischargeError {
     }
 }
 
+impl From<IllegalLinkStateError> for OwnedDischargeError {
+    fn from(value: IllegalLinkStateError) -> Self {
+        Self::ControllerSendError(value.into())
+    }
+}
+
 /// Error associated with sending a txn message
 ///
 /// It is similar to [`SendError`] but differs in how transactional states

--- a/fe2o3-amqp/src/transaction/manager.rs
+++ b/fe2o3-amqp/src/transaction/manager.rs
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn test_recover_key_from_txn_id() {
         let uuid = Uuid::new_v4();
-        let txn_id = TransactionId::from(uuid.clone().into_bytes());
+        let txn_id = TransactionId::from(uuid.into_bytes());
         let uuid2 = Uuid::from_slice(txn_id.as_ref()).unwrap();
         assert_eq!(uuid, uuid2);
     }

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -78,7 +78,6 @@ cfg_acceptor! {
 }
 
 /// Trait for generics for TxnAcquisition
-
 pub trait TransactionDischarge: Sized {
     /// Errors with discharging
     type Error: Send;
@@ -117,7 +116,6 @@ pub trait TransactionDischarge: Sized {
 }
 
 /// Retiring a transaction
-
 pub trait TransactionalRetirement {
     /// Error with retirement
     type RetireError: Send;

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -36,6 +36,7 @@ use crate::{
     endpoint::ReceiverLink,
     link::{
         delivery::{DeliveryFut, DeliveryInfo, UnsettledMessage},
+        sender::SenderInner,
         DispositionError, FlowError, LinkFrame,
     },
     util::TryConsume,
@@ -66,7 +67,9 @@ use serde_amqp::{ser::Serializer, Value};
 
 mod acquisition;
 pub use acquisition::*;
-use tokio::sync::{mpsc::error::TryRecvError, oneshot};
+use tokio::sync::{mpsc::error::TryRecvError, oneshot, Mutex};
+
+use controller::ControlLink;
 
 mod owned;
 pub use owned::*;
@@ -572,172 +575,172 @@ impl TransactionExt for Transaction<'_> {}
 impl<'t> Drop for Transaction<'t> {
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     fn drop(&mut self) {
-        const TRIALS_BEFORE_GIVE_UP: u64 = 20;
-
         if !self.is_discharged {
-            // rollback
-            let discharge = Discharge {
-                txn_id: self.declared.txn_id.clone(),
-                fail: Some(true),
-            };
-            // As with the declare message, it is an error if the sender sends the transfer pre-settled.
-            let message = Message::builder().value(discharge).build();
-            let mut payload = BytesMut::new();
-            let mut serializer = Serializer::from((&mut payload).writer());
-            if let Err(_error) = Serializable(message).serialize(&mut serializer) {
+            rollback_on_drop(&self.controller.inner, &self.declared.txn_id);
+        }
+    }
+}
+
+/// Roll back an undischarged transaction when it is dropped.
+///
+/// This is a best-effort synchronous operation: the discharge transfer is serialized and
+/// sent over the control link without `.await` (which is not possible in `Drop`), retrying
+/// the lock acquisition and the outcome wait for a limited number of trials.
+pub(crate) fn rollback_on_drop(
+    controller: &Mutex<SenderInner<ControlLink>>,
+    txn_id: &TransactionId,
+) {
+    const TRIALS_BEFORE_GIVE_UP: u64 = 20;
+
+    let discharge = Discharge {
+        txn_id: txn_id.clone(),
+        fail: Some(true),
+    };
+    // As with the declare message, it is an error if the sender sends the transfer pre-settled.
+    let message = Message::builder().value(discharge).build();
+    let mut payload = BytesMut::new();
+    let mut serializer = Serializer::from((&mut payload).writer());
+    if let Err(_error) = Serializable(message).serialize(&mut serializer) {
+        #[cfg(feature = "tracing")]
+        tracing::error!(error = ?_error);
+        #[cfg(feature = "log")]
+        log::error!("error = {:?}", _error);
+        return;
+    }
+    let payload = payload.freeze();
+    let payload_copy = payload.clone();
+
+    // TODO: what if lock fails
+    let mut counter = 0;
+    let mut inner = loop {
+        if counter > TRIALS_BEFORE_GIVE_UP {
+            return;
+        }
+        counter += 1;
+
+        match controller.try_lock() {
+            Ok(inner) => break inner,
+            Err(_error) => {
                 #[cfg(feature = "tracing")]
                 tracing::error!(error = ?_error);
                 #[cfg(feature = "log")]
                 log::error!("error = {:?}", _error);
-                return;
+
+                std::thread::sleep(std::time::Duration::from_millis(10 * counter + 1))
             }
-            // let payload = BytesMut::from(payload);
-            let payload = payload.freeze();
-            let payload_copy = payload.clone();
+        }
+    };
 
-            // let mut inner = self.controller.inner.blocking_lock();
-            // TODO: what if lock fails
-            let mut counter = 0;
-            let mut inner = loop {
-                if counter > TRIALS_BEFORE_GIVE_UP {
-                    return;
-                }
-                counter += 1;
-
-                match self.controller.inner.try_lock() {
-                    Ok(inner) => break inner,
-                    Err(_error) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::error!(error = ?_error);
-                        #[cfg(feature = "log")]
-                        log::error!("error = {:?}", _error);
-
-                        std::thread::sleep(std::time::Duration::from_millis(10 * counter + 1))
-                    }
-                }
-            };
-
-            match inner.link.flow_state.try_consume(1) {
-                Ok(_) => {
-                    let input_handle = match inner
-                        .link
-                        .input_handle
-                        .clone()
-                        .ok_or(AmqpError::IllegalState)
-                    {
-                        Ok(handle) => handle,
-                        Err(_error) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!(error = ?_error);
-                            #[cfg(feature = "log")]
-                            log::error!("error = {:?}", _error);
-                            return;
-                        }
-                    };
-                    let handle = match inner.link.output_handle.clone() {
-                        Some(handle) => handle.into(),
-                        None => return,
-                    };
-                    // let tag = self.flow_state.state().delivery_count().await.to_be_bytes();
-                    let tag = match inner.link.flow_state.state().lock.try_read() {
-                        Some(inner) => inner.delivery_count.to_be_bytes(),
-                        None => return,
-                    };
-                    let delivery_tag = DeliveryTag::from(tag);
-
-                    let transfer = Transfer {
-                        handle,
-                        delivery_id: None,
-                        delivery_tag: Some(delivery_tag.clone()),
-                        message_format: Some(MESSAGE_FORMAT),
-                        settled: Some(false),
-                        more: false, // This message should be small enough
-                        rcv_settle_mode: None,
-                        state: None,
-                        resume: false,
-                        aborted: false,
-                        batchable: false,
-                    };
-
-                    // try receive in case of detach
-                    match inner.incoming.try_recv() {
-                        Ok(_) => {
-                            // The only frames that are relayed is detach
-                            return;
-                        }
-                        Err(error) => match error {
-                            TryRecvError::Empty => {}
-                            TryRecvError::Disconnected => return,
-                        },
-                    }
-
-                    // Send out Rollback
-                    let frame = LinkFrame::Transfer {
-                        input_handle,
-                        performative: transfer,
-                        payload,
-                    };
-                    if inner.outgoing.try_send(frame).is_err() {
-                        // Channel is already closed
-                        return;
-                    }
-
-                    // TODO: Wait for accept or not?
-                    // The transfer is sent unsettled and will be
-                    // inserted into
-                    let (tx, mut rx) = oneshot::channel();
-                    let unsettled = UnsettledMessage::new(payload_copy, None, MESSAGE_FORMAT, tx);
-                    {
-                        let mut guard = match inner.link.unsettled.try_write() {
-                            Some(guard) => guard,
-                            None => return,
-                        };
-                        guard
-                            .get_or_insert(OrderedMap::new())
-                            .insert(delivery_tag, unsettled);
-                    }
-                    let mut counter = 0;
-                    loop {
-                        // TODO:: limits?
-                        if counter > TRIALS_BEFORE_GIVE_UP {
-                            return;
-                        }
-                        counter += 1;
-
-                        match rx.try_recv() {
-                            Ok(Some(state)) => match state {
-                                DeliveryState::Accepted(_) => break,
-                                _ => {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::error!(error = ?state);
-                                    #[cfg(feature = "log")]
-                                    log::error!("error = {:?}", state);
-                                    break;
-                                }
-                            },
-                            Ok(None) => {
-                                // #[cfg(feature = "tracing")]
-                                // tracing::error!(error = ?ControllerSendError::IllegalDeliveryState);
-                                // #[cfg(feature = "log")]
-                                // log::error!("error = {:?}", ControllerSendError::IllegalDeliveryState);
-                                std::thread::sleep(std::time::Duration::from_millis(10 * counter + 1));
-                            }
-                            Err(_error) => {
-                                #[cfg(feature = "tracing")]
-                                tracing::error!(error = ?_error);
-                                #[cfg(feature = "log")]
-                                log::error!("error = {:?}", _error);
-                            }
-                        };
-                    }
-                }
+    match inner.link.flow_state.try_consume(1) {
+        Ok(_) => {
+            let input_handle = match inner.link.input_handle.clone().ok_or(AmqpError::IllegalState)
+            {
+                Ok(handle) => handle,
                 Err(_error) => {
                     #[cfg(feature = "tracing")]
                     tracing::error!(error = ?_error);
                     #[cfg(feature = "log")]
                     log::error!("error = {:?}", _error);
+                    return;
                 }
+            };
+            let handle = match inner.link.output_handle.clone() {
+                Some(handle) => handle.into(),
+                None => return,
+            };
+            let tag = match inner.link.flow_state.state().lock.try_read() {
+                Some(inner) => inner.delivery_count.to_be_bytes(),
+                None => return,
+            };
+            let delivery_tag = DeliveryTag::from(tag);
+
+            let transfer = Transfer {
+                handle,
+                delivery_id: None,
+                delivery_tag: Some(delivery_tag.clone()),
+                message_format: Some(MESSAGE_FORMAT),
+                settled: Some(false),
+                more: false, // This message should be small enough
+                rcv_settle_mode: None,
+                state: None,
+                resume: false,
+                aborted: false,
+                batchable: false,
+            };
+
+            // try receive in case of detach
+            match inner.incoming.try_recv() {
+                Ok(_) => {
+                    // The only frames that are relayed is detach
+                    return;
+                }
+                Err(error) => match error {
+                    TryRecvError::Empty => {}
+                    TryRecvError::Disconnected => return,
+                },
             }
+
+            // Send out Rollback
+            let frame = LinkFrame::Transfer {
+                input_handle,
+                performative: transfer,
+                payload,
+            };
+            if inner.outgoing.try_send(frame).is_err() {
+                // Channel is already closed
+                return;
+            }
+
+            // TODO: Wait for accept or not?
+            // The transfer is sent unsettled and will be
+            // inserted into
+            let (tx, mut rx) = oneshot::channel();
+            let unsettled = UnsettledMessage::new(payload_copy, None, MESSAGE_FORMAT, tx);
+            {
+                let mut guard = match inner.link.unsettled.try_write() {
+                    Some(guard) => guard,
+                    None => return,
+                };
+                guard
+                    .get_or_insert(OrderedMap::new())
+                    .insert(delivery_tag, unsettled);
+            }
+            let mut counter = 0;
+            loop {
+                // TODO:: limits?
+                if counter > TRIALS_BEFORE_GIVE_UP {
+                    return;
+                }
+                counter += 1;
+
+                match rx.try_recv() {
+                    Ok(Some(state)) => match state {
+                        DeliveryState::Accepted(_) => break,
+                        _ => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!(error = ?state);
+                            #[cfg(feature = "log")]
+                            log::error!("error = {:?}", state);
+                            break;
+                        }
+                    },
+                    Ok(None) => {
+                        std::thread::sleep(std::time::Duration::from_millis(10 * counter + 1));
+                    }
+                    Err(_error) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!(error = ?_error);
+                        #[cfg(feature = "log")]
+                        log::error!("error = {:?}", _error);
+                    }
+                };
+            }
+        }
+        Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(error = ?_error);
+            #[cfg(feature = "log")]
+            log::error!("error = {:?}", _error);
         }
     }
 }

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -7,8 +7,9 @@
 //! # Controller side
 //!
 //! Please see [`Controller`], [`Transaction`], and [`OwnedTransaction`], as well as the
-//! [`TransactionDischarge`], [`TransactionalPosting`], [`TransactionalRetirement`], and
-//! [`TransactionalAcquisition`] traits that define the transactional operations.
+//! [`TransactionBase`], [`TransactionDischarge`], [`TransactionPosting`],
+//! [`TransactionRetirement`], and [`TransactionAcquisition`] traits that define the
+//! transactional operations.
 //!
 //! # Resource side
 //!
@@ -79,6 +80,15 @@ cfg_acceptor! {
     pub mod session;
 }
 
+/// The base trait for transactions, providing access to the transaction identifier.
+///
+/// All other transaction traits extend this trait so that they can access the `txn-id`
+/// of the transaction they operate on.
+pub trait TransactionBase {
+    /// Get the `txn-id` of the transaction
+    fn txn_id(&self) -> &TransactionId;
+}
+
 /// Trait for generics for TxnAcquisition
 pub trait TransactionDischarge: Sized {
     /// Errors with discharging
@@ -118,9 +128,9 @@ pub trait TransactionDischarge: Sized {
 }
 
 /// Retiring a transaction
-pub trait TransactionalRetirement {
+pub trait TransactionRetirement: TransactionBase {
     /// Error with retirement
-    type RetireError: Send;
+    type RetireError: Send + From<DispositionError>;
 
     /// Associate an outcome with a transaction
     ///
@@ -135,7 +145,19 @@ pub trait TransactionalRetirement {
         outcome: Outcome,
     ) -> impl Future<Output = Result<(), Self::RetireError>> + Send
     where
-        T: Into<DeliveryInfo> + Send;
+        T: Into<DeliveryInfo> + Send,
+        Self: Sync,
+    {
+        async move {
+            let txn_state = TransactionalState {
+                txn_id: self.txn_id().clone(),
+                outcome: Some(outcome),
+            };
+            let state = DeliveryState::TransactionalState(txn_state);
+            recver.inner.dispose(delivery, None, state).await?;
+            Ok(())
+        }
+    }
 
     /// Associate an Accepted outcome with a transaction
     fn accept<T>(
@@ -204,10 +226,17 @@ pub trait TransactionalRetirement {
     }
 }
 
-/// Extension trait that also act as a trait bound for TxnAcquisition
-pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
-    /// Get the `txn-id` of the transaction
-    fn txn_id(&self) -> &TransactionId;
+/// The aggregate trait for all transactional operations.
+///
+/// A type that implements this trait supports transactional posting, retirement, acquisition,
+/// and discharging.
+pub trait TransactionExt:
+    TransactionBase
+        + TransactionDischarge
+        + TransactionPosting
+        + TransactionAcquisition
+        + TransactionRetirement
+{
 }
 
 /// Transactional posting (AMQP 1.0 §4.4.4)
@@ -215,7 +244,7 @@ pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
 /// Posting transactional work associates an outgoing transfer with a transaction by setting the
 /// state of the transfer to a `transactional-state` carrying the transaction identifier. The
 /// resource will route the message upon the successful discharge (commit) of the transaction.
-pub trait TransactionalPosting: TransactionExt {
+pub trait TransactionPosting: TransactionBase {
     /// Post a ref of transactional work and wait for the acknowledgement.
     fn post_batchable_ref<T: SerializableBody + Sync>(
         &self,
@@ -344,8 +373,8 @@ where
 /// transactionally, i.e. the deliveries are tagged with a `transactional-state` carrying the
 /// transaction identifier, and are only retired from the resource upon the successful discharge
 /// of the transaction.
-pub trait TransactionalAcquisition:
-    Sized + TransactionExt + TransactionDischarge + TransactionalRetirement + Send + Sync
+pub trait TransactionAcquisition:
+    Sized + TransactionBase + TransactionDischarge + TransactionRetirement + Send + Sync
 {
     /// Acquire a transactional work
     ///
@@ -409,7 +438,7 @@ pub trait TransactionalAcquisition:
 ///
 /// ```rust,no_run
 /// use fe2o3_amqp::transaction::{
-///     Controller, Transaction, TransactionDischarge, TransactionalPosting,
+///     Controller, Transaction, TransactionDischarge, TransactionPosting,
 /// };
 ///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
@@ -436,7 +465,7 @@ pub trait TransactionalAcquisition:
 ///
 /// ```rust,no_run
 /// use fe2o3_amqp::transaction::{
-///     Controller, Transaction, TransactionDischarge, TransactionalRetirement,
+///     Controller, Transaction, TransactionDischarge, TransactionRetirement,
 /// };
 ///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
@@ -461,7 +490,7 @@ pub trait TransactionalAcquisition:
 ///
 /// ```rust,no_run
 /// use fe2o3_amqp::transaction::{
-///     Controller, Transaction, TransactionalAcquisition, TransactionalRetirement,
+///     Controller, Transaction, TransactionAcquisition, TransactionRetirement,
 /// };
 ///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
@@ -508,37 +537,14 @@ impl<'t> TransactionDischarge for Transaction<'t> {
 }
 
 
-impl<'t> TransactionalRetirement for Transaction<'t> {
-    type RetireError = DispositionError;
-
-    /// Associate an outcome with a transaction
-    ///
-    /// The delivery itself need not be associated with the same transaction as the outcome, or
-    /// indeed with any transaction at all. However, the delivery MUST NOT be associated with a
-    /// different non-discharged transaction than the outcome. If this happens then the control link
-    /// MUST be terminated with a transaction-rollback error.
-    async fn retire<T>(
-        &self,
-        recver: &mut Receiver,
-        delivery: T,
-        outcome: Outcome,
-    ) -> Result<(), Self::RetireError>
-    where
-        T: Into<DeliveryInfo> + Send,
-    {
-        let txn_state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: Some(outcome),
-        };
-        let state = DeliveryState::TransactionalState(txn_state);
-        recver.inner.dispose(delivery, None, state).await
-    }
-}
-
-impl<'t> TransactionExt for Transaction<'t> {
+impl TransactionBase for Transaction<'_> {
     fn txn_id(&self) -> &TransactionId {
         &self.declared.txn_id
     }
+}
+
+impl TransactionRetirement for Transaction<'_> {
+    type RetireError = DispositionError;
 }
 
 impl<'t> Transaction<'t> {
@@ -558,9 +564,11 @@ impl<'t> Transaction<'t> {
     }
 }
 
-impl TransactionalPosting for Transaction<'_> {}
+impl TransactionPosting for Transaction<'_> {}
 
-impl TransactionalAcquisition for Transaction<'_> {}
+impl TransactionAcquisition for Transaction<'_> {}
+
+impl TransactionExt for Transaction<'_> {}
 
 impl<'t> Drop for Transaction<'t> {
     #[cfg_attr(feature = "tracing", tracing::instrument)]

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -6,7 +6,9 @@
 //!
 //! # Controller side
 //!
-//! Please see [`Controller`], [`Transaction`], and [`OwnedTransaction`]
+//! Please see [`Controller`], [`Transaction`], and [`OwnedTransaction`], as well as the
+//! [`TransactionDischarge`], [`TransactionalPosting`], [`TransactionalRetirement`], and
+//! [`TransactionalAcquisition`] traits that define the transactional operations.
 //!
 //! # Resource side
 //!
@@ -208,6 +210,191 @@ pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
     fn txn_id(&self) -> &TransactionId;
 }
 
+/// Transactional posting (AMQP 1.0 §4.4.4)
+///
+/// Posting transactional work associates an outgoing transfer with a transaction by setting the
+/// state of the transfer to a `transactional-state` carrying the transaction identifier. The
+/// resource will route the message upon the successful discharge (commit) of the transaction.
+pub trait TransactionalPosting: TransactionExt {
+    /// Post a ref of transactional work and wait for the acknowledgement.
+    fn post_batchable_ref<T: SerializableBody + Sync>(
+        &self,
+        sender: &mut Sender,
+        sendable: &Sendable<T>,
+    ) -> impl Future<Output = Result<DeliveryFut<Result<Outcome, PostError>>, PostError>> + Send
+    where
+        Self: Sync,
+    {
+        async move { post_ref_inner(self.txn_id(), sender, sendable, true).await }
+    }
+
+    /// Post a ref of transactional work
+    fn post_ref<T: SerializableBody + Sync>(
+        &self,
+        sender: &mut Sender,
+        sendable: &Sendable<T>,
+    ) -> impl Future<Output = Result<Outcome, PostError>> + Send
+    where
+        Self: Sync,
+    {
+        async move { post_ref_inner(self.txn_id(), sender, sendable, false).await?.await }
+    }
+
+    /// Post a transactional work without waiting for the acknowledgement.
+    ///
+    /// This will set the `batchable` field of the `Transfer` performative to true.
+    fn post_batchable<T: SerializableBody + Send>(
+        &self,
+        sender: &mut Sender,
+        sendable: impl Into<Sendable<T>>,
+    ) -> impl Future<Output = Result<DeliveryFut<Result<Outcome, PostError>>, PostError>> + Send
+    where
+        Self: Sync,
+    {
+        let sendable = sendable.into();
+        async move { post_inner(self.txn_id(), sender, sendable, true).await }
+    }
+
+    /// Post a transactional work
+    fn post<T: SerializableBody + Send>(
+        &self,
+        sender: &mut Sender,
+        sendable: impl Into<Sendable<T>>,
+    ) -> impl Future<Output = Result<Outcome, PostError>> + Send
+    where
+        Self: Sync,
+    {
+        let sendable = sendable.into();
+        async move {
+            let fut = post_inner(self.txn_id(), sender, sendable, false).await?;
+
+            // On receiving a non-settled delivery associated with a live transaction, the
+            // transactional resource MUST inform the controller of the presumptive terminal
+            // outcome before it can successfully discharge the transaction. That is, the resource
+            // MUST send a disposition performative which covers the posted transfer with the state
+            // of the delivery being a transactional-state with the correct transaction identified,
+            // and a terminal outcome. This informs the controller of the outcome that will be in
+            // effect at the point that the transaction is successfully discharged.
+            fut.await
+        }
+    }
+}
+
+/// Send a transactional posting with the given `batchable` flag.
+///
+/// If the transaction controller wishes to associate an outgoing transfer with a transaction, it
+/// MUST set the state of the transfer with a transactional-state carrying the appropriate
+/// transaction identifier. Note that if the delivery is split across several transfer frames then
+/// all frames MUST be explicitly associated with the same transaction.
+#[inline]
+async fn post_inner<T>(
+    txn_id: &TransactionId,
+    sender: &mut Sender,
+    sendable: Sendable<T>,
+    batchable: bool,
+) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError>
+where
+    T: SerializableBody + Send,
+{
+    let state = TransactionalState {
+        txn_id: txn_id.clone(),
+        outcome: None,
+    };
+    let state = DeliveryState::TransactionalState(state);
+    let settlement = sender
+        .inner
+        .send_with_state::<T, PostError>(sendable, Some(state), batchable)
+        .await?;
+
+    Ok(DeliveryFut::from(settlement))
+}
+
+/// Send a ref of transactional posting with the given `batchable` flag.
+///
+/// If the transaction controller wishes to associate an outgoing transfer with a transaction, it
+/// MUST set the state of the transfer with a transactional-state carrying the appropriate
+/// transaction identifier. Note that if the delivery is split across several transfer frames then
+/// all frames MUST be explicitly associated with the same transaction.
+#[inline]
+async fn post_ref_inner<T>(
+    txn_id: &TransactionId,
+    sender: &mut Sender,
+    sendable: &Sendable<T>,
+    batchable: bool,
+) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError>
+where
+    T: SerializableBody + Sync,
+{
+    let state = TransactionalState {
+        txn_id: txn_id.clone(),
+        outcome: None,
+    };
+    let state = DeliveryState::TransactionalState(state);
+    let settlement = sender
+        .inner
+        .send_ref_with_state::<T, PostError>(sendable, Some(state), batchable)
+        .await?;
+
+    Ok(DeliveryFut::from(settlement))
+}
+
+/// Transactional acquisition (AMQP 1.0 §4.4.3)
+///
+/// Transactionally acquiring work causes the resource to acquire (deliver) messages
+/// transactionally, i.e. the deliveries are tagged with a `transactional-state` carrying the
+/// transaction identifier, and are only retired from the resource upon the successful discharge
+/// of the transaction.
+pub trait TransactionalAcquisition:
+    Sized + TransactionExt + TransactionDischarge + TransactionalRetirement + Send + Sync
+{
+    /// Acquire a transactional work
+    ///
+    /// This will set the `txn-id` property in the link's flow and send a flow frame with the
+    /// given credit. The returned [`TxnAcquisition`] can be used to receive and retire the
+    /// acquired deliveries.
+    fn acquire<'r>(
+        self,
+        recver: &'r mut Receiver,
+        credit: SequenceNo,
+    ) -> impl Future<Output = Result<TxnAcquisition<'r, Self>, FlowError>> + Send {
+        async move {
+            let value = Value::Binary(self.txn_id().clone());
+            {
+                let mut writer = recver.inner.link.flow_state.lock.write();
+                match &mut writer.properties {
+                    Some(fields) => {
+                        if fields.contains_key(TXN_ID_KEY) {
+                            return Err(FlowError::IllegalState);
+                        }
+
+                        fields.insert(Symbol::from(TXN_ID_KEY), value);
+                    }
+                    None => {
+                        let mut fields = Fields::new();
+                        fields.insert(Symbol::from(TXN_ID_KEY), value);
+                    }
+                }
+            }
+
+            match recver
+                .inner
+                .link
+                .send_flow(&recver.inner.outgoing, Some(credit), None, false, false)
+                .await
+            {
+                Ok(_) => Ok(TxnAcquisition { txn: self, recver }),
+                Err(error) => {
+                    let mut writer = recver.inner.link.flow_state.lock.write();
+                    if let Some(fields) = &mut writer.properties {
+                        fields.swap_remove(TXN_ID_KEY);
+                    }
+                    Err(error)
+                }
+            }
+        }
+    }
+}
+
 /// A transaction scope for the client side
 ///
 /// [`Transaction`] holds a reference to a [`Controller`], which thus allow reusing the same
@@ -220,7 +407,11 @@ pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
 ///
 /// ## Transactional posting
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// use fe2o3_amqp::transaction::{
+///     Controller, Transaction, TransactionDischarge, TransactionalPosting,
+/// };
+///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
 /// let mut sender = Sender::attach(&mut session, "rust-sender-link-1", "q1")
 ///     .await
@@ -243,7 +434,11 @@ pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
 ///
 /// ## Transactional retirement
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// use fe2o3_amqp::transaction::{
+///     Controller, Transaction, TransactionDischarge, TransactionalRetirement,
+/// };
+///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
 ///     .await
@@ -264,13 +459,17 @@ pub trait TransactionExt: TransactionDischarge + TransactionalRetirement {
 ///
 /// Please note that this is not supported on the resource side yet.
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// use fe2o3_amqp::transaction::{
+///     Controller, Transaction, TransactionalAcquisition, TransactionalRetirement,
+/// };
+///
 /// let controller = Controller::attach(&mut session, "controller").await.unwrap();
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
 ///     .await
 ///     .unwrap();
 ///
-/// // Transactionally retiring
+/// // Transactionally acquiring
 /// let mut txn = Transaction::declare(&controller, None).await.unwrap();
 /// let mut txn_acq = txn.acquire(&mut receiver, 2).await.unwrap();
 /// let delivery1: Delivery<Value> = txn_acq.recv().await.unwrap();
@@ -357,135 +556,11 @@ impl<'t> Transaction<'t> {
             is_discharged: false,
         })
     }
-
-    /// Post a ref of transactional work and wait for the acknowledgement.
-    pub async fn post_batchable_ref<T: SerializableBody>(
-        &self,
-        sender: &mut Sender,
-        sendable: &Sendable<T>,
-    ) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError> {
-        let state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: None,
-        };
-        let state = DeliveryState::TransactionalState(state);
-        let settlement = sender
-            .inner
-            .send_ref_with_state::<T, PostError>(sendable, Some(state), false)
-            .await?;
-
-        Ok(DeliveryFut::from(settlement))
-    }
-
-    /// Post a ref of transactional work
-    pub async fn post_ref<T: SerializableBody>(
-        &self,
-        sender: &mut Sender,
-        sendable: &Sendable<T>,
-    ) -> Result<Outcome, PostError> {
-        let fut = self.post_batchable_ref(sender, sendable).await?;
-        fut.await
-    }
-
-    /// Post a transactional work without waiting for the acknowledgement.
-    pub async fn post_batchable<T>(
-        &self,
-        sender: &mut Sender,
-        sendable: impl Into<Sendable<T>>,
-    ) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError>
-    where
-        T: SerializableBody,
-    {
-        // If the transaction controller wishes to associate an outgoing transfer with a
-        // transaction, it MUST set the state of the transfer with a transactional-state carrying
-        // the appropriate transaction identifier
-
-        // Note that if delivery is split across several transfer frames then all frames MUST be
-        // explicitly associated with the same transaction.
-        let sendable = sendable.into();
-        let state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: None,
-        };
-        let state = DeliveryState::TransactionalState(state);
-        let settlement = sender
-            .inner
-            .send_with_state::<T, PostError>(sendable, Some(state), false)
-            .await?;
-
-        Ok(DeliveryFut::from(settlement))
-    }
-
-    /// Post a transactional work
-    pub async fn post<T>(
-        &self,
-        sender: &mut Sender,
-        sendable: impl Into<Sendable<T>>,
-    ) -> Result<Outcome, PostError>
-    where
-        T: SerializableBody,
-    {
-        // If the transaction controller wishes to associate an outgoing transfer with a
-        // transaction, it MUST set the state of the transfer with a transactional-state carrying
-        // the appropriate transaction identifier
-
-        // Note that if delivery is split across several transfer frames then all frames MUST be
-        // explicitly associated with the same transaction.
-        let fut = self.post_batchable(sender, sendable).await?;
-
-        // On receiving a non-settled delivery associated with a live transaction, the transactional
-        // resource MUST inform the controller of the presumptive terminal outcome before it can
-        // successfully discharge the transaction. That is, the resource MUST send a disposition
-        // performative which covers the posted transfer with the state of the delivery being a
-        // transactional-state with the correct transaction identified, and a terminal outcome. This
-        // informs the controller of the outcome that will be in effect at the point that the
-        // transaction is successfully discharged.
-        fut.await
-    }
-
-    /// Acquire a transactional work
-    ///
-    /// This will send
-    pub async fn acquire<'r>(
-        self,
-        recver: &'r mut Receiver,
-        credit: SequenceNo,
-    ) -> Result<TxnAcquisition<'r, Transaction<'t>>, FlowError> {
-        let value = Value::Binary(self.declared.txn_id.clone());
-        {
-            let mut writer = recver.inner.link.flow_state.lock.write();
-            match &mut writer.properties {
-                Some(fields) => {
-                    if fields.contains_key(TXN_ID_KEY) {
-                        return Err(FlowError::IllegalState);
-                    }
-
-                    fields.insert(Symbol::from(TXN_ID_KEY), value);
-                }
-                None => {
-                    let mut fields = Fields::new();
-                    fields.insert(Symbol::from(TXN_ID_KEY), value);
-                }
-            }
-        }
-
-        match recver
-            .inner
-            .link
-            .send_flow(&recver.inner.outgoing, Some(credit), None, false, false)
-            .await
-        {
-            Ok(_) => Ok(TxnAcquisition { txn: self, recver }),
-            Err(error) => {
-                let mut writer = recver.inner.link.flow_state.lock.write();
-                if let Some(fields) = &mut writer.properties {
-                    fields.swap_remove(TXN_ID_KEY);
-                }
-                Err(error)
-            }
-        }
-    }
 }
+
+impl TransactionalPosting for Transaction<'_> {}
+
+impl TransactionalAcquisition for Transaction<'_> {}
 
 impl<'t> Drop for Transaction<'t> {
     #[cfg_attr(feature = "tracing", tracing::instrument)]

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -71,9 +71,8 @@ use tokio::sync::{mpsc::error::TryRecvError, oneshot};
 mod owned;
 pub use owned::*;
 
-pub(crate) mod control_link_frame;
-
 cfg_acceptor! {
+    pub(crate) mod control_link_frame;
     pub mod coordinator;
     pub mod frame;
     pub mod manager;

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -436,7 +436,7 @@ pub trait TransactionAcquisition:
 ///
 /// ## Transactional posting
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
 ///     Controller, Transaction, TransactionDischarge, TransactionPosting,
 /// };
@@ -463,7 +463,7 @@ pub trait TransactionAcquisition:
 ///
 /// ## Transactional retirement
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
 ///     Controller, Transaction, TransactionDischarge, TransactionRetirement,
 /// };
@@ -488,7 +488,7 @@ pub trait TransactionAcquisition:
 ///
 /// Please note that this is not supported on the resource side yet.
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
 ///     Controller, Transaction, TransactionAcquisition, TransactionRetirement,
 /// };

--- a/fe2o3-amqp/src/transaction/owned.rs
+++ b/fe2o3-amqp/src/transaction/owned.rs
@@ -2,26 +2,20 @@
 
 
 use fe2o3_amqp_types::{
-    definitions::{Fields, SequenceNo},
-    messaging::{DeliveryState, Outcome, SerializableBody},
-    primitives::Symbol,
+    messaging::{DeliveryState, Outcome},
     transaction::{Declared, TransactionId, TransactionalState},
 };
-use serde_amqp::Value;
 
 use crate::{
-    endpoint::ReceiverLink,
-    link::{
-        delivery::{DeliveryFut, DeliveryInfo},
-        DispositionError, FlowError,
-    },
+    link::{delivery::DeliveryInfo, DispositionError},
     session::SessionHandle,
-    Receiver, Sendable, Sender,
+    Receiver,
 };
 
 use super::{
-    Controller, ControllerSendError, OwnedDeclareError, OwnedDischargeError, PostError,
-    TransactionDischarge, TransactionExt, TransactionalRetirement, TxnAcquisition, TXN_ID_KEY,
+    Controller, ControllerSendError, OwnedDeclareError, OwnedDischargeError,
+    TransactionDischarge, TransactionExt, TransactionalAcquisition, TransactionalPosting,
+    TransactionalRetirement,
 };
 
 /// An owned transaction that has exclusive access to its own control link.
@@ -33,6 +27,10 @@ use super::{
 /// ## Transactional posting
 ///
 /// ```rust,ignore
+/// use fe2o3_amqp::transaction::{
+///     OwnedTransaction, TransactionDischarge, TransactionalPosting,
+/// };
+///
 /// let mut sender = Sender::attach(&mut session, "rust-sender-link-1", "q1")
 ///     .await
 ///     .unwrap();
@@ -52,6 +50,10 @@ use super::{
 /// ## Transactional retirement
 ///
 /// ```rust,ignore
+/// use fe2o3_amqp::transaction::{
+///     OwnedTransaction, TransactionDischarge, TransactionalRetirement,
+/// };
+///
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
 ///     .await
 ///     .unwrap();
@@ -69,11 +71,15 @@ use super::{
 /// Please note that this is not supported on the resource side yet.
 ///
 /// ```rust,ignore
+/// use fe2o3_amqp::transaction::{
+///     OwnedTransaction, TransactionalAcquisition, TransactionalRetirement,
+/// };
+///
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
 ///     .await
 ///     .unwrap();
 ///
-/// // Transactionally retiring
+/// // Transactionally acquiring
 /// let mut txn = OwnedTransaction::declare(&mut session, "owned-controller", None).await.unwrap();
 /// let mut txn_acq = txn.acquire(&mut receiver, 2).await.unwrap();
 /// let delivery1: Delivery<Value> = txn_acq.recv().await.unwrap();
@@ -179,143 +185,8 @@ impl OwnedTransaction {
             is_discharged: false,
         })
     }
-
-    /// Post a ref of transactional work and wait for the acknowledgement.
-    pub async fn post_batchable_ref<T: SerializableBody>(
-        &self,
-        sender: &mut Sender,
-        sendable: &Sendable<T>,
-    ) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError> {
-        let state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: None,
-        };
-        let state = DeliveryState::TransactionalState(state);
-        let settlement = sender
-            .inner
-            .send_ref_with_state::<T, PostError>(sendable, Some(state), false)
-            .await?;
-
-        Ok(DeliveryFut::from(settlement))
-    }
-
-    /// Post a ref of transactional work
-    pub async fn post_ref<T: SerializableBody>(
-        &self,
-        sender: &mut Sender,
-        sendable: &Sendable<T>,
-    ) -> Result<Outcome, PostError> {
-        let fut = self.post_batchable_ref(sender, sendable).await?;
-        fut.await
-    }
-
-    /// Post a transactional work without waiting for the acknowledgement.
-    pub async fn post_batchable<T>(
-        &self,
-        sender: &mut Sender,
-        sendable: impl Into<Sendable<T>>,
-    ) -> Result<DeliveryFut<Result<Outcome, PostError>>, PostError>
-    where
-        T: SerializableBody,
-    {
-        // If the transaction controller wishes to associate an outgoing transfer with a
-        // transaction, it MUST set the state of the transfer with a transactional-state carrying
-        // the appropriate transaction identifier
-
-        // Note that if delivery is split across several transfer frames then all frames MUST be
-        // explicitly associated with the same transaction.
-        let sendable = sendable.into();
-        let state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: None,
-        };
-        let state = DeliveryState::TransactionalState(state);
-        let settlement = sender
-            .inner
-            .send_with_state::<T, PostError>(sendable, Some(state), true)
-            .await?;
-
-        Ok(DeliveryFut::from(settlement))
-    }
-
-    /// Post a transactional work
-    pub async fn post<T>(
-        &self,
-        sender: &mut Sender,
-        sendable: impl Into<Sendable<T>>,
-    ) -> Result<Outcome, PostError>
-    where
-        T: SerializableBody,
-    {
-        // If the transaction controller wishes to associate an outgoing transfer with a
-        // transaction, it MUST set the state of the transfer with a transactional-state carrying
-        // the appropriate transaction identifier
-
-        // Note that if delivery is split across several transfer frames then all frames MUST be
-        // explicitly associated with the same transaction.
-        let sendable = sendable.into();
-        let state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: None,
-        };
-        let state = DeliveryState::TransactionalState(state);
-        let settlement = sender
-            .inner
-            .send_with_state::<T, PostError>(sendable, Some(state), false)
-            .await?;
-
-        let fut = DeliveryFut::from(settlement);
-
-        // On receiving a non-settled delivery associated with a live transaction, the transactional
-        // resource MUST inform the controller of the presumptive terminal outcome before it can
-        // successfully discharge the transaction. That is, the resource MUST send a disposition
-        // performative which covers the posted transfer with the state of the delivery being a
-        // transactional-state with the correct transaction identified, and a terminal outcome. This
-        // informs the controller of the outcome that will be in effect at the point that the
-        // transaction is successfully discharged.
-        fut.await
-    }
-
-    /// Acquire a transactional work
-    ///
-    /// This will send
-    pub async fn acquire(
-        self,
-        recver: &mut Receiver,
-        credit: SequenceNo,
-    ) -> Result<TxnAcquisition<'_, OwnedTransaction>, FlowError> {
-        {
-            let mut writer = recver.inner.link.flow_state.lock.write();
-            let value = Value::Binary(self.declared.txn_id.clone());
-            match &mut writer.properties {
-                Some(fields) => {
-                    if fields.contains_key(TXN_ID_KEY) {
-                        return Err(FlowError::IllegalState);
-                    }
-
-                    fields.insert(Symbol::from(TXN_ID_KEY), value);
-                }
-                None => {
-                    let mut fields = Fields::new();
-                    fields.insert(Symbol::from(TXN_ID_KEY), value);
-                }
-            }
-        }
-
-        match recver
-            .inner
-            .link
-            .send_flow(&recver.inner.outgoing, Some(credit), None, false, false)
-            .await
-        {
-            Ok(_) => Ok(TxnAcquisition { txn: self, recver }),
-            Err(error) => {
-                let mut writer = recver.inner.link.flow_state.lock.write();
-                if let Some(fields) = &mut writer.properties {
-                    fields.swap_remove(TXN_ID_KEY);
-                }
-                Err(error)
-            }
-        }
-    }
 }
+
+impl TransactionalPosting for OwnedTransaction {}
+
+impl TransactionalAcquisition for OwnedTransaction {}

--- a/fe2o3-amqp/src/transaction/owned.rs
+++ b/fe2o3-amqp/src/transaction/owned.rs
@@ -3,15 +3,23 @@
 
 use fe2o3_amqp_types::transaction::{Declared, TransactionId};
 
-use crate::{link::DispositionError, session::SessionHandle};
+use crate::{
+    link::{shared_inner::LinkEndpointInnerDetach, DispositionError},
+    session::SessionHandle,
+};
 
 use super::{
-    Controller, ControllerSendError, OwnedDeclareError, OwnedDischargeError, TransactionAcquisition,
-    TransactionBase, TransactionDischarge, TransactionExt, TransactionPosting,
-    TransactionRetirement,
+    rollback_on_drop, Controller, ControllerSendError, OwnedDeclareError,
+    OwnedDischargeError, TransactionAcquisition, TransactionBase, TransactionDischarge,
+    TransactionExt, TransactionPosting, TransactionRetirement,
 };
 
 /// An owned transaction that has exclusive access to its own control link.
+///
+/// If the transaction is dropped without being discharged (i.e. without calling
+/// [`commit`](TransactionDischarge::commit) or
+/// [`rollback`](TransactionDischarge::rollback)), it is rolled back as a best-effort
+/// operation.
 ///
 /// # Examples
 ///
@@ -108,13 +116,13 @@ impl TransactionDischarge for OwnedTransaction {
 
     async fn rollback(mut self) -> Result<(), Self::Error> {
         self.discharge(true).await?;
-        self.controller.close().await?;
+        self.controller.inner.get_mut().close_with_error(None).await?;
         Ok(())
     }
 
     async fn commit(mut self) -> Result<(), Self::Error> {
         self.discharge(false).await?;
-        self.controller.close().await?;
+        self.controller.inner.get_mut().close_with_error(None).await?;
         Ok(())
     }
 }
@@ -162,3 +170,11 @@ impl TransactionPosting for OwnedTransaction {}
 impl TransactionAcquisition for OwnedTransaction {}
 
 impl TransactionExt for OwnedTransaction {}
+
+impl Drop for OwnedTransaction {
+    fn drop(&mut self) {
+        if !self.is_discharged {
+            rollback_on_drop(&self.controller.inner, &self.declared.txn_id);
+        }
+    }
+}

--- a/fe2o3-amqp/src/transaction/owned.rs
+++ b/fe2o3-amqp/src/transaction/owned.rs
@@ -1,21 +1,14 @@
 //! Implements OwnedTransaction
 
 
-use fe2o3_amqp_types::{
-    messaging::{DeliveryState, Outcome},
-    transaction::{Declared, TransactionId, TransactionalState},
-};
+use fe2o3_amqp_types::transaction::{Declared, TransactionId};
 
-use crate::{
-    link::{delivery::DeliveryInfo, DispositionError},
-    session::SessionHandle,
-    Receiver,
-};
+use crate::{link::DispositionError, session::SessionHandle};
 
 use super::{
-    Controller, ControllerSendError, OwnedDeclareError, OwnedDischargeError,
-    TransactionDischarge, TransactionExt, TransactionalAcquisition, TransactionalPosting,
-    TransactionalRetirement,
+    Controller, ControllerSendError, OwnedDeclareError, OwnedDischargeError, TransactionAcquisition,
+    TransactionBase, TransactionDischarge, TransactionExt, TransactionPosting,
+    TransactionRetirement,
 };
 
 /// An owned transaction that has exclusive access to its own control link.
@@ -28,7 +21,7 @@ use super::{
 ///
 /// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
-///     OwnedTransaction, TransactionDischarge, TransactionalPosting,
+///     OwnedTransaction, TransactionDischarge, TransactionPosting,
 /// };
 ///
 /// let mut sender = Sender::attach(&mut session, "rust-sender-link-1", "q1")
@@ -51,7 +44,7 @@ use super::{
 ///
 /// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
-///     OwnedTransaction, TransactionDischarge, TransactionalRetirement,
+///     OwnedTransaction, TransactionDischarge, TransactionRetirement,
 /// };
 ///
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
@@ -72,7 +65,7 @@ use super::{
 ///
 /// ```rust,ignore
 /// use fe2o3_amqp::transaction::{
-///     OwnedTransaction, TransactionalAcquisition, TransactionalRetirement,
+///     OwnedTransaction, TransactionAcquisition, TransactionRetirement,
 /// };
 ///
 /// let mut receiver = Receiver::attach(&mut session, "rust-recver-1", "q1")
@@ -127,34 +120,11 @@ impl TransactionDischarge for OwnedTransaction {
 }
 
 
-impl TransactionalRetirement for OwnedTransaction {
+impl TransactionRetirement for OwnedTransaction {
     type RetireError = DispositionError;
-
-    /// Associate an outcome with a transaction
-    ///
-    /// The delivery itself need not be associated with the same transaction as the outcome, or
-    /// indeed with any transaction at all. However, the delivery MUST NOT be associated with a
-    /// different non-discharged transaction than the outcome. If this happens then the control link
-    /// MUST be terminated with a transaction-rollback error.
-    async fn retire<T>(
-        &self,
-        recver: &mut Receiver,
-        delivery: T,
-        outcome: Outcome,
-    ) -> Result<(), Self::RetireError>
-    where
-        T: Into<DeliveryInfo> + Send,
-    {
-        let txn_state = TransactionalState {
-            txn_id: self.declared.txn_id.clone(),
-            outcome: Some(outcome),
-        };
-        let state = DeliveryState::TransactionalState(txn_state);
-        recver.inner.dispose(delivery, None, state).await
-    }
 }
 
-impl TransactionExt for OwnedTransaction {
+impl TransactionBase for OwnedTransaction {
     fn txn_id(&self) -> &TransactionId {
         &self.declared.txn_id
     }
@@ -187,6 +157,8 @@ impl OwnedTransaction {
     }
 }
 
-impl TransactionalPosting for OwnedTransaction {}
+impl TransactionPosting for OwnedTransaction {}
 
-impl TransactionalAcquisition for OwnedTransaction {}
+impl TransactionAcquisition for OwnedTransaction {}
+
+impl TransactionExt for OwnedTransaction {}

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -73,7 +73,7 @@ pub(crate) async fn commit_transaction(
         .map_err(Into::into)
 }
 
-///
+/// A session wrapper that handles transactional work on the resource side.
 #[derive(Debug)]
 pub(crate) struct TxnSession<S>
 where

--- a/fe2o3-amqp/src/util/consumer.rs
+++ b/fe2o3-amqp/src/util/consumer.rs
@@ -36,13 +36,13 @@ pub trait Consume {
     type Item: Send;
     type Outcome: Send;
 
-    async fn consume(&mut self, item: Self::Item) -> Self::Outcome;
+    async fn consume(&self, item: Self::Item) -> Self::Outcome;
 }
 
 cfg_transaction! {
     pub trait TryConsume: Consume {
         type Error;
 
-        fn try_consume(&mut self, item: Self::Item) -> Result<Self::Outcome, Self::Error>;
+        fn try_consume(&self, item: Self::Item) -> Result<Self::Outcome, Self::Error>;
     }
 }

--- a/fe2o3-amqp/tests/broker_connection_compat.rs
+++ b/fe2o3-amqp/tests/broker_connection_compat.rs
@@ -15,15 +15,6 @@ cfg_not_wasm32! {
     mod common;
 
     #[tokio::test]
-    async fn test_connection_compat() {
-        activemq_artemis_connection().await;
-        activemq_artemis_sasl_plain_connection().await;
-        qpid_broker_j_connection().await;
-        qpid_broker_j_sasl_plain_connection().await;
-        rabbitmq_amqp10_connection().await;
-        rabbitmq_amqp10_sasl_plain_connection().await;
-    }
-
     async fn activemq_artemis_connection() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
         let url = format!("amqp://localhost:{}", port);
@@ -31,6 +22,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn activemq_artemis_sasl_plain_connection() {
         let (_node, port) = common::setup_activemq_artemis(Some("artemis"), Some("artemis")).await;
         let url = format!("amqp://artemis:artemis@localhost:{}", port);
@@ -38,6 +30,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn qpid_broker_j_connection() {
         // The default config of the image only supports SASL PLAIN with the
         // `admin`/`admin` user. Anonymous access is not enabled.
@@ -47,6 +40,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn qpid_broker_j_sasl_plain_connection() {
         let (_node, port) = common::setup_qpid_broker_j(Some("admin"), Some("admin")).await;
         let url = format!("amqp://admin:admin@localhost:{}", port);
@@ -54,6 +48,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn rabbitmq_amqp10_connection() {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
         let url = format!("amqp://localhost:{}", port);
@@ -61,6 +56,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn rabbitmq_amqp10_sasl_plain_connection() {
         let (_node, port) = common::setup_rabbitmq_amqp10(Some("guest"), Some("guest")).await;
         let url = format!("amqp://guest:guest@localhost:{}", port);

--- a/fe2o3-amqp/tests/common.rs
+++ b/fe2o3-amqp/tests/common.rs
@@ -72,6 +72,7 @@ pub async fn setup_qpid_broker_j(
 }
 
 // TODO: disable default user and add a new user
+#[allow(dead_code)] // not used by all test binaries
 pub async fn setup_rabbitmq_amqp10(
     username: Option<&str>,
     password: Option<&str>,

--- a/fe2o3-amqp/tests/link.rs
+++ b/fe2o3-amqp/tests/link.rs
@@ -18,15 +18,6 @@ cfg_not_wasm32! {
     mod common;
 
     #[tokio::test]
-    async fn test_send_receive_compat() {
-        activemq_artemis_send_receive().await;
-        activemq_artemis_send_receive_large_content().await;
-        qpid_broker_j_send_receive().await;
-        qpid_broker_j_send_receive_large_content().await;
-        rabbitmq_amqp10_send_receive().await;
-        rabbitmq_amqp10_send_receive_large_content().await;
-    }
-
     async fn activemq_artemis_send_receive() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
 
@@ -54,6 +45,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn activemq_artemis_send_receive_large_content() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
 
@@ -81,6 +73,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn qpid_broker_j_send_receive() {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
 
@@ -108,6 +101,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn qpid_broker_j_send_receive_large_content() {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
 
@@ -135,6 +129,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn rabbitmq_amqp10_send_receive() {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
 
@@ -163,6 +158,7 @@ cfg_not_wasm32! {
         connection.close().await.unwrap();
     }
 
+    #[tokio::test]
     async fn rabbitmq_amqp10_send_receive_large_content() {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
 

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -15,7 +15,9 @@ cfg_not_wasm32! {
     use fe2o3_amqp::{
         connection::Connection,
         session::Session,
-        transaction::{Controller, Transaction, TransactionDischarge},
+        transaction::{
+            Controller, Transaction, TransactionDischarge, TransactionalPosting,
+        },
         Receiver, Sender,
     };
     use fe2o3_amqp_types::messaging::Message;

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -1,4 +1,10 @@
-//! Tests transactional posting with commit against real brokers
+//! Tests transactional support against real brokers:
+//! - posting (all four variants) with commit/rollback
+//! - retirement (accept/reject/release/modify/retire)
+//! - acquisition (Qpid only; Artemis does not implement it)
+//!
+//! Both `Transaction` (shared control link) and `OwnedTransaction` (owned control
+//! link) are exercised, each with their own connection/session/controller.
 
 #![cfg(feature = "transaction")]
 
@@ -12,40 +18,59 @@ macro_rules! cfg_not_wasm32 {
 }
 
 cfg_not_wasm32! {
+    use std::fmt::Debug;
+    use std::time::Duration;
+
     use fe2o3_amqp::{
         connection::Connection,
-        session::Session,
+        link::FlowError,
+        session::{Session, SessionHandle},
         transaction::{
-            Controller, OwnedTransaction, Transaction, TransactionDischarge,
-            TransactionPosting,
+            Controller, OwnedTransaction, Transaction, TransactionAcquisition,
+            TransactionDischarge, TransactionPosting, TransactionRetirement,
         },
-        Receiver, Sender,
+        Delivery, Receiver, Sendable, Sender,
     };
-    use fe2o3_amqp_types::messaging::Message;
-
-    use std::fmt::Debug;
+    use fe2o3_amqp_types::messaging::{Message, Modified, Outcome, Released};
+    use tokio::time::timeout;
 
     mod common;
 
     #[tokio::test]
-    async fn test_transactional_posting_commit() {
-        qpid_broker_j_post_commit().await;
-        activemq_artemis_post_commit().await;
-    }
-
-    async fn activemq_artemis_post_commit() {
-        let (_node, port) = common::setup_activemq_artemis(None, None).await;
-        let url = format!("amqp://localhost:{}", port);
-        transaction_posting_commit(&url).await;
-        owned_transaction_posting_commit(&url).await;
-    }
-
-    async fn qpid_broker_j_post_commit() {
+    async fn test_qpid_transactions() {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
         let url = format!("amqp://admin:admin@localhost:{}", port);
         transaction_posting_commit(&url).await;
         owned_transaction_posting_commit(&url).await;
+        transaction_discharge(&url).await;
+        owned_transaction_discharge(&url).await;
+        posting_variants(&url).await;
+        owned_posting_variants(&url).await;
+        transaction_rollback(&url).await;
+        owned_transaction_rollback(&url).await;
+        qpid_retirement(&url).await;
+        qpid_owned_retirement(&url).await;
+        acquisition(&url).await;
+        owned_acquisition(&url).await;
     }
+
+    #[tokio::test]
+    async fn test_artemis_transactions() {
+        let (_node, port) = common::setup_activemq_artemis(None, None).await;
+        let url = format!("amqp://localhost:{}", port);
+        transaction_posting_commit(&url).await;
+        owned_transaction_posting_commit(&url).await;
+        transaction_discharge(&url).await;
+        owned_transaction_discharge(&url).await;
+        posting_variants(&url).await;
+        owned_posting_variants(&url).await;
+        transaction_rollback(&url).await;
+        owned_transaction_rollback(&url).await;
+        artemis_retirement(&url).await;
+        artemis_owned_retirement(&url).await;
+    }
+
+    // ----- posting + commit -----
 
     async fn post_commit_and_verify<T>(
         txn: T,
@@ -55,6 +80,7 @@ cfg_not_wasm32! {
         T: TransactionPosting + TransactionDischarge + Send + Sync,
         <T as TransactionDischarge>::Error: Debug,
     {
+        assert!(!txn.is_discharged());
         let outcome = txn.post(sender, Message::from("hello")).await.unwrap();
         outcome.accepted_or("Not accepted").unwrap();
         let outcome = txn.post(sender, Message::from("world")).await.unwrap();
@@ -110,6 +136,719 @@ cfg_not_wasm32! {
 
         sender.close().await.unwrap();
         receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    // ----- discharge + is_discharged -----
+
+    async fn discharge_and_verify<T>(
+        mut txn: T,
+        sender: &mut Sender,
+        receiver: &mut Receiver,
+    ) where
+        T: TransactionPosting + TransactionDischarge + Send + Sync,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        assert!(!txn.is_discharged());
+        let outcome = txn.post(sender, Message::from("discharge")).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        txn.discharge(false).await.unwrap();
+        assert!(txn.is_discharged());
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), "discharge");
+    }
+
+    async fn transaction_discharge(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-discharge")
+            .await
+            .unwrap();
+        let mut receiver =
+            Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")
+                .await
+                .unwrap();
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        discharge_and_verify(txn, &mut sender, &mut receiver).await;
+
+        controller.close().await.unwrap();
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn owned_transaction_discharge(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-discharge")
+            .await
+            .unwrap();
+        let mut receiver =
+            Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")
+                .await
+                .unwrap();
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
+            .await
+            .unwrap();
+        discharge_and_verify(txn, &mut sender, &mut receiver).await;
+
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    // ----- posting variants -----
+
+    async fn post_variants_and_verify<T>(
+        txn: T,
+        sender: &mut Sender,
+        receiver: &mut Receiver,
+    ) where
+        T: TransactionPosting + TransactionDischarge + Send + Sync,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let outcome = txn.post(sender, Message::from("post")).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        let sendable = Sendable::builder()
+            .message(Message::from("post_ref"))
+            .build();
+        let outcome = txn.post_ref(sender, &sendable).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        let fut = txn
+            .post_batchable(sender, Message::from("post_batchable"))
+            .await
+            .unwrap();
+        let outcome = fut.await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        let sendable = Sendable::builder()
+            .message(Message::from("post_batchable_ref"))
+            .build();
+        let fut = txn.post_batchable_ref(sender, &sendable).await.unwrap();
+        let outcome = fut.await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        txn.commit().await.unwrap();
+
+        for expected in ["post", "post_ref", "post_batchable", "post_batchable_ref"] {
+            let received = receiver.recv::<String>().await.unwrap();
+            receiver.accept(&received).await.unwrap();
+            assert_eq!(received.body(), expected);
+        }
+    }
+
+    async fn posting_variants(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+        let mut sender =
+            Sender::attach(&mut session, "test-sender", "test-queue-variants")
+                .await
+                .unwrap();
+        let mut receiver = Receiver::attach(
+            &mut session,
+            "test-receiver",
+            "test-queue-variants",
+        )
+        .await
+        .unwrap();
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        post_variants_and_verify(txn, &mut sender, &mut receiver).await;
+
+        controller.close().await.unwrap();
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn owned_posting_variants(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut sender =
+            Sender::attach(&mut session, "test-sender", "test-queue-variants")
+                .await
+                .unwrap();
+        let mut receiver = Receiver::attach(
+            &mut session,
+            "test-receiver",
+            "test-queue-variants",
+        )
+        .await
+        .unwrap();
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
+            .await
+            .unwrap();
+        post_variants_and_verify(txn, &mut sender, &mut receiver).await;
+
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    // ----- rollback -----
+
+    async fn rollback_and_verify<T>(
+        txn: T,
+        sender: &mut Sender,
+        receiver: &mut Receiver,
+    ) where
+        T: TransactionPosting + TransactionDischarge + Send + Sync,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        for body in ["a", "b"] {
+            let outcome = txn.post(sender, Message::from(body)).await.unwrap();
+            outcome.accepted_or("Not accepted").unwrap();
+        }
+        txn.rollback().await.unwrap();
+
+        let result = timeout(Duration::from_secs(3), receiver.recv::<String>()).await;
+        assert!(result.is_err(), "message arrived after rollback");
+    }
+
+    async fn transaction_rollback(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-rollback")
+            .await
+            .unwrap();
+        let mut receiver =
+            Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")
+                .await
+                .unwrap();
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        rollback_and_verify(txn, &mut sender, &mut receiver).await;
+
+        // A subsequent transaction on the same controller still works
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        post_commit_and_verify(txn, &mut sender, &mut receiver).await;
+
+        controller.close().await.unwrap();
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn owned_transaction_rollback(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-rollback")
+            .await
+            .unwrap();
+        let mut receiver =
+            Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")
+                .await
+                .unwrap();
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)
+            .await
+            .unwrap();
+        rollback_and_verify(txn, &mut sender, &mut receiver).await;
+
+        // A subsequent transaction on its own control link still works
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)
+            .await
+            .unwrap();
+        post_commit_and_verify(txn, &mut sender, &mut receiver).await;
+
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    // ----- retirement -----
+
+    /// The message bodies of the retirement sub-cases. Each case also uses a queue
+    /// named `test-queue-ret-<body>`.
+    const RETIREMENT_BODIES: [&str; 6] = [
+        "rollback-accept",
+        "accept",
+        "reject",
+        "release",
+        "modify",
+        "retire",
+    ];
+
+    async fn recv_string(receiver: &mut Receiver) -> Delivery<String> {
+        timeout(Duration::from_secs(5), receiver.recv::<String>())
+            .await
+            .expect("timed out waiting for a delivery")
+            .unwrap()
+    }
+
+    async fn expect_redelivered(receiver: &mut Receiver, expected: &str) {
+        let redelivered = recv_string(receiver).await;
+        assert_eq!(redelivered.body(), expected);
+        receiver.accept(&redelivered).await.unwrap();
+    }
+
+    async fn retire_accept_rollback<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        txn.accept(receiver, &delivery).await.unwrap();
+        txn.rollback().await.unwrap();
+    }
+
+    async fn retire_accept_commit<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        txn.accept(receiver, &delivery).await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    /// Retire a delivery with a `Rejected` outcome and commit.
+    ///
+    /// The message's fate after the commit depends on the broker, so the caller
+    /// decides whether to verify the redelivery (the redelivery is verified by the caller).
+    async fn retire_reject_commit<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        txn.reject(receiver, &delivery, None).await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    /// Retire a delivery with a `Released` outcome and commit.
+    ///
+    /// The message's fate after the commit depends on the broker, so the caller
+    /// decides whether to verify the redelivery (the redelivery is verified by the caller).
+    async fn retire_release_commit<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        txn.release(receiver, &delivery).await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    /// Retire a delivery with a `Modified` outcome and commit.
+    ///
+    /// The message's fate after the commit depends on the broker, so the caller
+    /// decides whether to verify the redelivery (the redelivery is verified by the caller).
+    async fn retire_modify_commit<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        let modified = Modified {
+            delivery_failed: None,
+            undeliverable_here: None,
+            message_annotations: None,
+        };
+        txn.modify(receiver, &delivery, modified).await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    /// Retire a delivery with an explicit outcome and commit.
+    ///
+    /// The message's fate after the commit depends on the broker, so the caller
+    /// decides whether to verify the redelivery.
+    async fn retire_outcome_commit<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let delivery = recv_string(receiver).await;
+        assert_eq!(delivery.body(), expected);
+        txn.retire(receiver, &delivery, Outcome::Released(Released {}))
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    /// Run one Qpid retirement sub-case: attach the seed sender and receiver for
+    /// the case's queue, seed the message, and exercise the retirement method
+    /// selected by `body`.
+    ///
+    /// Qpid applies every transactional outcome: an `Accepted` retirement consumes
+    /// the message, while `Rejected`, `Released`, and `Modified` ones return it to
+    /// the queue (rejected messages are released with an incremented delivery
+    /// count). The returned messages are verified via [`expect_redelivered`].
+    ///
+    /// Each sub-case uses its own queue and receiver so that a late redelivery of an
+    /// earlier case cannot interfere with the next one. The receiver is attached
+    /// before seeding: on Artemis a message that is enqueued before the consuming
+    /// link attaches is not delivered.
+    async fn qpid_retire_case<T, R>(
+        body: &str,
+        txn: T,
+        session: &mut SessionHandle<R>,
+    ) where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let queue = format!("test-queue-ret-{}", body);
+
+        let mut seed_sender = Sender::attach(
+            session,
+            format!("test-seed-sender-{}", body),
+            &queue,
+        )
+        .await
+        .unwrap();
+        let mut receiver = Receiver::attach(
+            session,
+            format!("test-receiver-{}", body),
+            &queue,
+        )
+        .await
+        .unwrap();
+        seed_sender.send(Message::from(body)).await.unwrap();
+
+        match body {
+            "rollback-accept" => {
+                retire_accept_rollback(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+            "accept" => retire_accept_commit(txn, &mut receiver, body).await,
+            "reject" => {
+                retire_reject_commit(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+            "release" => {
+                retire_release_commit(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+            "modify" => {
+                retire_modify_commit(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+            _ => {
+                retire_outcome_commit(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+        }
+
+        receiver.close().await.unwrap();
+        seed_sender.close().await.unwrap();
+    }
+
+    async fn qpid_retirement(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+
+        for &body in RETIREMENT_BODIES.iter() {
+            let txn = Transaction::declare(&controller, None).await.unwrap();
+            qpid_retire_case(body, txn, &mut session).await;
+        }
+
+        controller.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn qpid_owned_retirement(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+
+        for (index, &body) in RETIREMENT_BODIES.iter().enumerate() {
+            let txn = OwnedTransaction::declare(
+                &mut session,
+                format!("test-owned-controller-{}", index),
+                None,
+            )
+            .await
+            .unwrap();
+            qpid_retire_case(body, txn, &mut session).await;
+        }
+
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    /// Run one Artemis retirement sub-case: attach the seed sender and receiver for
+    /// the case's queue, seed the message, and exercise the retirement method
+    /// selected by `body`.
+    ///
+    /// Artemis only enlists transactional `Accepted` retirements; `Rejected`,
+    /// `Released`, and `Modified` transactional outcomes are silently ignored by the
+    /// broker, so those cases only verify that the operations complete without an
+    /// error and the message's fate is not asserted. An `Accepted` retirement is
+    /// reversed on rollback, and consumes the message on commit.
+    ///
+    /// Each sub-case uses its own queue and receiver so that a late redelivery of an
+    /// earlier case cannot interfere with the next one. The receiver is attached
+    /// before seeding: on Artemis a message that is enqueued before the consuming
+    /// link attaches is not delivered.
+    async fn artemis_retire_case<T, R>(
+        body: &str,
+        txn: T,
+        session: &mut SessionHandle<R>,
+    ) where
+        T: TransactionRetirement + TransactionDischarge + Send + Sync,
+        T::RetireError: Debug,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let queue = format!("test-queue-ret-{}", body);
+
+        let mut seed_sender = Sender::attach(
+            session,
+            format!("test-seed-sender-{}", body),
+            &queue,
+        )
+        .await
+        .unwrap();
+        let mut receiver = Receiver::attach(
+            session,
+            format!("test-receiver-{}", body),
+            &queue,
+        )
+        .await
+        .unwrap();
+        seed_sender.send(Message::from(body)).await.unwrap();
+
+        match body {
+            "rollback-accept" => {
+                retire_accept_rollback(txn, &mut receiver, body).await;
+                expect_redelivered(&mut receiver, body).await;
+            }
+            "accept" => retire_accept_commit(txn, &mut receiver, body).await,
+            "reject" => retire_reject_commit(txn, &mut receiver, body).await,
+            "release" => retire_release_commit(txn, &mut receiver, body).await,
+            "modify" => retire_modify_commit(txn, &mut receiver, body).await,
+            _ => retire_outcome_commit(txn, &mut receiver, body).await,
+        }
+
+        receiver.close().await.unwrap();
+        seed_sender.close().await.unwrap();
+    }
+
+    async fn artemis_retirement(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+
+        for &body in RETIREMENT_BODIES.iter() {
+            let txn = Transaction::declare(&controller, None).await.unwrap();
+            artemis_retire_case(body, txn, &mut session).await;
+        }
+
+        controller.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn artemis_owned_retirement(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+
+        for (index, &body) in RETIREMENT_BODIES.iter().enumerate() {
+            let txn = OwnedTransaction::declare(
+                &mut session,
+                format!("test-owned-controller-{}", index),
+                None,
+            )
+            .await
+            .unwrap();
+            artemis_retire_case(body, txn, &mut session).await;
+        }
+
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    // ----- acquisition -----
+    //
+    // Transactional acquisition is only tested against Qpid Broker-J: Artemis does
+    // not implement it (its coordinator only handles declare/discharge and there is
+    // no `txn-id` flow handling on the receiving side), so the acquisition scenarios
+    // are not run against Artemis.
+
+    async fn acquire_commit_and_verify<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionAcquisition,
+        <T as TransactionDischarge>::Error: From<FlowError> + Debug,
+        <T as TransactionRetirement>::RetireError: Debug,
+    {
+        let mut txn_acq = txn.acquire(receiver, 1).await.unwrap();
+        assert!(!txn_acq.txn_id().as_ref().is_empty());
+        let delivery = timeout(Duration::from_secs(5), txn_acq.recv::<String>())
+            .await
+            .expect("timed out waiting for an acquired delivery")
+            .unwrap();
+        assert_eq!(delivery.body(), expected);
+        txn_acq.accept(&delivery).await.unwrap();
+        txn_acq.commit().await.unwrap();
+    }
+
+    async fn acquire_rollback_and_verify<T>(txn: T, receiver: &mut Receiver, expected: &str)
+    where
+        T: TransactionAcquisition,
+        <T as TransactionDischarge>::Error: From<FlowError> + Debug,
+        <T as TransactionRetirement>::RetireError: Debug,
+    {
+        let mut txn_acq = txn.acquire(receiver, 1).await.unwrap();
+        let delivery = timeout(Duration::from_secs(5), txn_acq.recv::<String>())
+            .await
+            .expect("timed out waiting for an acquired delivery")
+            .unwrap();
+        assert_eq!(delivery.body(), expected);
+        txn_acq.accept(&delivery).await.unwrap();
+        txn_acq.rollback().await.unwrap();
+    }
+
+    /// Seed a message, acquire and commit it, and verify that it is consumed.
+    async fn acquire_commit_case<T, R>(
+        txn: T,
+        session: &mut SessionHandle<R>,
+        queue: &str,
+        body: &str,
+    ) where
+        T: TransactionAcquisition,
+        <T as TransactionDischarge>::Error: From<FlowError> + Debug,
+        <T as TransactionRetirement>::RetireError: Debug,
+    {
+        let mut seed_sender = Sender::attach(session, "test-seed-sender", queue)
+            .await
+            .unwrap();
+        seed_sender.send(Message::from(body)).await.unwrap();
+        let mut receiver = Receiver::attach(session, "test-receiver", queue)
+            .await
+            .unwrap();
+
+        acquire_commit_and_verify(txn, &mut receiver, body).await;
+
+        let mut verify_receiver = Receiver::attach(session, "test-verify-receiver", queue)
+            .await
+            .unwrap();
+        let result = timeout(
+            Duration::from_secs(3),
+            verify_receiver.recv::<String>(),
+        )
+        .await;
+        assert!(result.is_err(), "acquired message was not consumed by commit");
+        verify_receiver.close().await.unwrap();
+        receiver.close().await.unwrap();
+        seed_sender.close().await.unwrap();
+    }
+
+    /// Seed a message, acquire and roll it back, and verify that it is returned
+    /// to the queue.
+    async fn acquire_rollback_case<T, R>(
+        txn: T,
+        session: &mut SessionHandle<R>,
+        queue: &str,
+        body: &str,
+    ) where
+        T: TransactionAcquisition,
+        <T as TransactionDischarge>::Error: From<FlowError> + Debug,
+        <T as TransactionRetirement>::RetireError: Debug,
+    {
+        let mut seed_sender = Sender::attach(session, "test-seed-sender", queue)
+            .await
+            .unwrap();
+        seed_sender.send(Message::from(body)).await.unwrap();
+        let mut receiver = Receiver::attach(session, "test-receiver", queue)
+            .await
+            .unwrap();
+
+        acquire_rollback_and_verify(txn, &mut receiver, body).await;
+
+        let mut verify_receiver = Receiver::attach(session, "test-verify-receiver", queue)
+            .await
+            .unwrap();
+        let delivery = recv_string(&mut verify_receiver).await;
+        assert_eq!(delivery.body(), body);
+        verify_receiver.accept(&delivery).await.unwrap();
+        verify_receiver.close().await.unwrap();
+        receiver.close().await.unwrap();
+        seed_sender.close().await.unwrap();
+    }
+
+    async fn acquisition(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        acquire_commit_case(txn, &mut session, "test-queue-acquire", "acquire-commit").await;
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        acquire_rollback_case(
+            txn,
+            &mut session,
+            "test-queue-acquire-rollback",
+            "acquire-rollback",
+        )
+        .await;
+
+        controller.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn owned_acquisition(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)
+            .await
+            .unwrap();
+        acquire_commit_case(txn, &mut session, "test-queue-acquire", "acquire-commit").await;
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)
+            .await
+            .unwrap();
+        acquire_rollback_case(
+            txn,
+            &mut session,
+            "test-queue-acquire-rollback",
+            "acquire-rollback",
+        )
+        .await;
+
         session.close().await.unwrap();
         connection.close().await.unwrap();
     }

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -16,11 +16,14 @@ cfg_not_wasm32! {
         connection::Connection,
         session::Session,
         transaction::{
-            Controller, Transaction, TransactionDischarge, TransactionPosting,
+            Controller, OwnedTransaction, Transaction, TransactionDischarge,
+            TransactionPosting,
         },
         Receiver, Sender,
     };
     use fe2o3_amqp_types::messaging::Message;
+
+    use std::fmt::Debug;
 
     mod common;
 
@@ -33,16 +36,41 @@ cfg_not_wasm32! {
     async fn activemq_artemis_post_commit() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
         let url = format!("amqp://localhost:{}", port);
-        transactional_posting_commit(&url).await;
+        transaction_posting_commit(&url).await;
+        owned_transaction_posting_commit(&url).await;
     }
 
     async fn qpid_broker_j_post_commit() {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
         let url = format!("amqp://admin:admin@localhost:{}", port);
-        transactional_posting_commit(&url).await;
+        transaction_posting_commit(&url).await;
+        owned_transaction_posting_commit(&url).await;
     }
 
-    async fn transactional_posting_commit(url: &str) {
+    async fn post_commit_and_verify<T>(
+        txn: T,
+        sender: &mut Sender,
+        receiver: &mut Receiver,
+    ) where
+        T: TransactionPosting + TransactionDischarge + Send + Sync,
+        <T as TransactionDischarge>::Error: Debug,
+    {
+        let outcome = txn.post(sender, Message::from("hello")).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        let outcome = txn.post(sender, Message::from("world")).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        txn.commit().await.unwrap();
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), "hello");
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), "world");
+    }
+
+    async fn transaction_posting_commit(url: &str) {
         let mut connection = Connection::open("test-connection", url).await.unwrap();
         let mut session = Session::begin(&mut connection).await.unwrap();
         let controller = Controller::attach(&mut session, "test-controller")
@@ -56,27 +84,30 @@ cfg_not_wasm32! {
             .unwrap();
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
-        let outcome = txn
-            .post(&mut sender, Message::from("hello"))
-            .await
-            .unwrap();
-        outcome.accepted_or("Not accepted").unwrap();
-        let outcome = txn
-            .post(&mut sender, Message::from("world"))
-            .await
-            .unwrap();
-        outcome.accepted_or("Not accepted").unwrap();
-        txn.commit().await.unwrap();
-
-        let received = receiver.recv::<String>().await.unwrap();
-        receiver.accept(&received).await.unwrap();
-        assert_eq!(received.body(), "hello");
-
-        let received = receiver.recv::<String>().await.unwrap();
-        receiver.accept(&received).await.unwrap();
-        assert_eq!(received.body(), "world");
+        post_commit_and_verify(txn, &mut sender, &mut receiver).await;
 
         controller.close().await.unwrap();
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    async fn owned_transaction_posting_commit(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
+            .await
+            .unwrap();
+        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
+            .await
+            .unwrap();
+
+        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
+            .await
+            .unwrap();
+        post_commit_and_verify(txn, &mut sender, &mut receiver).await;
+
         sender.close().await.unwrap();
         receiver.close().await.unwrap();
         session.close().await.unwrap();

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -16,7 +16,7 @@ cfg_not_wasm32! {
         connection::Connection,
         session::Session,
         transaction::{
-            Controller, Transaction, TransactionDischarge, TransactionalPosting,
+            Controller, Transaction, TransactionDischarge, TransactionPosting,
         },
         Receiver, Sender,
     };

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -1,0 +1,83 @@
+//! Tests transactional posting with commit against real brokers
+
+#![cfg(feature = "transaction")]
+
+macro_rules! cfg_not_wasm32 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(target_arch = "wasm32"))]
+            $item
+        )*
+    }
+}
+
+cfg_not_wasm32! {
+    use fe2o3_amqp::{
+        connection::Connection,
+        session::Session,
+        transaction::{Controller, Transaction, TransactionDischarge},
+        Receiver, Sender,
+    };
+    use fe2o3_amqp_types::messaging::Message;
+
+    mod common;
+
+    #[tokio::test]
+    async fn test_transactional_posting_commit() {
+        qpid_broker_j_post_commit().await;
+        activemq_artemis_post_commit().await;
+    }
+
+    async fn activemq_artemis_post_commit() {
+        let (_node, port) = common::setup_activemq_artemis(None, None).await;
+        let url = format!("amqp://localhost:{}", port);
+        transactional_posting_commit(&url).await;
+    }
+
+    async fn qpid_broker_j_post_commit() {
+        let (_node, port) = common::setup_qpid_broker_j(None, None).await;
+        let url = format!("amqp://admin:admin@localhost:{}", port);
+        transactional_posting_commit(&url).await;
+    }
+
+    async fn transactional_posting_commit(url: &str) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let controller = Controller::attach(&mut session, "test-controller")
+            .await
+            .unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
+            .await
+            .unwrap();
+        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
+            .await
+            .unwrap();
+
+        let txn = Transaction::declare(&controller, None).await.unwrap();
+        let outcome = txn
+            .post(&mut sender, Message::from("hello"))
+            .await
+            .unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        let outcome = txn
+            .post(&mut sender, Message::from("world"))
+            .await
+            .unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        txn.commit().await.unwrap();
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), "hello");
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), "world");
+
+        controller.close().await.unwrap();
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+}

--- a/serde_amqp/benches/serialize.rs
+++ b/serde_amqp/benches/serialize.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::all)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::{distr::SampleString, Rng, RngCore};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{distr::SampleString, Rng};
 use rand_distr::Alphanumeric;
 use serde_amqp::primitives::{Binary, Dec128, Dec32, Dec64, Timestamp};
+use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let value = ();
@@ -177,42 +178,42 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     // 16 bytes of u64
     let mut value = vec![0u64; 16 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 16B", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });
 
     // 64 bytes of u64
     let mut value = vec![0u64; 64 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 64B", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });
 
     // 256 bytes of u64
     let mut value = vec![0u64; 256 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 256B", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });
 
     // 1kB of u64
     let mut value = vec![0u64; 1024 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 1kB", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });
 
     // 1MB of u64
     let mut value = vec![0u64; 1024 * 1024 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 1MB", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });
 
     // 10MB of u64
     let mut value = vec![0u64; 10 * 1024 * 1024 / std::mem::size_of::<u64>()];
-    rand::rng().fill(&mut value[..]);
+    rand::fill(&mut value[..]);
     c.bench_function("serialize List<u64> 10MB", |b| {
         b.iter(|| serde_amqp::to_vec(black_box(&value)).unwrap())
     });

--- a/serde_amqp/src/described.rs
+++ b/serde_amqp/src/described.rs
@@ -124,7 +124,7 @@ mod tests {
         let value = Box::new(vec![1i32, 2]);
         let described = Described { descriptor, value };
         let buf = to_vec(&described).unwrap();
-        println!("{:?}", &buf);
+        println!("{:?}", buf);
         let recovered: Described<Vec<i32>> = from_slice(&buf).unwrap();
         println!("{:?}", recovered);
     }
@@ -150,9 +150,9 @@ mod tests {
             a: 0,
         };
         let serialized = to_vec(&foo).unwrap();
-        println!("{:?}", &serialized);
+        println!("{:?}", serialized);
         let deserialized: Foo = from_slice(&serialized).unwrap();
-        println!("{:?}", &deserialized);
+        println!("{:?}", deserialized);
         assert_eq!(foo, deserialized);
     }
 
@@ -171,9 +171,9 @@ mod tests {
             b: true,
         };
         let serialized = to_vec(&test).unwrap();
-        println!("{:?}", &serialized);
+        println!("{:?}", serialized);
         let deserialized: Test = from_slice(&serialized).unwrap();
-        println!("{:?}", &deserialized);
+        println!("{:?}", deserialized);
         assert_eq!(test, deserialized);
     }
 }

--- a/serde_amqp/src/ser.rs
+++ b/serde_amqp/src/ser.rs
@@ -2096,11 +2096,7 @@ mod test {
         assert_eq_on_serialized_vs_expected(descriptor, &expected);
     }
 
-    #[cfg(feature = "derive")]
-    use serde::Deserialize;
     use serde::Serialize;
-    #[cfg(feature = "derive")]
-    use serde_amqp_derive::{DeserializeComposite, SerializeComposite};
 
     #[derive(Serialize)]
     struct Foo {
@@ -2563,6 +2559,7 @@ mod test {
     pub struct NewType<T>(T);
 
     #[derive(Debug, Serialize)]
+    #[allow(dead_code)] // only used to check that the derive compiles
     pub struct AnotherNewType<T>(T);
 
     #[test]

--- a/serde_amqp/src/value/ser.rs
+++ b/serde_amqp/src/value/ser.rs
@@ -815,7 +815,7 @@ impl ser::SerializeStructVariant for VariantSerializer<'_> {
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
 
     #[cfg(feature = "derive")]
     use serde_amqp_derive::{DeserializeComposite, SerializeComposite};

--- a/serde_amqp/tests/derive.rs
+++ b/serde_amqp/tests/derive.rs
@@ -4,6 +4,9 @@
 #[cfg(feature = "derive")]
 use serde_amqp::{DeserializeComposite, SerializeComposite};
 
+// This file only serves as a test and macro expansion for the derive macro, so
+// the structs here are intentionally never constructed at runtime.
+#[allow(dead_code)]
 #[cfg(feature = "derive")]
 #[derive(SerializeComposite, DeserializeComposite)]
 #[amqp_contract(

--- a/serde_amqp/tests/described_basic.rs
+++ b/serde_amqp/tests/described_basic.rs
@@ -12,6 +12,7 @@ use serde_amqp::{DeserializeComposite, SerializeComposite};
 )]
 struct Single<T>(T);
 
+#[allow(dead_code)] // only used to check that the serde derives compile
 #[derive(Debug, Serialize, Deserialize)]
 struct CustomStruct {
     a: u8,


### PR DESCRIPTION
## Summary

- **Trait restructure**: added `TransactionBase` (txn-id accessor); renamed
  `TransactionalPosting/Retirement/Acquisition` → `TransactionPosting/Retirement/Acquisition`
  with default `post*`/`retire`/`acquire` impls shared by `Transaction` and
  `OwnedTransaction`; `TransactionExt` is now the aggregate trait. The `Transfer`
  `batchable` flag is now set consistently. *(Breaking)*
- **Fixes**: `OwnedTransaction` rolls back on drop (matching `Transaction`); new
  `From<IllegalLinkStateError> for OwnedDischargeError` unblocks
  `TxnAcquisition::commit`/`rollback` for `OwnedTransaction`; the session no longer
  ends itself when a detach reply can't reach a dropped link endpoint;
  `control_link_frame` is gated behind `acceptor` (clippy fix).
- **Tests**: per-broker integration tests (Qpid Broker-J + ActiveMQ Artemis) covering
  every transaction method for both `Transaction` and `OwnedTransaction`.

## Testing

- CI clippy runs `--all --all-features --all-targets -- --deny warnings`.
- The fe2o3-amqp `test` make task uses `--all-features`, so all feature-gated tests
  (including the transaction integration tests, ~5 min with two broker containers)
  run in CI.