### PR TITLE
refactor: Propagate connection/session stop reason to link, fix frame draining during close-exchange

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -36,22 +36,26 @@
     `SendAttachErrorKind`, `SenderAttachError`, `ReceiverAttachError`, and
     [`AcceptorAttachError`]. The new public [`SessionStopReason`] tells whether the session
     or its connection stopped first and whether it carried an error, so callers can decide
-    whether to retry at the session or connection level. `SenderAttachError`,
-    `ReceiverAttachError`, and `AllocLinkError` also gain a `SessionNotMapped` variant for
-    sessions that were never begun; link allocation on an ending or stopped session reports
-    `SessionStopped(reason)` instead (the reason is recorded on the [`Session`] itself).
+    whether to retry at the session or connection level.
 10. **Breaking**: `FromOneshotRecvError` is renamed to `FromDeliveryFailure` and gains a
     required `from_session_stop_reason` method.
-11. A session now ends cleanly (with a warning logged) when its connection stops first,
+11. **Breaking**: `SenderAttachError`, `ReceiverAttachError`, and `AllocLinkError` gain a
+    `SessionNotMapped` variant for sessions that were never begun; link allocation on an
+    ending or stopped session reports `SessionStopped(reason)` instead.
+12. A session now ends cleanly (with a warning logged) when its connection stops first,
     instead of reporting `IllegalConnectionState`; connection-level errors stay on the
-    [`ConnectionHandle`], while interrupted link operations surface the stop reason. The
-    stop-reason cell is owned by the [`Session`] and shared with its handle and links —
-    including links created by the listener acceptors and the transaction control link —
-    so the real reason (`ConnectionClosed(..)` vs `Ended`/`EndedWithError`) is observed.
-    `AcceptorAttachError` no longer hoists session stops out of local attach errors. The
-    cells are renamed `session_stop_reason`/`connection_stop_reason`, and the sender/
-    receiver inner no longer keep a copy of the session stop reason (read from the link
-    via the internal `LinkExt` trait).
+    [`ConnectionHandle`]. Interrupted link operations surface the real stop reason
+    (`ConnectionClosed(..)` vs `Ended`/`EndedWithError`) — including on links created by
+    the listener acceptors and the transaction control link.
+13. [`AcceptorAttachError`] no longer hoists a session stop out of the local
+    sender/receiver attach errors; it stays wrapped in `LocalSender`/`LocalReceiver`.
+14. **Breaking**: `IllegalConnectionState` is replaced by
+    `ConnectionStopped(ConnectionStopReason)` on [`BeginError`] and `Error` (and the
+    internal session error types). The new public [`ConnectionStopReason`] (`Closed` /
+    `ClosedWithError`) mirrors `SessionStopped(..)` at the connection level.
+15. **Breaking**: [`BeginError`] gains a `ConnectionNotOpened` variant: beginning a session
+    on a connection that has not been opened yet reports `ConnectionNotOpened`, while one
+    on a stopped connection reports `ConnectionStopped(reason)`.
 
 ## 0.16.2
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -31,6 +31,27 @@
    `TxnCoordinator` now logs a warning when the teardown message cannot be enqueued,
    instead of silently discarding the failure. Rollback-on-drop failures log errors as
    well. Gated behind the `log` and `tracing` features.
+9. **Breaking**: `IllegalSessionState` is replaced by `SessionStopped(SessionStopReason)` on
+    [`LinkStateError`], `IllegalLinkStateError`, `DetachError`, `AllocLinkError`,
+    `SendAttachErrorKind`, `SenderAttachError`, `ReceiverAttachError`, and
+    [`AcceptorAttachError`]. The new public [`SessionStopReason`] tells whether the session
+    or its connection stopped first and whether it carried an error, so callers can decide
+    whether to retry at the session or connection level. `SenderAttachError`,
+    `ReceiverAttachError`, and `AllocLinkError` also gain a `SessionNotMapped` variant for
+    sessions that were never begun; link allocation on an ending or stopped session reports
+    `SessionStopped(reason)` instead (the reason is recorded on the [`Session`] itself).
+10. **Breaking**: `FromOneshotRecvError` is renamed to `FromDeliveryFailure` and gains a
+    required `from_session_stop_reason` method.
+11. A session now ends cleanly (with a warning logged) when its connection stops first,
+    instead of reporting `IllegalConnectionState`; connection-level errors stay on the
+    [`ConnectionHandle`], while interrupted link operations surface the stop reason. The
+    stop-reason cell is owned by the [`Session`] and shared with its handle and links —
+    including links created by the listener acceptors and the transaction control link —
+    so the real reason (`ConnectionClosed(..)` vs `Ended`/`EndedWithError`) is observed.
+    `AcceptorAttachError` no longer hoists session stops out of local attach errors. The
+    cells are renamed `session_stop_reason`/`connection_stop_reason`, and the sender/
+    receiver inner no longer keep a copy of the session stop reason (read from the link
+    via the internal `LinkExt` trait).
 
 ## 0.16.2
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -34,9 +34,7 @@
 9. **Breaking**: `IllegalSessionState` is replaced by `SessionStopped(SessionStopReason)` on
     [`LinkStateError`], `IllegalLinkStateError`, `DetachError`, `AllocLinkError`,
     `SendAttachErrorKind`, `SenderAttachError`, `ReceiverAttachError`, and
-    [`AcceptorAttachError`]. The new public [`SessionStopReason`] tells whether the session
-    or its connection stopped first and whether it carried an error, so callers can decide
-    whether to retry at the session or connection level.
+    [`AcceptorAttachError`].
 10. **Breaking**: `FromOneshotRecvError` is renamed to `FromDeliveryFailure` and gains a
     required `from_session_stop_reason` method.
 11. **Breaking**: `SenderAttachError`, `ReceiverAttachError`, and `AllocLinkError` gain a
@@ -44,16 +42,21 @@
     ending or stopped session reports `SessionStopped(reason)` instead.
 12. A session now ends cleanly (with a warning logged) when its connection stops first,
     instead of reporting `IllegalConnectionState`; connection-level errors stay on the
-    [`ConnectionHandle`]. Interrupted link operations surface the real stop reason
-    (`ConnectionClosed(..)` vs `Ended`/`EndedWithError`) — including on links created by
-    the listener acceptors and the transaction control link.
-13. [`AcceptorAttachError`] no longer hoists a session stop out of the local
+    [`ConnectionHandle`].
+13. Interrupted link operations surface the real stop reason on links created by the
+    listener acceptors and the transaction control link.
+14. [`AcceptorAttachError`] no longer hoists a session stop out of the local
     sender/receiver attach errors; it stays wrapped in `LocalSender`/`LocalReceiver`.
-14. **Breaking**: `IllegalConnectionState` is replaced by
+15. **Breaking**: `IllegalConnectionState` is replaced by
     `ConnectionStopped(ConnectionStopReason)` on [`BeginError`] and `Error` (and the
-    internal session error types). The new public [`ConnectionStopReason`] (`Closed` /
-    `ClosedWithError`) mirrors `SessionStopped(..)` at the connection level.
-15. **Breaking**: [`BeginError`] gains a `ConnectionNotOpened` variant: beginning a session
+    internal session error types).
+16. **Breaking**: The public [`SessionStopReason`] and [`ConnectionStopReason`] now
+    distinguish a local from a remote-originated stop (`EndedWithError`/`ClosedWithError`
+    are local; `RemoteEndedWithError`/`RemoteClosedWithError` are remote), and the session
+    reason embeds the connection reason via `ConnectionStopped(ConnectionStopReason)`.
+17. Frames arriving while the connection is `Discarding` are now silently discarded per
+    the AMQP specification instead of failing the close exchange.
+18. **Breaking**: [`BeginError`] gains a `ConnectionNotOpened` variant: beginning a session
     on a connection that has not been opened yet reports `ConnectionNotOpened`, while one
     on a stopped connection reports `ConnectionStopped(reason)`.
 

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -19,7 +19,7 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 use crate::{
     acceptor::sasl_acceptor::SaslServerFrame,
     connection::{
-        self, engine::ConnectionEngine, ConnectionHandle, OpenError,
+        self, engine::ConnectionEngine, ConnectionHandle, ConnectionStopReason, OpenError,
         DEFAULT_CONTROL_CHAN_BUF, DEFAULT_OUTGOING_BUFFER_SIZE,
     },
     endpoint::{self, IncomingChannel, OutgoingChannel},
@@ -207,7 +207,7 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
 
         let engine = ConnectionEngine::open(transport, listener_connection, control_rx, outgoing_rx)
             .await?;
-        let connection_stop_reason = engine.connection_stop_reason.clone();
+        let connection_stop_reason = engine.connection_stop_reason().clone();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -495,6 +495,16 @@ impl endpoint::Connection for ListenerConnection {
     #[inline]
     fn local_open(&self) -> &fe2o3_amqp_types::performatives::Open {
         self.connection.local_open()
+    }
+
+    #[inline]
+    fn connection_stop_reason(&self) -> &std::sync::Arc<std::sync::OnceLock<ConnectionStopReason>> {
+        self.connection.connection_stop_reason()
+    }
+
+    #[inline]
+    fn set_connection_stop_reason(&mut self, reason: ConnectionStopReason) {
+        self.connection.set_connection_stop_reason(reason)
     }
 
     #[inline]

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -205,8 +205,9 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
             session_listener: begin_tx,
         };
 
-        let engine =
-            ConnectionEngine::open(transport, listener_connection, control_rx, outgoing_rx).await?;
+        let engine = ConnectionEngine::open(transport, listener_connection, control_rx, outgoing_rx)
+            .await?;
+        let connection_stop_reason = engine.connection_stop_reason.clone();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -215,6 +216,7 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
             handle,
             outcome,
             outgoing: outgoing_tx,
+            connection_stop_reason,
             session_listener: begin_rx,
         };
         Ok(connection_handle)

--- a/fe2o3-amqp/src/acceptor/error.rs
+++ b/fe2o3-amqp/src/acceptor/error.rs
@@ -1,13 +1,13 @@
 //! Implements errors for the acceptors
 
-use crate::link::{ReceiverAttachError, SenderAttachError};
+use crate::link::{ReceiverAttachError, SenderAttachError, SessionStopReason};
 
 /// Error accepting incoming attach
 #[derive(Debug, thiserror::Error)]
 pub enum AcceptorAttachError {
-    /// Session stopped
-    #[error("Session has stopped")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped
+    #[error("The session stopped before the link was attached: {:?}", .0)]
+    SessionStopped(SessionStopReason),
 
     /// Local sender is unable to accept incoming attach from remote receiver
     #[error("Local sender is unable to accept incoming attach from remote receiver")]
@@ -20,20 +20,12 @@ pub enum AcceptorAttachError {
 
 impl From<SenderAttachError> for AcceptorAttachError {
     fn from(value: SenderAttachError) -> Self {
-        if let SenderAttachError::IllegalSessionState = value {
-            Self::IllegalSessionState
-        } else {
-            Self::LocalSender(value)
-        }
+        Self::LocalSender(value)
     }
 }
 
 impl From<ReceiverAttachError> for AcceptorAttachError {
     fn from(value: ReceiverAttachError) -> Self {
-        if let ReceiverAttachError::IllegalSessionState = value {
-            Self::IllegalSessionState
-        } else {
-            Self::LocalReceiver(value)
-        }
+        Self::LocalReceiver(value)
     }
 }

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -13,7 +13,12 @@ use fe2o3_amqp_types::{
     primitives::{Symbol, Ulong},
 };
 
-use crate::{connection::DEFAULT_OUTGOING_BUFFER_SIZE, session::SessionHandle, util::Initialized};
+use crate::{
+    connection::DEFAULT_OUTGOING_BUFFER_SIZE,
+    link::SessionStopReason,
+    session::SessionHandle,
+    util::Initialized,
+};
 
 use super::{
     builder::Builder, error::AcceptorAttachError, local_receiver_link::LocalReceiverLinkAcceptor,
@@ -215,10 +220,97 @@ where
         &self,
         session: &mut ListenerSessionHandle,
     ) -> Result<LinkEndpoint, AcceptorAttachError> {
-        let remote_attach = session
-            .next_incoming_attach()
-            .await
-            .ok_or(AcceptorAttachError::IllegalSessionState)?;
+        let remote_attach = match session.next_incoming_attach().await {
+            Some(attach) => attach,
+            None => {
+                return Err(match session.session_stop_reason.get() {
+                    Some(reason) => AcceptorAttachError::SessionStopped(reason.clone()),
+                    None => {
+                        // The session engine should always record a stop reason
+                        // before its channels close; an unset cell here is a
+                        // defensive fallback.
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "accept: session stop reason not recorded; reporting SessionStopped(Ended)"
+                        );
+                        #[cfg(feature = "log")]
+                        log::warn!(
+                            "accept: session stop reason not recorded; reporting SessionStopped(Ended)"
+                        );
+                        AcceptorAttachError::SessionStopped(SessionStopReason::Ended)
+                    }
+                });
+            }
+        };
         self.accept_incoming_attach(remote_attach, session).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, OnceLock};
+
+    use fe2o3_amqp_types::performatives::Attach;
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::{AcceptorAttachError, LinkAcceptor, ListenerSessionHandle, SessionHandle, SessionStopReason};
+    use crate::{
+        control::SessionControl,
+        link::LinkFrame,
+        session::error::Error,
+    };
+
+    /// Constructs a listener session handle in the "ended" state: the link
+    /// listener sender is dropped (as if the session engine exited) and the
+    /// stop reason cell is either pre-set or left unset.
+    fn ended_listener_session_handle(
+        session_stop_reason: Option<SessionStopReason>,
+    ) -> ListenerSessionHandle {
+        let (_, link_listener) = mpsc::channel::<Attach>(16);
+        let (control, _) = mpsc::channel::<SessionControl>(16);
+        let (outgoing, _) = mpsc::channel::<LinkFrame>(16);
+        let (outcome_tx, outcome) = oneshot::channel::<Result<(), Error>>();
+        drop(outcome_tx);
+        let stop_reason_cell = Arc::new(OnceLock::new());
+        if let Some(reason) = session_stop_reason {
+            let _ = stop_reason_cell.set(reason);
+        }
+        SessionHandle {
+            is_ended: false,
+            control,
+            engine_handle: tokio::spawn(async {}),
+            outcome,
+            outgoing,
+            session_stop_reason: stop_reason_cell,
+            link_listener,
+        }
+    }
+
+    /// The recorded stop reason must be surfaced as-is when the link listener
+    /// ends.
+    #[tokio::test]
+    async fn accept_reports_recorded_stop_reason() {
+        let mut handle = ended_listener_session_handle(Some(SessionStopReason::ConnectionClosed));
+
+        let result = LinkAcceptor::new().accept(&mut handle).await;
+
+        match result {
+            Err(AcceptorAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+            other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
+        }
+    }
+
+    /// When the link listener ends without a recorded stop reason (defensive
+    /// fallback), the acceptor reports `Ended` rather than panicking.
+    #[tokio::test]
+    async fn accept_falls_back_to_ended_without_stop_reason() {
+        let mut handle = ended_listener_session_handle(None);
+
+        let result = LinkAcceptor::new().accept(&mut handle).await;
+
+        match result {
+            Err(AcceptorAttachError::SessionStopped(SessionStopReason::Ended)) => {}
+            other => panic!("expected SessionStopped(Ended), got {:?}", other),
+        }
     }
 }

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -290,12 +290,18 @@ mod tests {
     /// ends.
     #[tokio::test]
     async fn accept_reports_recorded_stop_reason() {
-        let mut handle = ended_listener_session_handle(Some(SessionStopReason::ConnectionClosed));
+        let mut handle = ended_listener_session_handle(Some(
+            SessionStopReason::ConnectionStopped(crate::connection::ConnectionStopReason::Closed),
+        ));
 
         let result = LinkAcceptor::new().accept(&mut handle).await;
 
         match result {
-            Err(AcceptorAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+            Err(AcceptorAttachError::SessionStopped(
+                SessionStopReason::ConnectionStopped(
+                    crate::connection::ConnectionStopReason::Closed,
+                ),
+            )) => {}
             other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
         }
     }

--- a/fe2o3-amqp/src/acceptor/local_receiver_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_receiver_link.rs
@@ -2,7 +2,7 @@
 
 use std::{
     marker::PhantomData,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use fe2o3_amqp_types::{
@@ -21,6 +21,7 @@ use crate::{
         state::{LinkFlowState, LinkFlowStateInner, LinkState},
         target_archetype::TargetArchetypeExt,
         LinkFrame, LinkIncomingItem, LinkRelay, ReceiverAttachError, ReceiverLink,
+        SessionStopReason,
     },
     session::SessionHandle,
     Receiver,
@@ -92,6 +93,7 @@ where
             remote_attach,
             session.control.clone(),
             session.outgoing.clone(),
+            session.session_stop_reason().clone(),
         )
         .await
         .map(|inner| Receiver { inner })
@@ -110,6 +112,7 @@ where
         remote_attach: Attach,
         control: mpsc::Sender<SessionControl>,
         outgoing: mpsc::Sender<LinkFrame>,
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
     ) -> Result<ReceiverInner<ReceiverLink<T>>, ReceiverAttachError>
     where
         T: Into<TargetArchetype>
@@ -172,6 +175,7 @@ where
             remote_attach.name.clone(),
             link_handle,
             input_handle,
+            &session_stop_reason,
         )
         .await?;
 
@@ -216,6 +220,7 @@ where
             desired_capabilities: shared.desired_capabilities.clone(),
             flow_state: flow_state_consumer,
             unsettled,
+            session_stop_reason,
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         };

--- a/fe2o3-amqp/src/acceptor/local_sender_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_sender_link.rs
@@ -127,6 +127,7 @@ where
             remote_attach.name.clone(),
             link_handle,
             input_handle,
+            session.session_stop_reason(),
         )
         .await?;
 
@@ -161,6 +162,7 @@ where
             desired_capabilities: shared.desired_capabilities.clone(),
             flow_state: flow_state_consumer,
             unsettled,
+            session_stop_reason: session.session_stop_reason().clone(),
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         };

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -2,6 +2,7 @@
 
 
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{
     definitions::{self, ConnectionError},
@@ -12,12 +13,12 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::{
-    connection::AllocSessionError,
+    connection::{AllocSessionError, ConnectionStopReason},
     control::{ConnectionControl, SessionControl},
     endpoint::{
         self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle, Session,
     },
-    link::{LinkFrame, LinkRelay},
+    link::{LinkFrame, LinkRelay, SessionStopReason},
     session::{
         self,
         engine::SessionEngine,
@@ -64,8 +65,26 @@ pub(crate) async fn allocate_incoming_link(
     link_name: String,
     link_relay: LinkRelay<()>,
     input_handle: InputHandle,
+    session_stop_reason: &Arc<OnceLock<SessionStopReason>>,
 ) -> Result<OutputHandle, AllocLinkError> {
     let (responder, resp_rx) = oneshot::channel();
+
+    let reason = || match session_stop_reason.get() {
+        Some(reason) => reason.clone(),
+        None => {
+            // The session engine should always record a stop reason before
+            // its channels close; an unset cell here is a defensive fallback.
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "allocate_incoming_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+            );
+            #[cfg(feature = "log")]
+            log::warn!(
+                "allocate_incoming_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+            );
+            SessionStopReason::Ended
+        }
+    };
 
     control
         .send(SessionControl::AllocateIncomingLink {
@@ -75,17 +94,10 @@ pub(crate) async fn allocate_incoming_link(
             responder,
         })
         .await
-        // The `SendError` could only happen when the receiving half is
-        // dropped, meaning the `SessionEngine::event_loop` has stopped.
-        // This would also mean the `Session` is Unmapped, and thus it
-        // may be treated as illegal state
-        .map_err(|_| AllocLinkError::IllegalSessionState)?;
+        .map_err(|_| AllocLinkError::SessionStopped(reason()))?;
     resp_rx
         .await
-        // The error could only occur when the sending half is dropped,
-        // indicating the `SessionEngine::even_loop` has stopped or
-        // unmapped. Thus it could be considered as illegal state
-        .map_err(|_| AllocLinkError::IllegalSessionState)?
+        .map_err(|_| AllocLinkError::SessionStopped(reason()))?
 }
 
 /// An acceptor for incoming session
@@ -160,6 +172,7 @@ impl SessionAcceptor {
             session_control_rx: mpsc::Receiver<SessionControl>,
             incoming: mpsc::Receiver<SessionFrame>,
             outgoing_link_frames: mpsc::Receiver<LinkFrame>,
+            conn_stop: Arc<OnceLock<ConnectionStopReason>>,
         ) -> Result<(JoinHandle<()>, oneshot::Receiver<Result<(), Error>>), BeginError> {
             let engine = SessionEngine::begin_listener_session(
                 connection.control.clone(),
@@ -168,6 +181,7 @@ impl SessionAcceptor {
                 incoming,
                 connection.outgoing.clone(),
                 outgoing_link_frames,
+                conn_stop,
             )
             .await?;
             Ok(engine.spawn())
@@ -185,6 +199,7 @@ impl SessionAcceptor {
             session_control_rx: mpsc::Receiver<SessionControl>,
             incoming: mpsc::Receiver<SessionFrame>,
             outgoing_link_frames: mpsc::Receiver<LinkFrame>,
+            conn_stop: Arc<OnceLock<ConnectionStopReason>>,
         ) -> Result<(JoinHandle<()>, oneshot::Receiver<Result<(), Error>>), BeginError> {
             match self.0.control_link_acceptor.clone() {
                 Some(control_link_acceptor) => {
@@ -203,6 +218,7 @@ impl SessionAcceptor {
                         incoming,
                         connection.outgoing.clone(),
                         outgoing_link_frames,
+                        conn_stop,
                     )
                     .await?;
                     Ok(engine.spawn())
@@ -215,6 +231,7 @@ impl SessionAcceptor {
                         incoming,
                         connection.outgoing.clone(),
                         outgoing_link_frames,
+                        conn_stop,
                     )
                     .await?;
                     Ok(engine.spawn())
@@ -271,7 +288,17 @@ impl SessionAcceptor {
             }
         };
 
-        let mut session = self.0.clone().into_session(outgoing_channel, local_state);
+        // The stop reason cells are created here so that the session object, the
+        // engine, and the handle share them: the engine publishes the reason on
+        // the session at exit, and the handle (and the links attached through
+        // it) can read it.
+        let conn_stop = connection.connection_stop_reason.clone();
+        let session_stop_reason = Arc::new(OnceLock::new());
+
+        let mut session = self
+            .0
+            .clone()
+            .into_session(outgoing_channel, local_state, session_stop_reason.clone());
         session.on_incoming_begin(
             IncomingChannel(incoming_session.channel),
             incoming_session.begin,
@@ -292,6 +319,7 @@ impl SessionAcceptor {
                 session_control_rx,
                 incoming_rx,
                 outgoing_rx,
+                conn_stop,
             )
             .await?;
 
@@ -301,6 +329,7 @@ impl SessionAcceptor {
             engine_handle,
             outcome,
             outgoing: outgoing_tx,
+            session_stop_reason,
             link_listener: link_listener_rx,
         };
         Ok(handle)
@@ -326,6 +355,7 @@ where
     S: ListenerSessionEndpoint + endpoint::SessionEndpoint,
     BeginError: From<S::BeginError>,
 {
+    #[allow(clippy::too_many_arguments)]
     pub async fn begin_listener_session(
         conn_control: mpsc::Sender<ConnectionControl>,
         session: S,
@@ -333,6 +363,7 @@ where
         incoming: mpsc::Receiver<SessionIncomingItem>,
         outgoing: mpsc::Sender<SessionFrame>,
         outgoing_link_frames: mpsc::Receiver<LinkFrame>,
+        conn_stop: Arc<OnceLock<ConnectionStopReason>>,
     ) -> Result<Self, BeginError> {
         #[cfg(feature = "tracing")]
         tracing::trace!("Instantiating session engine");
@@ -345,6 +376,7 @@ where
             incoming,
             outgoing,
             outgoing_link_frames,
+            conn_stop,
         };
 
         // send a begin
@@ -375,6 +407,14 @@ impl endpoint::Session for ListenerSession {
 
     fn local_state(&self) -> &Self::State {
         self.session.local_state()
+    }
+
+    fn set_session_stop_reason(&mut self, reason: SessionStopReason) {
+        self.session.set_session_stop_reason(reason)
+    }
+
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        self.session.session_stop_reason()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -23,7 +23,10 @@ use crate::{
         self,
         engine::SessionEngine,
         frame::{SessionFrame, SessionIncomingItem, SessionOutgoingItem},
-        error::{AllocLinkError, BeginError, Error, SessionInnerError}, SessionHandle, 
+        error::{
+            connection_stop_reason_or_closed, AllocLinkError, BeginError, Error, SessionInnerError,
+        },
+        SessionHandle,
         DEFAULT_SESSION_CONTROL_BUFFER_SIZE,
     },
     util::Initialized,
@@ -162,7 +165,6 @@ impl SessionAcceptor {
     }
 
     cfg_not_transaction! {
-        #[allow(clippy::too_many_arguments)]
         async fn launch_listener_session_engine<R>(
             &self,
             listener_session: ListenerSession,
@@ -172,7 +174,6 @@ impl SessionAcceptor {
             session_control_rx: mpsc::Receiver<SessionControl>,
             incoming: mpsc::Receiver<SessionFrame>,
             outgoing_link_frames: mpsc::Receiver<LinkFrame>,
-            conn_stop: Arc<OnceLock<ConnectionStopReason>>,
         ) -> Result<(JoinHandle<()>, oneshot::Receiver<Result<(), Error>>), BeginError> {
             let engine = SessionEngine::begin_listener_session(
                 connection.control.clone(),
@@ -181,7 +182,6 @@ impl SessionAcceptor {
                 incoming,
                 connection.outgoing.clone(),
                 outgoing_link_frames,
-                conn_stop,
             )
             .await?;
             Ok(engine.spawn())
@@ -199,7 +199,6 @@ impl SessionAcceptor {
             session_control_rx: mpsc::Receiver<SessionControl>,
             incoming: mpsc::Receiver<SessionFrame>,
             outgoing_link_frames: mpsc::Receiver<LinkFrame>,
-            conn_stop: Arc<OnceLock<ConnectionStopReason>>,
         ) -> Result<(JoinHandle<()>, oneshot::Receiver<Result<(), Error>>), BeginError> {
             match self.0.control_link_acceptor.clone() {
                 Some(control_link_acceptor) => {
@@ -218,7 +217,6 @@ impl SessionAcceptor {
                         incoming,
                         connection.outgoing.clone(),
                         outgoing_link_frames,
-                        conn_stop,
                     )
                     .await?;
                     Ok(engine.spawn())
@@ -231,7 +229,6 @@ impl SessionAcceptor {
                         incoming,
                         connection.outgoing.clone(),
                         outgoing_link_frames,
-                        conn_stop,
                     )
                     .await?;
                     Ok(engine.spawn())
@@ -265,9 +262,6 @@ impl SessionAcceptor {
                 let outgoing_channel = match connection.allocate_session(incoming_tx).await {
                     Ok(channel) => channel,
                     Err(error) => match error {
-                        AllocSessionError::IllegalState => {
-                            return Err(BeginError::IllegalConnectionState)
-                        }
                         AllocSessionError::ChannelMaxReached => {
                             let error = definitions::Error::new(
                                 ConnectionError::FramingError,
@@ -278,10 +272,15 @@ impl SessionAcceptor {
                                 .control
                                 .send(ConnectionControl::Close(Some(error)))
                                 .await
-                                .map_err(|_| BeginError::IllegalConnectionState)?;
+                                .map_err(|_| {
+                                    BeginError::ConnectionStopped(connection_stop_reason_or_closed(
+                                        &connection.connection_stop_reason,
+                                    ))
+                                })?;
 
                             return Err(BeginError::LocalChannelMaxReached);
                         }
+                        other => return Err(other.into()),
                     },
                 };
                 (outgoing_channel, incoming_rx)
@@ -292,13 +291,14 @@ impl SessionAcceptor {
         // engine, and the handle share them: the engine publishes the reason on
         // the session at exit, and the handle (and the links attached through
         // it) can read it.
-        let conn_stop = connection.connection_stop_reason.clone();
         let session_stop_reason = Arc::new(OnceLock::new());
 
-        let mut session = self
-            .0
-            .clone()
-            .into_session(outgoing_channel, local_state, session_stop_reason.clone());
+        let mut session = self.0.clone().into_session(
+            outgoing_channel,
+            local_state,
+            session_stop_reason.clone(),
+            connection.connection_stop_reason.clone(),
+        );
         session.on_incoming_begin(
             IncomingChannel(incoming_session.channel),
             incoming_session.begin,
@@ -319,7 +319,6 @@ impl SessionAcceptor {
                 session_control_rx,
                 incoming_rx,
                 outgoing_rx,
-                conn_stop,
             )
             .await?;
 
@@ -344,7 +343,9 @@ impl SessionAcceptor {
         let incoming_session = connection
             .next_incoming_session()
             .await
-            .ok_or(BeginError::IllegalConnectionState)?;
+            .ok_or(BeginError::ConnectionStopped(connection_stop_reason_or_closed(
+                &connection.connection_stop_reason,
+            )))?;
         self.accept_incoming_session(incoming_session, connection)
             .await
     }
@@ -363,7 +364,6 @@ where
         incoming: mpsc::Receiver<SessionIncomingItem>,
         outgoing: mpsc::Sender<SessionFrame>,
         outgoing_link_frames: mpsc::Receiver<LinkFrame>,
-        conn_stop: Arc<OnceLock<ConnectionStopReason>>,
     ) -> Result<Self, BeginError> {
         #[cfg(feature = "tracing")]
         tracing::trace!("Instantiating session engine");
@@ -376,7 +376,6 @@ where
             incoming,
             outgoing,
             outgoing_link_frames,
-            conn_stop,
         };
 
         // send a begin
@@ -415,6 +414,10 @@ impl endpoint::Session for ListenerSession {
 
     fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
         self.session.session_stop_reason()
+    }
+
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
+        self.session.connection_stop_reason()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -759,7 +759,6 @@ impl<Tls> Builder<'_, mode::ConnectorWithId, Tls> {
         let connection = Connection::new(local_state, local_open);
 
         let engine = ConnectionEngine::open(transport, connection, control_rx, outgoing_rx).await?;
-        // Self::spawn_engine(engine, control_tx, outgoing_tx)
         (spawn_engine_fn)(engine, control_tx, outgoing_tx)
     }
 }
@@ -1339,6 +1338,7 @@ cfg_not_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
+        let connection_stop_reason = engine.connection_stop_reason.clone();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -1347,6 +1347,7 @@ cfg_not_wasm32! {
             handle,
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
+            connection_stop_reason,
             session_listener: (),
         };
 
@@ -1364,6 +1365,7 @@ cfg_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
+        let connection_stop_reason = engine.connection_stop_reason.clone();
         let (handle, outcome) = engine.spawn_on_local_set(local_set);
 
         let connection_handle = ConnectionHandle {
@@ -1372,6 +1374,7 @@ cfg_wasm32! {
             handle,
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
+            connection_stop_reason,
             session_listener: (),
         };
 
@@ -1386,6 +1389,7 @@ cfg_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
+        let connection_stop_reason = engine.connection_stop_reason.clone();
         let (handle, outcome) = engine.spawn_local();
 
         let connection_handle = ConnectionHandle {
@@ -1394,6 +1398,7 @@ cfg_wasm32! {
             handle,
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
+            connection_stop_reason,
             session_listener: (),
         };
 

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -1338,7 +1338,7 @@ cfg_not_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
-        let connection_stop_reason = engine.connection_stop_reason.clone();
+        let connection_stop_reason = engine.connection_stop_reason().clone();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -1365,7 +1365,7 @@ cfg_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
-        let connection_stop_reason = engine.connection_stop_reason.clone();
+        let connection_stop_reason = engine.connection_stop_reason().clone();
         let (handle, outcome) = engine.spawn_on_local_set(local_set);
 
         let connection_handle = ConnectionHandle {
@@ -1389,7 +1389,7 @@ cfg_wasm32! {
     where
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
-        let connection_stop_reason = engine.connection_stop_reason.clone();
+        let connection_stop_reason = engine.connection_stop_reason().clone();
         let (handle, outcome) = engine.spawn_local();
 
         let connection_handle = ConnectionHandle {

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -32,7 +32,17 @@ pub(crate) struct ConnectionEngine<Io, C> {
     control: Receiver<ConnectionControl>,
     outgoing_session_frames: Receiver<SessionFrame>,
     heartbeat: HeartBeat,
-    pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+}
+
+impl<Io, C> ConnectionEngine<Io, C>
+where
+    C: endpoint::Connection,
+{
+    /// The shared cell holding why the connection stopped, on the connection
+    /// object and shared with the sessions and the handle
+    pub(crate) fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
+        self.connection.connection_stop_reason()
+    }
 }
 
 cfg_not_wasm32! {
@@ -225,7 +235,6 @@ where
             control,
             outgoing_session_frames,
             heartbeat: HeartBeat::never(),
-            connection_stop_reason: Arc::new(OnceLock::new()),
         };
 
         match engine.open_inner().await {
@@ -627,20 +636,12 @@ where
         //
         // When the Receiver is dropped, it is possible for unprocessed messages to remain
         // in the channel. Instead, it is usually desirable to perform a “clean” shutdown.
-        // To do this, the receiver first calls close, which will prevent any further messages
-        // to be sent into the channel. Then, the receiver consumes the channel to completion,
-        // at which point the receiver can be dropped.
-        self.control.close();
-        self.outgoing_session_frames.close();
+        // To do this, the receiver first closes the channels, which will prevent any
+        // further messages to be sent into them.
         let close = self.transport.close().await.map_err(Into::into);
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!("Stopped");
-        #[cfg(feature = "log")]
-        log::debug!("Stopped");
-
         let result = outcome.and(close).map_err(Into::into);
-        // Publish the stop reason before the session relays are dropped, so every
+
+        // Publish the stop reason before the channels are closed, so every
         // session that wakes on the channel closure sees it.
         let connection_stop_reason = match &result {
             Err(Error::RemoteClosedWithError(error)) => {
@@ -648,7 +649,17 @@ where
             }
             _ => ConnectionStopReason::Closed,
         };
-        let _ = self.connection_stop_reason.set(connection_stop_reason);
+        self.connection
+            .set_connection_stop_reason(connection_stop_reason);
+
+        self.control.close();
+        self.outgoing_session_frames.close();
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!("Stopped");
+        #[cfg(feature = "log")]
+        log::debug!("Stopped");
+
         let _ = tx.send(result);
     }
 }

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -2,6 +2,7 @@
 //! transferring frames/messages over channels
 
 use std::io;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use fe2o3_amqp_types::definitions::{self, AmqpError};
@@ -20,6 +21,7 @@ use crate::transport::Transport;
 use crate::util::Running;
 use crate::{endpoint, transport, SendBound};
 
+use super::ConnectionStopReason;
 use super::{heartbeat::HeartBeat, ConnectionState};
 use super::{AllocSessionError, ConnectionInnerError, ConnectionStateError, Error, OpenError};
 
@@ -30,6 +32,7 @@ pub(crate) struct ConnectionEngine<Io, C> {
     control: Receiver<ConnectionControl>,
     outgoing_session_frames: Receiver<SessionFrame>,
     heartbeat: HeartBeat,
+    pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
 }
 
 cfg_not_wasm32! {
@@ -222,6 +225,7 @@ where
             control,
             outgoing_session_frames,
             heartbeat: HeartBeat::never(),
+            connection_stop_reason: Arc::new(OnceLock::new()),
         };
 
         match engine.open_inner().await {
@@ -636,6 +640,15 @@ where
         log::debug!("Stopped");
 
         let result = outcome.and(close).map_err(Into::into);
+        // Publish the stop reason before the session relays are dropped, so every
+        // session that wakes on the channel closure sees it.
+        let connection_stop_reason = match &result {
+            Err(Error::RemoteClosedWithError(error)) => {
+                ConnectionStopReason::ClosedWithError(error.clone())
+            }
+            _ => ConnectionStopReason::Closed,
+        };
+        let _ = self.connection_stop_reason.set(connection_stop_reason);
         let _ = tx.send(result);
     }
 }

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -292,6 +292,15 @@ where
         #[cfg(feature = "log")]
         log::trace!("RECV frame={:?}", frame);
 
+        // In the DISCARDING state, any incoming frames on the connection MUST
+        // be silently discarded until the peer's close frame is received
+        // (AMQP 1.0 section 2.4.6).
+        if matches!(self.connection.local_state(), ConnectionState::Discarding)
+            && !matches!(frame.body, FrameBody::Close(_))
+        {
+            return Ok(Running::Continue);
+        }
+
         let Frame { channel, body } = frame;
         let channel = IncomingChannel(channel);
         match body {
@@ -384,6 +393,14 @@ where
         log::debug!("{}", control);
         match control {
             ConnectionControl::Close(error) => {
+                // Record a locally initiated close with an error before the
+                // channels close, so sessions and links observe the local
+                // error regardless of how the peer responds.
+                if let Some(error) = &error {
+                    self.connection.set_connection_stop_reason(
+                        ConnectionStopReason::ClosedWithError(error.clone()),
+                    );
+                }
                 self.outgoing_session_frames.close();
                 while let Some(frame) = self.outgoing_session_frames.recv().await {
                     self.on_outgoing_session_frames(frame).await?;
@@ -427,7 +444,10 @@ where
         frame: SessionFrame,
     ) -> Result<Running, ConnectionInnerError> {
         match self.connection.local_state() {
-            ConnectionState::Opened => {}
+            // The drain during the close exchange runs while the state is
+            // `CloseReceived`; the buffered frames are flushed as part of
+            // closing the connection.
+            ConnectionState::Opened | ConnectionState::CloseReceived => {}
             _ => return Err(ConnectionInnerError::IllegalState),
         }
 
@@ -645,8 +665,9 @@ where
         // session that wakes on the channel closure sees it.
         let connection_stop_reason = match &result {
             Err(Error::RemoteClosedWithError(error)) => {
-                ConnectionStopReason::ClosedWithError(error.clone())
+                ConnectionStopReason::RemoteClosedWithError(error.clone())
             }
+            Err(Error::RemoteClosed) => ConnectionStopReason::RemoteClosed,
             _ => ConnectionStopReason::Closed,
         };
         self.connection
@@ -659,7 +680,6 @@ where
         tracing::debug!("Stopped");
         #[cfg(feature = "log")]
         log::debug!("Stopped");
-
         let _ = tx.send(result);
     }
 }

--- a/fe2o3-amqp/src/connection/error.rs
+++ b/fe2o3-amqp/src/connection/error.rs
@@ -6,7 +6,10 @@ use bytes::Bytes;
 use fe2o3_amqp_types::{definitions, primitives::Binary, sasl::SaslCode};
 use tokio::{sync::mpsc, task::JoinError};
 
-use crate::transport::{self, error::NegotiationError};
+use crate::{
+    connection::ConnectionStopReason,
+    transport::{self, error::NegotiationError},
+};
 
 cfg_scram! {
     use crate::auth::error::ScramErrorKind;
@@ -256,8 +259,13 @@ impl From<ConnectionStateError> for Error {
 /// Error associated with allocation of new session
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AllocSessionError {
-    #[error("Illegal local state")]
-    IllegalState,
+    /// The connection has not been opened yet
+    #[error("The connection has not been opened")]
+    ConnectionNotOpened,
+
+    /// The connection stopped before the session was allocated
+    #[error("The connection stopped: {:?}", .0)]
+    ConnectionStopped(ConnectionStopReason),
 
     #[error("Reached connection channel max")]
     ChannelMaxReached,

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -62,12 +62,19 @@ type SessionRelay = Arc<Sender<SessionIncomingItem>>;
 
 /// Why the connection stopped, shared with the sessions so they can derive
 /// the reason their links observe.
+///
+/// The unprefixed variants describe the local side's action; the `Remote*`
+/// variants describe a remote-initiated close.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionStopReason {
-    /// The connection closed cleanly
+    /// The connection closed cleanly (locally)
     Closed,
-    /// The connection closed with an error
+    /// We closed the connection with this error
     ClosedWithError(definitions::Error),
+    /// The remote peer closed the connection cleanly
+    RemoteClosed,
+    /// The remote peer closed the connection with this error
+    RemoteClosedWithError(definitions::Error),
 }
 
 /// A handle to the [`Connection`] event loop.

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -1,6 +1,10 @@
 //! Implements AMQP1.0 Connection
 
-use std::{cmp::min, collections::HashMap, sync::Arc};
+use std::{
+    cmp::min,
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
 use fe2o3_amqp_types::{
     definitions::{self},
@@ -53,6 +57,16 @@ pub const DEFAULT_CHANNEL_MAX: u16 = 255;
 
 type SessionRelay = Arc<Sender<SessionIncomingItem>>;
 
+/// Why the connection stopped, shared with the sessions so they can derive
+/// the reason their links observe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ConnectionStopReason {
+    /// The connection closed cleanly
+    Closed,
+    /// The connection closed with an error
+    ClosedWithError(definitions::Error),
+}
+
 /// A handle to the [`Connection`] event loop.
 ///
 /// Dropping the handle will also stop the [`Connection`] event loop.
@@ -70,6 +84,8 @@ pub struct ConnectionHandle<R> {
 
     // outgoing channel for session
     pub(crate) outgoing: Sender<SessionFrame>,
+    /// Why the connection stopped, shared with the sessions
+    pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
     pub(crate) session_listener: R,
 }
 
@@ -138,6 +154,10 @@ impl<R> ConnectionHandle<R> {
 
     cfg_not_wasm32! {
         /// Close the connection
+        ///
+        /// Closing the connection implicitly ends its sessions (the AMQP model); there is
+        /// no need to end the sessions first. If the peer closed the connection with an
+        /// error, the error is reported through this method.
         ///
         /// An `Error::IllegalState` will be returned if this is called after executing any of
         /// [`close`](#method.close), [`close_with_error`](#method.close_with_error) or

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -30,8 +30,11 @@ use crate::{
     control::ConnectionControl,
     endpoint::{self, IncomingChannel, OutgoingChannel},
     frames::amqp::{Frame, FrameBody},
-    session::frame::{SessionFrame, SessionFrameBody, SessionIncomingItem},
     session::Session,
+    session::{
+        error::connection_stop_reason_or_closed,
+        frame::{SessionFrame, SessionFrameBody, SessionIncomingItem},
+    },
     SendBound,
 };
 
@@ -60,7 +63,7 @@ type SessionRelay = Arc<Sender<SessionIncomingItem>>;
 /// Why the connection stopped, shared with the sessions so they can derive
 /// the reason their links observe.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ConnectionStopReason {
+pub enum ConnectionStopReason {
     /// The connection closed cleanly
     Closed,
     /// The connection closed with an error
@@ -229,8 +232,16 @@ impl<R> ConnectionHandle<R> {
         self.control
             .send(ConnectionControl::AllocateSession { tx, responder })
             .await
-            .map_err(|_| AllocSessionError::IllegalState)?; // Connection must have stopped
-        resp_rx.await.map_err(|_| AllocSessionError::IllegalState)?
+            .map_err(|_| {
+                AllocSessionError::ConnectionStopped(connection_stop_reason_or_closed(
+                    &self.connection_stop_reason,
+                ))
+            })?; // Connection must have stopped
+        resp_rx.await.map_err(|_| {
+            AllocSessionError::ConnectionStopped(connection_stop_reason_or_closed(
+                &self.connection_stop_reason,
+            ))
+        })?
     }
 }
 
@@ -437,6 +448,9 @@ pub struct Connection {
 
     // mutually agreed channel max
     pub(crate) agreed_channel_max: u16,
+
+    /// Why this connection stopped, shared with the sessions and the handle
+    pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
 }
 
 /* ------------------------------- Public API ------------------------------- */
@@ -541,6 +555,7 @@ impl Connection {
 
             remote_open: None,
             agreed_channel_max,
+            connection_stop_reason: Arc::new(OnceLock::new()),
         }
     }
 }
@@ -561,18 +576,32 @@ impl endpoint::Connection for Connection {
         &self.local_open
     }
 
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
+        &self.connection_stop_reason
+    }
+
+    fn set_connection_stop_reason(&mut self, reason: ConnectionStopReason) {
+        let _ = self.connection_stop_reason.set(reason);
+    }
+
     fn allocate_session(
         &mut self,
         tx: Sender<SessionIncomingItem>,
     ) -> Result<OutgoingChannel, Self::AllocError> {
         match &self.local_state {
+            // The connection has not been opened yet
             ConnectionState::Start
             | ConnectionState::HeaderSent
             | ConnectionState::HeaderReceived
-            | ConnectionState::HeaderExchange
-            | ConnectionState::CloseSent
-            | ConnectionState::Discarding
-            | ConnectionState::End => return Err(AllocSessionError::IllegalState),
+            | ConnectionState::HeaderExchange => {
+                return Err(AllocSessionError::ConnectionNotOpened)
+            }
+            // The connection is closing or closed
+            ConnectionState::CloseSent | ConnectionState::Discarding | ConnectionState::End => {
+                return Err(AllocSessionError::ConnectionStopped(
+                    connection_stop_reason_or_closed(&self.connection_stop_reason),
+                ))
+            }
             // TODO: what about pipelined open?
             _ => {}
         };
@@ -825,5 +854,55 @@ impl Connection {
                 Ok(None)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fe2o3_amqp_types::performatives::Open;
+    use tokio::sync::mpsc;
+
+    use super::{
+        AllocSessionError, Connection, ConnectionState, ConnectionStopReason, SessionIncomingItem,
+    };
+    use crate::endpoint::Connection as _;
+
+    fn test_open() -> Open {
+        Open {
+            container_id: "test".to_string(),
+            hostname: None,
+            max_frame_size: Default::default(),
+            channel_max: Default::default(),
+            idle_time_out: None,
+            outgoing_locales: None,
+            incoming_locales: None,
+            offered_capabilities: None,
+            desired_capabilities: None,
+            properties: None,
+        }
+    }
+
+    /// Session allocation must distinguish a connection that has not been
+    /// opened yet from a connection that is closing or closed.
+    #[test]
+    fn allocate_session_distinguishes_not_opened_from_stopped() {
+        // Not opened yet
+        let mut connection = Connection::new(ConnectionState::Start, test_open());
+        let (tx, _rx) = mpsc::channel::<SessionIncomingItem>(8);
+        assert!(matches!(
+            connection.allocate_session(tx),
+            Err(AllocSessionError::ConnectionNotOpened)
+        ));
+
+        // Closing/closed (no stop reason recorded yet, so the defensive
+        // `Closed` fallback is reported)
+        let mut connection = Connection::new(ConnectionState::End, test_open());
+        let (tx, _rx) = mpsc::channel::<SessionIncomingItem>(8);
+        assert!(matches!(
+            connection.allocate_session(tx),
+            Err(AllocSessionError::ConnectionStopped(
+                ConnectionStopReason::Closed
+            ))
+        ));
     }
 }

--- a/fe2o3-amqp/src/endpoint/connection.rs
+++ b/fe2o3-amqp/src/endpoint/connection.rs
@@ -2,6 +2,8 @@
 
 use std::future::Future;
 
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::Error,
     performatives::{Begin, Close, End, Open},
@@ -9,7 +11,10 @@ use fe2o3_amqp_types::{
 use futures_util::Sink;
 use tokio::sync::mpsc;
 
-use crate::{frames::amqp::Frame, session::frame::SessionIncomingItem, SendBound};
+use crate::{
+    connection::ConnectionStopReason, frames::amqp::Frame, session::frame::SessionIncomingItem,
+    SendBound,
+};
 
 use super::{IncomingChannel, OutgoingChannel, Session};
 
@@ -24,6 +29,15 @@ pub(crate) trait Connection {
 
     fn local_state(&self) -> &Self::State;
     fn local_open(&self) -> &Open;
+
+    /// The shared cell holding why this connection stopped
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>>;
+
+    /// Record why this connection stopped
+    ///
+    /// Only succeeds if the stop reason has not been recorded yet; a later
+    /// call is a no-op (the first recorded reason wins).
+    fn set_connection_stop_reason(&mut self, reason: ConnectionStopReason);
 
     // Allocate outgoing channel id and session id to a new session
     fn allocate_session(

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -1,5 +1,7 @@
 //! Defines traits for link implementations
 
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::{DeliveryNumber, DeliveryTag, Error, Fields, MessageFormat, ReceiverSettleMode},
     messaging::{DeliveryState, FromBody},
@@ -13,7 +15,7 @@ use crate::{
     link::{
         delivery::{Delivery, DeliveryInfo},
         state::LinkState,
-        LinkFrame,
+        LinkFrame, SessionStopReason,
     },
     util::{AsByteIterator, IntoReader},
     Payload,
@@ -63,6 +65,9 @@ pub(crate) trait LinkExt: Link {
     fn name(&self) -> &str;
 
     fn output_handle_mut(&mut self) -> &mut Option<OutputHandle>;
+
+    /// The shared cell holding why the session (or its connection) stopped
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>>;
 
     fn flow_state(&self) -> &Self::FlowState;
 

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -12,6 +12,7 @@ use fe2o3_amqp_types::{
 use tokio::sync::mpsc;
 
 use crate::{
+    connection::ConnectionStopReason,
     link::{LinkRelay, SessionStopReason},
     session::frame::{SessionFrame, SessionOutgoingItem},
     Payload, SendBound,
@@ -29,10 +30,16 @@ pub(crate) trait Session {
     fn local_state(&self) -> &Self::State;
 
     /// Record why the session (or its connection) stopped
+    ///
+    /// Only succeeds if the stop reason has not been recorded yet; a later
+    /// call is a no-op (the first recorded reason wins).
     fn set_session_stop_reason(&mut self, reason: SessionStopReason);
 
     /// The shared cell holding why the session (or its connection) stopped
     fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>>;
+
+    /// The shared cell holding why the connection stopped
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>>;
 
     fn outgoing_channel(&self) -> OutgoingChannel;
 

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -2,6 +2,8 @@
 
 use std::future::Future;
 
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::Error,
     performatives::{Attach, Begin, Detach, Disposition, End, Flow, Transfer},
@@ -10,7 +12,7 @@ use fe2o3_amqp_types::{
 use tokio::sync::mpsc;
 
 use crate::{
-    link::LinkRelay,
+    link::{LinkRelay, SessionStopReason},
     session::frame::{SessionFrame, SessionOutgoingItem},
     Payload, SendBound,
 };
@@ -25,6 +27,12 @@ pub(crate) trait Session {
     type State;
 
     fn local_state(&self) -> &Self::State;
+
+    /// Record why the session (or its connection) stopped
+    fn set_session_stop_reason(&mut self, reason: SessionStopReason);
+
+    /// The shared cell holding why the session (or its connection) stopped
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>>;
 
     fn outgoing_channel(&self) -> OutgoingChannel;
 

--- a/fe2o3-amqp/src/link/builder.rs
+++ b/fe2o3-amqp/src/link/builder.rs
@@ -1,6 +1,6 @@
 //! Implements the builder for a link
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, sync::OnceLock};
 
 use fe2o3_amqp_types::{
     definitions::{Fields, ReceiverSettleMode, SenderSettleMode, SequenceNo},
@@ -26,7 +26,7 @@ use super::{
     target_archetype::VerifyTargetArchetype,
     ArcUnsettledMap, Receiver, ReceiverAttachError, ReceiverFlowState, ReceiverLink,
     ReceiverRelayFlowState, Sender, SenderAttachError, SenderFlowState, SenderLink,
-    SenderRelayFlowState,
+    SenderRelayFlowState, SessionStopReason,
 };
 
 cfg_transaction! {
@@ -419,6 +419,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
         unsettled: ArcUnsettledMap<M>,
         output_handle: OutputHandle,
         flow_state_consumer: C,
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
         // state_code: Arc<AtomicU8>,
     ) -> Link<Role, T, C, M> {
         let local_state = LinkState::Unattached;
@@ -446,6 +447,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             // flow_state: Consumer::new(notifier, flow_state),
             flow_state: flow_state_consumer,
             unsettled,
+            session_stop_reason,
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         }
@@ -536,9 +538,19 @@ where
         let unsettled = Arc::new(RwLock::new(None));
 
         let link_relay = LinkRelay::new_sender(incoming_tx, producer, unsettled.clone());
-        let output_handle =
-            session::allocate_link(&session.control, self.name.clone(), link_relay).await?;
-        let mut link = self.create_link(unsettled, output_handle, consumer);
+        let output_handle = session::allocate_link(
+            &session.control,
+            self.name.clone(),
+            link_relay,
+            session.session_stop_reason(),
+        )
+        .await?;
+        let mut link = self.create_link(
+            unsettled,
+            output_handle,
+            consumer,
+            session.session_stop_reason().clone(),
+        );
 
         match link
             .exchange_attach(&session.outgoing, &mut incoming_rx, &session.control, false)
@@ -575,7 +587,6 @@ where
             session: session.control.clone(),
             outgoing,
             incoming: incoming_rx,
-            // marker: PhantomData,
         };
         Ok(inner)
     }
@@ -649,9 +660,19 @@ where
         );
         // Create Link in Session
         // Any error here will be on the Session level and thus it should immediately return with an error
-        let output_handle =
-            session::allocate_link(&session.control, self.name.clone(), link_relay).await?;
-        let mut link = self.create_link(unsettled, output_handle, flow_state);
+        let output_handle = session::allocate_link(
+            &session.control,
+            self.name.clone(),
+            link_relay,
+            session.session_stop_reason(),
+        )
+        .await?;
+        let mut link = self.create_link(
+            unsettled,
+            output_handle,
+            flow_state,
+            session.session_stop_reason().clone(),
+        );
 
         match link
             .exchange_attach(&session.outgoing, &mut incoming_rx, &session.control, false)

--- a/fe2o3-amqp/src/link/delivery.rs
+++ b/fe2o3-amqp/src/link/delivery.rs
@@ -7,7 +7,12 @@ use fe2o3_amqp_types::{
 };
 use futures_util::FutureExt;
 use pin_project_lite::pin_project;
-use std::{future::Future, marker::PhantomData, task::Poll};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    sync::{Arc, OnceLock},
+    task::Poll,
+};
 use tokio::sync::oneshot::{self, error::RecvError};
 
 use crate::{
@@ -16,7 +21,7 @@ use crate::{
 };
 use crate::{util::AsDeliveryState, Payload};
 
-use super::{LinkStateError, SendError};
+use super::{LinkStateError, SendError, SessionStopReason};
 
 /// Delivery information that is needed for disposing a message
 #[derive(Clone)]
@@ -341,11 +346,26 @@ pin_project! {
         #[pin]
         // Reserved for future use on actively sending disposition from Sender
         settlement: Settlement,
-        outcome_marker: PhantomData<O>
+        outcome_marker: PhantomData<O>,
+        // Why the session (or its connection) stopped, consulted when the
+        // settlement oneshot dies
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
     }
 }
 
 impl<O> DeliveryFut<O> {
+    /// Create a new delivery future with the shared stop-reason cell
+    pub(crate) fn new(
+        settlement: Settlement,
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+    ) -> Self {
+        Self {
+            settlement,
+            outcome_marker: PhantomData,
+            session_stop_reason,
+        }
+    }
+
     /// Get the delivery tag
     pub fn delivery_tag(&self) -> &DeliveryTag {
         match &self.settlement {
@@ -354,15 +374,6 @@ impl<O> DeliveryFut<O> {
                 delivery_tag,
                 outcome: _,
             } => delivery_tag,
-        }
-    }
-}
-
-impl<O> From<Settlement> for DeliveryFut<O> {
-    fn from(settlement: Settlement) -> Self {
-        Self {
-            settlement,
-            outcome_marker: PhantomData,
         }
     }
 }
@@ -387,16 +398,26 @@ pub trait FromDeliveryState {
 }
 
 /// This trait defines how to interprete `tokio::sync::oneshot::error::RecvError`
+/// and a session-stop reason when the settlement channel dies
 ///
 /// This is public for compatibility with rust versions <= 1.58.0
-pub trait FromOneshotRecvError {
+pub trait FromDeliveryFailure {
     /// how to interprete `tokio::sync::oneshot::error::RecvError`
     fn from_oneshot_recv_error(err: RecvError) -> Self;
+
+    /// how to interprete a "the session (or its connection) stopped" failure
+    fn from_session_stop_reason(reason: SessionStopReason) -> Self;
 }
 
-impl FromOneshotRecvError for SendResult {
+impl FromDeliveryFailure for SendResult {
     fn from_oneshot_recv_error(_: RecvError) -> Self {
-        Err(LinkStateError::IllegalSessionState.into())
+        // The settlement channel died without the session recording a stop,
+        // e.g. the link was torn down with the delivery still pending.
+        Err(LinkStateError::IllegalState.into())
+    }
+
+    fn from_session_stop_reason(reason: SessionStopReason) -> Self {
+        Err(LinkStateError::SessionStopped(reason).into())
     }
 }
 
@@ -434,7 +455,7 @@ impl FromDeliveryState for SendResult {
 
 impl<O> Future for DeliveryFut<O>
 where
-    O: FromPreSettled + FromDeliveryState + FromOneshotRecvError,
+    O: FromPreSettled + FromDeliveryState + FromDeliveryFailure,
 {
     type Output = O;
 
@@ -459,8 +480,14 @@ where
                             Ok(None) => Poll::Ready(O::from_none()),
                             Err(err) => {
                                 // If the sender is dropped, there is likely issues with the connection
-                                // or the session, and thus the error should propagate to the user
-                                Poll::Ready(O::from_oneshot_recv_error(err))
+                                // or the session, and thus the error should propagate to the user.
+                                // When the session (or its connection) stopped, the shared cell
+                                // holds the reason; otherwise the link was torn down first.
+                                if let Some(reason) = this.session_stop_reason.get() {
+                                    Poll::Ready(O::from_session_stop_reason(reason.clone()))
+                                } else {
+                                    Poll::Ready(O::from_oneshot_recv_error(err))
+                                }
                             }
                         }
                     }
@@ -472,12 +499,18 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, OnceLock};
+
     use fe2o3_amqp_types::{
+        definitions::{self, ConnectionError, DeliveryTag},
         messaging::{AmqpValue, Body, Data, Message},
         primitives::Binary,
     };
 
     use crate::Sendable;
+
+    use super::{DeliveryFut, FromDeliveryFailure, SendResult, SessionStopReason};
+    use crate::link::{LinkStateError, SendError};
 
     struct Foo {}
 
@@ -517,5 +550,65 @@ mod tests {
         let value = Foo {};
         let sendable = Sendable::from(value);
         assert_eq!(sendable.message.body, Data(Binary::from("Foo")));
+    }
+
+    #[test]
+    fn test_send_result_from_session_stop_reason() {
+        let reason = SessionStopReason::ConnectionClosedWithError(definitions::Error::new(
+            ConnectionError::ConnectionForced,
+            None,
+            None,
+        ));
+        let result = <SendResult as FromDeliveryFailure>::from_session_stop_reason(reason.clone());
+        match result {
+            Err(SendError::LinkStateError(LinkStateError::SessionStopped(actual))) => {
+                assert_eq!(actual, reason);
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delivery_fut_uses_session_stop_reason() {
+        use crate::endpoint::Settlement;
+        use tokio::sync::oneshot;
+
+        let (tx, rx) = oneshot::channel();
+        let settlement = Settlement::Unsettled {
+            delivery_tag: DeliveryTag::from(b"tag".to_vec()),
+            outcome: rx,
+        };
+        let session_stop_reason = Arc::new(OnceLock::new());
+        session_stop_reason
+            .set(SessionStopReason::ConnectionClosed)
+            .unwrap();
+        let fut = DeliveryFut::new(settlement, session_stop_reason);
+        drop(tx);
+
+        match fut.await {
+            Err(SendError::LinkStateError(LinkStateError::SessionStopped(
+                SessionStopReason::ConnectionClosed,
+            ))) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delivery_fut_falls_back_without_stop_reason() {
+        use crate::endpoint::Settlement;
+        use tokio::sync::oneshot;
+
+        let (tx, rx) = oneshot::channel();
+        let settlement = Settlement::Unsettled {
+            delivery_tag: DeliveryTag::from(b"tag".to_vec()),
+            outcome: rx,
+        };
+        let fut = DeliveryFut::new(settlement, Arc::new(OnceLock::new()));
+        drop(tx);
+
+        match fut.await {
+            Err(SendError::LinkStateError(LinkStateError::IllegalState)) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
     }
 }

--- a/fe2o3-amqp/src/link/delivery.rs
+++ b/fe2o3-amqp/src/link/delivery.rs
@@ -554,11 +554,11 @@ mod tests {
 
     #[test]
     fn test_send_result_from_session_stop_reason() {
-        let reason = SessionStopReason::ConnectionClosedWithError(definitions::Error::new(
-            ConnectionError::ConnectionForced,
-            None,
-            None,
-        ));
+        let reason = SessionStopReason::ConnectionStopped(
+            crate::connection::ConnectionStopReason::RemoteClosedWithError(
+                definitions::Error::new(ConnectionError::ConnectionForced, None, None),
+            ),
+        );
         let result = <SendResult as FromDeliveryFailure>::from_session_stop_reason(reason.clone());
         match result {
             Err(SendError::LinkStateError(LinkStateError::SessionStopped(actual))) => {
@@ -580,14 +580,18 @@ mod tests {
         };
         let session_stop_reason = Arc::new(OnceLock::new());
         session_stop_reason
-            .set(SessionStopReason::ConnectionClosed)
+            .set(SessionStopReason::ConnectionStopped(
+                crate::connection::ConnectionStopReason::Closed,
+            ))
             .unwrap();
         let fut = DeliveryFut::new(settlement, session_stop_reason);
         drop(tx);
 
         match fut.await {
             Err(SendError::LinkStateError(LinkStateError::SessionStopped(
-                SessionStopReason::ConnectionClosed,
+                SessionStopReason::ConnectionStopped(
+                    crate::connection::ConnectionStopReason::Closed,
+                ),
             ))) => {}
             other => panic!("unexpected result: {:?}", other),
         }

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -8,6 +8,22 @@ use fe2o3_amqp_types::transaction::Coordinator;
 
 use super::{delivery::DeliveryInfo, receiver::DetachedReceiver, sender::DetachedSender};
 
+/// Why the link's session (or its connection) stopped before the link was
+/// detached or closed. From a link's perspective, a parent stopping earlier
+/// is always an error for the link's operations; the variants here describe
+/// the parent's state so the caller can decide how to recover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStopReason {
+    /// The session ended cleanly
+    Ended,
+    /// The session ended with an error
+    EndedWithError(definitions::Error),
+    /// The connection stopped first, cleanly
+    ConnectionClosed,
+    /// The connection stopped first, with an error
+    ConnectionClosedWithError(definitions::Error),
+}
+
 /// Error associated with detaching
 #[derive(Debug, thiserror::Error)]
 pub enum DetachError {
@@ -15,9 +31,9 @@ pub enum DetachError {
     #[error("Illegal local state")]
     IllegalState,
 
-    /// Session has dropped
-    #[error("Session has dropped")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped before the link was detached
+    #[error("The session stopped before the link was detached: {:?}", .0)]
+    SessionStopped(SessionStopReason),
 
     // /// Expecting a detach but found other frame
     // #[error("Expecting a Detach")]
@@ -42,17 +58,20 @@ pub enum DetachError {
 /// Errors associated with attaching a link as sender
 #[derive(Debug, thiserror::Error)]
 pub enum SenderAttachError {
-    // Illegal session state
-    /// Session stopped
-    #[error("Illegal session state. Session might have stopped.")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped before the attach completed
+    #[error("The session stopped before the link was attached: {:?}", .0)]
+    SessionStopped(SessionStopReason),
+
+    /// The session is not in the `Mapped` state (e.g. not begun, or ending)
+    #[error("The session is not in a state that permits link attachment")]
+    SessionNotMapped,
 
     /// Link name duplicated
     #[error("Link name is not unique.")]
     DuplicatedLinkName,
 
     /// Illegal link state
-    #[error("Illegal session state")]
+    #[error("Illegal link state")]
     IllegalState,
 
     /// The local terminus is expecting an Attach from the remote peer
@@ -198,17 +217,20 @@ impl std::error::Error for DesiredFilterNotSupported {}
 /// Errors associated with attaching a link as receiver
 #[derive(Debug, thiserror::Error)]
 pub enum ReceiverAttachError {
-    // Errors that should end the session
-    /// The associated session has dropped
-    #[error("Illegal session state. Session might have stopped.")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped before the attach completed
+    #[error("The session stopped before the link was attached: {:?}", .0)]
+    SessionStopped(SessionStopReason),
+
+    /// The session is not in the `Mapped` state (e.g. not begun, or ending)
+    #[error("The session is not in a state that permits link attachment")]
+    SessionNotMapped,
 
     /// Link name is already in use
     #[error("Link name is not unique.")]
     DuplicatedLinkName,
 
     /// Illegal link state
-    #[error("Illegal session state")]
+    #[error("Illegal link state")]
     IllegalState,
 
     /// The local terminus is expecting an Attach from the remote peer
@@ -266,7 +288,8 @@ pub enum ReceiverAttachError {
 impl From<AllocLinkError> for ReceiverAttachError {
     fn from(value: AllocLinkError) -> Self {
         match value {
-            AllocLinkError::IllegalSessionState => Self::IllegalSessionState,
+            AllocLinkError::SessionNotMapped => Self::SessionNotMapped,
+            AllocLinkError::SessionStopped(reason) => Self::SessionStopped(reason),
             AllocLinkError::DuplicatedLinkName => Self::DuplicatedLinkName,
         }
     }
@@ -277,7 +300,7 @@ impl<'a> TryFrom<&'a ReceiverAttachError> for definitions::Error {
 
     fn try_from(value: &'a ReceiverAttachError) -> Result<Self, Self::Error> {
         let condition: ErrorCondition = match value {
-            ReceiverAttachError::IllegalSessionState => AmqpError::IllegalState.into(),
+            ReceiverAttachError::SessionStopped(_) => AmqpError::IllegalState.into(),
             ReceiverAttachError::DuplicatedLinkName => SessionError::HandleInUse.into(),
             ReceiverAttachError::IllegalState => AmqpError::IllegalState.into(),
             ReceiverAttachError::NonAttachFrameReceived => AmqpError::NotAllowed.into(),
@@ -303,7 +326,8 @@ impl<'a> TryFrom<&'a ReceiverAttachError> for definitions::Error {
 impl From<AllocLinkError> for SenderAttachError {
     fn from(value: AllocLinkError) -> Self {
         match value {
-            AllocLinkError::IllegalSessionState => Self::IllegalSessionState,
+            AllocLinkError::SessionNotMapped => Self::SessionNotMapped,
+            AllocLinkError::SessionStopped(reason) => Self::SessionStopped(reason),
             AllocLinkError::DuplicatedLinkName => Self::DuplicatedLinkName,
         }
     }
@@ -315,7 +339,7 @@ impl TryFrom<DetachError> for SenderAttachError {
     fn try_from(value: DetachError) -> Result<Self, Self::Error> {
         match value {
             DetachError::IllegalState => Ok(Self::IllegalState),
-            DetachError::IllegalSessionState => Ok(Self::IllegalSessionState),
+            DetachError::SessionStopped(reason) => Ok(Self::SessionStopped(reason)),
             DetachError::RemoteDetachedWithError(error)
             | DetachError::RemoteClosedWithError(error) => {
                 // A closing detach is used for errors during attach anyway
@@ -333,7 +357,7 @@ impl TryFrom<DetachError> for ReceiverAttachError {
     fn try_from(value: DetachError) -> Result<Self, Self::Error> {
         match value {
             DetachError::IllegalState => Ok(Self::IllegalState),
-            DetachError::IllegalSessionState => Ok(Self::IllegalSessionState),
+            DetachError::SessionStopped(reason) => Ok(Self::SessionStopped(reason)),
             DetachError::RemoteDetachedWithError(error)
             | DetachError::RemoteClosedWithError(error) => {
                 // A closing detach is used for errors during attach anyway
@@ -350,7 +374,7 @@ impl<'a> TryFrom<&'a SenderAttachError> for definitions::Error {
 
     fn try_from(value: &'a SenderAttachError) -> Result<Self, Self::Error> {
         let condition: ErrorCondition = match value {
-            SenderAttachError::IllegalSessionState => AmqpError::IllegalState.into(),
+            SenderAttachError::SessionStopped(_) => AmqpError::IllegalState.into(),
             SenderAttachError::DuplicatedLinkName => SessionError::HandleInUse.into(),
             SenderAttachError::IllegalState => AmqpError::IllegalState.into(),
             SenderAttachError::NonAttachFrameReceived => AmqpError::NotAllowed.into(),
@@ -376,33 +400,6 @@ impl<'a> TryFrom<&'a SenderAttachError> for definitions::Error {
     }
 }
 
-/// Errors with sending attach
-pub(crate) enum SendAttachErrorKind {
-    /// Illegal link state
-    IllegalState,
-
-    /// Illegal session state
-    IllegalSessionState,
-}
-
-impl From<SendAttachErrorKind> for SenderAttachError {
-    fn from(value: SendAttachErrorKind) -> Self {
-        match value {
-            SendAttachErrorKind::IllegalState => Self::IllegalState,
-            SendAttachErrorKind::IllegalSessionState => Self::IllegalSessionState,
-        }
-    }
-}
-
-impl From<SendAttachErrorKind> for ReceiverAttachError {
-    fn from(value: SendAttachErrorKind) -> Self {
-        match value {
-            SendAttachErrorKind::IllegalState => Self::IllegalState,
-            SendAttachErrorKind::IllegalSessionState => Self::IllegalSessionState,
-        }
-    }
-}
-
 /// Errors associated with link state
 #[derive(Debug, thiserror::Error)]
 pub enum LinkStateError {
@@ -410,9 +407,9 @@ pub enum LinkStateError {
     #[error("Illegal local state")]
     IllegalState,
 
-    /// Session has dropped
-    #[error("Session has dropped")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped before the link was detached or closed
+    #[error("The session stopped before the link was detached or closed: {:?}", .0)]
+    SessionStopped(SessionStopReason),
 
     /// Remote peer detached
     #[error("Remote detached")]
@@ -440,12 +437,11 @@ impl From<DetachError> for LinkStateError {
     fn from(value: DetachError) -> Self {
         match value {
             DetachError::IllegalState => Self::IllegalState,
-            DetachError::IllegalSessionState => Self::IllegalSessionState,
+            DetachError::SessionStopped(reason) => Self::SessionStopped(reason),
             DetachError::RemoteDetachedWithError(error) => Self::RemoteDetachedWithError(error),
             DetachError::ClosedByRemote => Self::RemoteClosed,
             DetachError::DetachedByRemote => Self::RemoteDetached,
             DetachError::RemoteClosedWithError(error) => Self::RemoteClosedWithError(error),
-            // DetachError::NonDetachFrameReceived => Self::ExpectImmediateDetach,
         }
     }
 }
@@ -571,16 +567,18 @@ pub enum IllegalLinkStateError {
     #[error("Illegal local state")]
     IllegalState,
 
-    /// Session has dropped
-    #[error("Session has dropped")]
-    IllegalSessionState,
+    /// The session (or its connection) stopped before the link was detached or closed
+    #[error("The session stopped before the link was detached or closed: {:?}", .0)]
+    SessionStopped(SessionStopReason),
 }
+
+pub(crate) type SendAttachErrorKind = IllegalLinkStateError;
 
 impl From<IllegalLinkStateError> for LinkStateError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => LinkStateError::IllegalState,
-            IllegalLinkStateError::IllegalSessionState => LinkStateError::IllegalSessionState,
+            IllegalLinkStateError::SessionStopped(reason) => LinkStateError::SessionStopped(reason),
         }
     }
 }
@@ -589,7 +587,9 @@ impl From<IllegalLinkStateError> for ReceiverAttachError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => ReceiverAttachError::IllegalState,
-            IllegalLinkStateError::IllegalSessionState => ReceiverAttachError::IllegalSessionState,
+            IllegalLinkStateError::SessionStopped(reason) => {
+                ReceiverAttachError::SessionStopped(reason)
+            }
         }
     }
 }
@@ -598,7 +598,9 @@ impl From<IllegalLinkStateError> for SenderAttachError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => SenderAttachError::IllegalState,
-            IllegalLinkStateError::IllegalSessionState => SenderAttachError::IllegalSessionState,
+            IllegalLinkStateError::SessionStopped(reason) => {
+                SenderAttachError::SessionStopped(reason)
+            }
         }
     }
 }
@@ -607,8 +609,8 @@ impl From<IllegalLinkStateError> for SendError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => LinkStateError::IllegalState.into(),
-            IllegalLinkStateError::IllegalSessionState => {
-                LinkStateError::IllegalSessionState.into()
+            IllegalLinkStateError::SessionStopped(reason) => {
+                LinkStateError::SessionStopped(reason).into()
             }
         }
     }
@@ -618,7 +620,7 @@ impl From<IllegalLinkStateError> for DetachError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => Self::IllegalState,
-            IllegalLinkStateError::IllegalSessionState => Self::IllegalSessionState,
+            IllegalLinkStateError::SessionStopped(reason) => Self::SessionStopped(reason),
         }
     }
 }
@@ -631,38 +633,6 @@ where
         Self::LinkStateError(value.into())
     }
 }
-
-// /// Error trying to unwrap the body section
-// #[derive(Debug, thiserror::Error)]
-// pub enum BodyError {
-//     /// Attempting to unwrap the body as either sequence or data but body is value
-//     #[error("Body is Value")]
-//     IsValue,
-
-//     /// Attempting to unwrap the body as either sequence or value but body is Data
-//     #[error("Body is Data")]
-//     IsData,
-
-//     /// Attempting to unwrap the body as either value or data but body is sequence
-//     #[error("Body is Sequence")]
-//     IsSequence,
-
-//     /// Attempting to unwrap the body as either sequence or value but body is DataBatch
-//     ///
-//     /// Added since `"0.6.0"`
-//     #[error("Body is DataBatch")]
-//     IsDataBatch,
-
-//     /// Attempting to unwrap the body as either sequence or value but body is SequenceBatch
-//     ///
-//     /// Added since `"0.6.0"`
-//     #[error("Body is SequenceBatch")]
-//     IsSequenceBatch,
-
-//     /// Attempting to unwrap the body but no body section is found
-//     #[error("Body is nothing")]
-//     IsEmpty,
-// }
 
 /// Errors associated with resuming a sender link endpoint
 #[derive(Debug, thiserror::Error)]

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -1,7 +1,7 @@
 use fe2o3_amqp_types::definitions::{self, AmqpError, ErrorCondition, SessionError};
 use serde_amqp::primitives::Symbol;
 
-use crate::session::error::AllocLinkError;
+use crate::{connection::ConnectionStopReason, session::error::AllocLinkError};
 
 #[cfg(docsrs)]
 use fe2o3_amqp_types::transaction::Coordinator;
@@ -12,16 +12,23 @@ use super::{delivery::DeliveryInfo, receiver::DetachedReceiver, sender::Detached
 /// detached or closed. From a link's perspective, a parent stopping earlier
 /// is always an error for the link's operations; the variants here describe
 /// the parent's state so the caller can decide how to recover.
+///
+/// The unprefixed variants describe the local side's action; the `Remote*`
+/// variants describe a remote-initiated end. `ConnectionStopped(..)` embeds
+/// the connection's own stop reason (see [`ConnectionStopReason`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionStopReason {
-    /// The session ended cleanly
+    /// The session ended cleanly (locally)
     Ended,
-    /// The session ended with an error
+    /// We ended the session with this error
     EndedWithError(definitions::Error),
-    /// The connection stopped first, cleanly
-    ConnectionClosed,
-    /// The connection stopped first, with an error
-    ConnectionClosedWithError(definitions::Error),
+    /// The remote peer ended the session cleanly
+    RemoteEnded,
+    /// The remote peer ended the session with this error
+    RemoteEndedWithError(definitions::Error),
+    /// The connection stopped; the embedded reason tells whether the close
+    /// was local or remote and whether it carried an error
+    ConnectionStopped(ConnectionStopReason),
 }
 
 /// Error associated with detaching

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -1,6 +1,6 @@
 //! Implements AMQP1.0 Link
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, sync::OnceLock};
 
 use bytes::{BufMut, BytesMut};
 use fe2o3_amqp_types::{
@@ -209,6 +209,9 @@ pub(crate) struct Link<R, T, F, M> {
     pub(crate) flow_state: F,
     pub(crate) unsettled: ArcUnsettledMap<M>,
 
+    /// Why the session (or its connection) stopped, shared from the session
+    pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+
     pub(crate) verify_incoming_source: bool,
     pub(crate) verify_incoming_target: bool,
 }
@@ -355,7 +358,7 @@ where
         let attach = match unsettled_map_len {
             Some(0) | None => self.as_complete_attach(handle, is_reattaching),
             Some(_) => {
-                let max_frame_size = get_max_frame_size(session).await?; // FIXME: cancel safe?
+                let max_frame_size = get_max_frame_size(session, &self.session_stop_reason).await?; // FIXME: cancel safe?
                 self.as_maybe_incomplete_attach(max_frame_size, handle, is_reattaching)?
             }
         };
@@ -367,7 +370,10 @@ where
             | LinkState::Detached // May attempt to resume
             | LinkState::DetachSent => {
                 writer.send(frame).await // cancel safe
-                    .map_err(|_| SendAttachErrorKind::IllegalSessionState)?;
+                    .map_err(|_| match self.session_stop_reason.get() {
+                        Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
+                        None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    })?;
                 if incomplete_unsettled {
                     self.local_state = LinkState::IncompleteAttachSent
                 } else {
@@ -376,7 +382,10 @@ where
             }
             LinkState::AttachReceived => {
                 writer.send(frame).await // cancel safe
-                    .map_err(|_| SendAttachErrorKind::IllegalSessionState)?;
+                    .map_err(|_| match self.session_stop_reason.get() {
+                        Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
+                        None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    })?;
                 if incomplete_unsettled {
                     self.local_state = LinkState::IncompleteAttachExchanged
                 } else {
@@ -395,14 +404,21 @@ where
 /// This should cancel safe if oneshot channel is cancel safe
 pub(crate) async fn get_max_frame_size(
     control: &mpsc::Sender<SessionControl>,
+    session_stop_reason: &OnceLock<SessionStopReason>,
 ) -> Result<usize, SendAttachErrorKind> {
     let (tx, rx) = oneshot::channel();
     control
         .send(SessionControl::GetMaxFrameSize(tx))
         .await // cancel safe
-        .map_err(|_| SendAttachErrorKind::IllegalSessionState)?;
+        .map_err(|_| match session_stop_reason.get() {
+            Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
+            None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })?;
     rx.await // FIXME: is oneshot channel cancel safe?
-        .map_err(|_| SendAttachErrorKind::IllegalSessionState)
+        .map_err(|_| match session_stop_reason.get() {
+            Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
+            None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })
 }
 
 impl<R, T, F, M> endpoint::LinkDetach for Link<R, T, F, M>
@@ -510,7 +526,10 @@ where
                 let result = writer
                     .send(LinkFrame::Detach(detach))
                     .await // cancel safe
-                    .map_err(|_| DetachError::IllegalSessionState);
+                    .map_err(|_| match self.session_stop_reason.get() {
+                        Some(reason) => DetachError::SessionStopped(reason.clone()),
+                        None => DetachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    });
 
                 self.output_handle.take();
                 result

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -1,7 +1,7 @@
 //! Implementation of AMQP1.0 receiver
 
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{
     definitions::{self, DeliveryTag, Fields, Handle, ReceiverSettleMode, Role, SequenceNo},
@@ -35,7 +35,7 @@ use super::{
     ArcReceiverUnsettledMap, DetachThenResumeReceiverError, DispositionError, FlowError,
     IllegalLinkStateError, LinkFrame, LinkRelay, LinkStateError, ReceiverAttachError,
     ReceiverAttachExchange, ReceiverFlowState, ReceiverLink, ReceiverResumeError,
-    ReceiverResumeErrorKind, ReceiverTransferError, RecvError, DEFAULT_CREDIT,
+    ReceiverResumeErrorKind, ReceiverTransferError, RecvError, SessionStopReason, DEFAULT_CREDIT,
 };
 
 cfg_transaction! {
@@ -590,6 +590,7 @@ impl Receiver {
             output_handle: self.inner.link.output_handle.clone(),
             processed: Arc::clone(&self.inner.processed),
             credit_mode: self.inner.credit_mode.clone(),
+            session_stop_reason: self.inner.link.session_stop_reason.clone(),
         }
     }
 }
@@ -610,6 +611,7 @@ pub struct ReceiverDisposer {
     output_handle: Option<OutputHandle>,
     processed: Arc<AtomicU32>,
     credit_mode: CreditMode,
+    session_stop_reason: Arc<OnceLock<SessionStopReason>>,
 }
 
 impl ReceiverDisposer {
@@ -669,7 +671,10 @@ impl ReceiverDisposer {
             self.outgoing
                 .send(LinkFrame::Disposition(disposition))
                 .await
-                .map_err(|_| DispositionError::IllegalSessionState)?;
+                .map_err(|_| match self.session_stop_reason.get() {
+                    Some(reason) => DispositionError::SessionStopped(reason.clone()),
+                    None => DispositionError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                })?;
         }
 
         let prev = self.processed.fetch_add(1, Ordering::Release);
@@ -683,7 +688,7 @@ impl ReceiverDisposer {
                 let handle: Handle = self
                     .output_handle
                     .clone()
-                    .ok_or(DispositionError::IllegalSessionState)?
+                    .ok_or(DispositionError::IllegalState)?
                     .into();
                 let delivery_count = {
                     let mut guard = self.flow_state.lock.write();
@@ -703,7 +708,10 @@ impl ReceiverDisposer {
                 self.outgoing
                     .send(LinkFrame::Flow(flow))
                     .await
-                    .map_err(|_| DispositionError::IllegalSessionState)?;
+                    .map_err(|_| match self.session_stop_reason.get() {
+                        Some(reason) => DispositionError::SessionStopped(reason.clone()),
+                        None => DispositionError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    })?;
             }
         }
         Ok(())
@@ -866,6 +874,10 @@ where
         &self.session
     }
 
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        self.link().session_stop_reason()
+    }
+
     async fn exchange_attach(
         &mut self,
         is_reattaching: bool,
@@ -960,11 +972,22 @@ where
     where
         for<'de> T: FromBody<'de> + Send,
     {
-        let frame = self
-            .incoming
-            .recv()
-            .await // cancel safe
-            .ok_or(LinkStateError::IllegalSessionState)?;
+        // When the session or the connection stops, the channel closes and this
+        // returns `RecvError::LinkStateError(SessionStopped(reason))` with the
+        // stop reason observed by the link.
+        let frame = match self.incoming.recv().await {
+            // cancel safe
+            Some(frame) => frame,
+            None => {
+                return Err(match self.link().session_stop_reason().get() {
+                    Some(reason) => {
+                        RecvError::LinkStateError(LinkStateError::SessionStopped(reason.clone()))
+                    }
+                    // defensive: no stop reason recorded; failure is link-local
+                    None => RecvError::LinkStateError(LinkStateError::IllegalState),
+                });
+            }
+        };
 
         match frame {
             LinkFrame::Detach(detach) => {
@@ -1739,6 +1762,7 @@ mod tests {
             output_handle: Some(OutputHandle(1)),
             processed: Arc::new(AtomicU32::new(0)),
             credit_mode,
+            session_stop_reason: Arc::new(OnceLock::new()),
         }
     }
 

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::{Fields, Handle},
     messaging::{message::DecodeIntoMessage, FromBody},
@@ -58,7 +60,10 @@ where
         writer
             .send(LinkFrame::Flow(flow))
             .await // cancel safe
-            .map_err(|_| Self::FlowError::IllegalSessionState)
+            .map_err(|_| match self.session_stop_reason.get() {
+                Some(reason) => Self::FlowError::SessionStopped(reason.clone()),
+                None => Self::FlowError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+            })
     }
 
     fn on_transfer_state(
@@ -292,7 +297,10 @@ where
             writer
                 .send(frame)
                 .await // cancel safe
-                .map_err(|_| Self::DispositionError::IllegalSessionState)?;
+                .map_err(|_| match self.session_stop_reason.get() {
+                    Some(reason) => Self::DispositionError::SessionStopped(reason.clone()),
+                    None => Self::DispositionError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                })?;
         }
 
         Ok(())
@@ -420,7 +428,10 @@ impl ReceiverLink<Target> {
             let flow = self.get_link_flow(handle, link_credit, drain, echo, include_properties);
             writer
                 .blocking_send(LinkFrame::Flow(flow))
-                .map_err(|_| FlowError::IllegalSessionState)
+                .map_err(|_| match self.session_stop_reason.get() {
+                    Some(reason) => FlowError::SessionStopped(reason.clone()),
+                    None => FlowError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                })
         }
     }
 }
@@ -500,7 +511,10 @@ impl<T> ReceiverLink<T> {
         writer
             .send(frame)
             .await // cancel safe
-            .map_err(|_| DispositionError::IllegalSessionState)
+            .map_err(|_| match self.session_stop_reason.get() {
+                Some(reason) => DispositionError::SessionStopped(reason.clone()),
+                None => DispositionError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+            })
     }
 
     fn get_link_flow(
@@ -781,6 +795,10 @@ where
         &mut self.output_handle
     }
 
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        &self.session_stop_reason
+    }
+
     fn flow_state(&self) -> &Self::FlowState {
         &self.flow_state
     }
@@ -833,8 +851,10 @@ where
         let remote_attach = match reader
             .recv()
             .await // cancel safe
-            .ok_or(ReceiverAttachError::IllegalSessionState)?
-        {
+            .ok_or_else(|| match self.session_stop_reason.get() {
+                Some(reason) => ReceiverAttachError::SessionStopped(reason.clone()),
+                None => ReceiverAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+            })? {
             LinkFrame::Attach(attach) => attach,
             _ => return Err(ReceiverAttachError::NonAttachFrameReceived),
         };
@@ -851,7 +871,7 @@ where
     ) -> ReceiverAttachError {
         match attach_error {
             // Errors that indicate failed attachment
-            ReceiverAttachError::IllegalSessionState
+            ReceiverAttachError::SessionStopped(_)
             | ReceiverAttachError::IllegalState
             | ReceiverAttachError::NonAttachFrameReceived
             | ReceiverAttachError::ExpectImmediateDetach
@@ -867,7 +887,10 @@ where
                     .send(SessionControl::End(Some(error)))
                     .await
                     .map(|_| attach_error)
-                    .unwrap_or(ReceiverAttachError::IllegalSessionState)
+                    .unwrap_or(match self.session_stop_reason.get() {
+                        Some(reason) => ReceiverAttachError::SessionStopped(reason.clone()),
+                        None => ReceiverAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    })
             }
 
             // ReceiverAttachError::SndSettleModeNotSupported
@@ -877,7 +900,10 @@ where
                     .send_detach(writer, true, None)
                     .await
                     .map(|_| attach_error)
-                    .unwrap_or(ReceiverAttachError::IllegalSessionState);
+                    .unwrap_or(match self.session_stop_reason.get() {
+                        Some(reason) => ReceiverAttachError::SessionStopped(reason.clone()),
+                        None => ReceiverAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    });
                 recv_detach(self, reader, err).await
             }
 
@@ -889,7 +915,10 @@ where
                 match (&attach_error).try_into() {
                     Ok(error) => match self.send_detach(writer, true, Some(error)).await {
                         Ok(_) => recv_detach(self, reader, attach_error).await,
-                        Err(_) => ReceiverAttachError::IllegalSessionState,
+                        Err(_) => match self.session_stop_reason.get() {
+                            Some(reason) => ReceiverAttachError::SessionStopped(reason.clone()),
+                            None => ReceiverAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                        },
                     },
                     Err(_) => attach_error,
                 }
@@ -918,7 +947,10 @@ where
             Err(detach_error) => detach_error.try_into().unwrap_or(err),
         },
         Some(_) => ReceiverAttachError::NonAttachFrameReceived,
-        None => ReceiverAttachError::IllegalSessionState,
+        None => match link.session_stop_reason.get() {
+            Some(reason) => ReceiverAttachError::SessionStopped(reason.clone()),
+            None => ReceiverAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        },
     }
 }
 

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -1,5 +1,7 @@
 //! Implementation of AMQP1.0 sender
 
+use std::sync::{Arc, OnceLock};
+
 use bytes::{Bytes, BytesMut};
 use tokio::sync::{mpsc, oneshot};
 
@@ -36,7 +38,7 @@ use super::{
     },
     ArcSenderUnsettledMap, DetachThenResumeSenderError, LinkFrame, LinkRelay, LinkStateError,
     SendError, SenderAttachError, SenderAttachExchange, SenderFlowState, SenderLink,
-    SenderResumeError, SenderResumeErrorKind,
+    SenderResumeError, SenderResumeErrorKind, SessionStopReason,
 };
 
 #[cfg(docsrs)]
@@ -393,7 +395,9 @@ impl Sender {
             .inner
             .send_with_state::<T, SendError>(sendable.into(), None, false)
             .await
-            .map(DeliveryFut::from)?;
+            .map(|settlement| {
+                DeliveryFut::new(settlement, self.inner.link.session_stop_reason.clone())
+            })?;
         fut.await
     }
 
@@ -409,7 +413,9 @@ impl Sender {
             .inner
             .send_ref_with_state::<T, SendError>(sendable, None, false)
             .await
-            .map(DeliveryFut::from)?;
+            .map(|settlement| {
+                DeliveryFut::new(settlement, self.inner.link.session_stop_reason.clone())
+            })?;
         fut.await
     }
 
@@ -444,7 +450,9 @@ impl Sender {
         self.inner
             .send_with_state(sendable.into(), None, true)
             .await
-            .map(DeliveryFut::from)
+            .map(|settlement| {
+                DeliveryFut::new(settlement, self.inner.link.session_stop_reason.clone())
+            })
     }
 
     /// Like [`send_batchable()`](#method.send_batchable) but this only takes a reference.
@@ -458,7 +466,9 @@ impl Sender {
         self.inner
             .send_ref_with_state(sendable, None, true)
             .await
-            .map(DeliveryFut::from)
+            .map(|settlement| {
+                DeliveryFut::new(settlement, self.inner.link.session_stop_reason.clone())
+            })
     }
 
     /// Returns when the remote peer detach/close the link
@@ -566,6 +576,10 @@ where
 
     fn session_control(&self) -> &mpsc::Sender<SessionControl> {
         &self.session
+    }
+
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        self.link().session_stop_reason()
     }
 
     async fn exchange_attach(

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{definitions::Fields, messaging::MESSAGE_FORMAT};
 use futures_util::Future;
 
@@ -38,13 +40,27 @@ where
         let more = (self.max_message_size != 0) && (payload.len() as u64 > self.max_message_size);
         if !more {
             transfer.more = false;
-            send_transfer(writer, input_handle, transfer, payload.clone()).await?;
+            send_transfer(
+                writer,
+                input_handle,
+                transfer,
+                payload.clone(),
+                &self.session_stop_reason,
+            )
+            .await?;
         // cancel safe
         } else {
             // Send the first frame
             let partial = payload.split_to(self.max_message_size as usize);
             transfer.more = true;
-            send_transfer(writer, input_handle.clone(), transfer.clone(), partial).await?; // cancel safe
+            send_transfer(
+                writer,
+                input_handle.clone(),
+                transfer.clone(),
+                partial,
+                &self.session_stop_reason,
+            )
+            .await?; // cancel safe
 
             // Send the transfers in the middle
             while payload.len() > self.max_message_size as usize {
@@ -52,7 +68,14 @@ where
                 transfer.delivery_tag = None;
                 transfer.message_format = None;
                 transfer.settled = None;
-                send_transfer(writer, input_handle.clone(), transfer.clone(), partial).await?;
+                send_transfer(
+                    writer,
+                    input_handle.clone(),
+                    transfer.clone(),
+                    partial,
+                    &self.session_stop_reason,
+                )
+                .await?;
                 // cancel safe
             }
 
@@ -61,7 +84,15 @@ where
             // data MAY be trans- ferred in additional transfer frames by setting the more flag on
             // all but the last transfer frame
             transfer.more = false;
-            send_transfer(writer, input_handle, transfer, payload).await?; // cancel safe
+            send_transfer(
+                writer,
+                input_handle,
+                transfer,
+                payload,
+                &self.session_stop_reason,
+            )
+            .await?;
+            // cancel safe
         }
 
         Ok(settled)
@@ -275,7 +306,16 @@ where
             }
         }
 
-        send_disposition(writer, delivery_id, None, settled, Some(state), batchable).await
+        send_disposition(
+            writer,
+            delivery_id,
+            None,
+            settled,
+            Some(state),
+            batchable,
+            &self.session_stop_reason,
+        )
+        .await
     }
 
     async fn batch_dispose(
@@ -323,6 +363,7 @@ where
                             settled,
                             Some(state.clone()),
                             batchable,
+                            &self.session_stop_reason,
                         )
                         .await?;
                     }
@@ -339,6 +380,7 @@ where
                             settled,
                             Some(state.clone()),
                             batchable,
+                            &self.session_stop_reason,
                         )
                         .await?;
                     }
@@ -349,7 +391,16 @@ where
 
         // if there is only one message to dispose
         if let (Some(first_id), None) = (first, last) {
-            send_disposition(writer, first_id, None, settled, Some(state), batchable).await?;
+            send_disposition(
+                writer,
+                first_id,
+                None,
+                settled,
+                Some(state),
+                batchable,
+                &self.session_stop_reason,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -364,6 +415,7 @@ async fn send_transfer(
     input_handle: InputHandle,
     transfer: Transfer,
     payload: Payload,
+    session_stop_reason: &OnceLock<SessionStopReason>,
 ) -> Result<(), LinkStateError> {
     let frame = LinkFrame::Transfer {
         input_handle,
@@ -373,7 +425,10 @@ async fn send_transfer(
     writer
         .send(frame)
         .await // cancel safe
-        .map_err(|_| LinkStateError::IllegalSessionState)
+        .map_err(|_| match session_stop_reason.get() {
+            Some(reason) => LinkStateError::SessionStopped(reason.clone()),
+            None => LinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })
 }
 
 #[inline]
@@ -384,6 +439,7 @@ async fn send_disposition(
     settled: bool,
     state: Option<DeliveryState>,
     batchable: bool,
+    session_stop_reason: &OnceLock<SessionStopReason>,
 ) -> Result<(), IllegalLinkStateError> {
     let disposition = Disposition {
         role: Role::Sender,
@@ -397,7 +453,10 @@ async fn send_disposition(
     writer
         .send(frame)
         .await
-        .map_err(|_| IllegalLinkStateError::IllegalSessionState)
+        .map_err(|_| match session_stop_reason.get() {
+            Some(reason) => IllegalLinkStateError::SessionStopped(reason.clone()),
+            None => IllegalLinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })
 }
 
 impl<T> SenderLink<T> {
@@ -647,6 +706,10 @@ where
         &mut self.output_handle
     }
 
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        &self.session_stop_reason
+    }
+
     fn flow_state(&self) -> &Self::FlowState {
         &self.flow_state
     }
@@ -693,14 +756,17 @@ where
         self.send_attach(writer, session, is_reattaching).await?;
 
         // Wait for remote attach
-        let remote_attach = match reader
-            .recv()
-            .await
-            .ok_or(SenderAttachError::IllegalSessionState)?
-        {
-            LinkFrame::Attach(attach) => attach,
-            _ => return Err(SenderAttachError::NonAttachFrameReceived),
-        };
+        let remote_attach =
+            match reader
+                .recv()
+                .await
+                .ok_or_else(|| match self.session_stop_reason.get() {
+                    Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+                    None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                })? {
+                LinkFrame::Attach(attach) => attach,
+                _ => return Err(SenderAttachError::NonAttachFrameReceived),
+            };
 
         self.on_incoming_attach(remote_attach)
     }
@@ -714,7 +780,8 @@ where
         session: &mpsc::Sender<SessionControl>,
     ) -> SenderAttachError {
         match attach_error {
-            SenderAttachError::IllegalSessionState
+            SenderAttachError::SessionStopped(_)
+            | SenderAttachError::SessionNotMapped
             | SenderAttachError::IllegalState
             | SenderAttachError::NonAttachFrameReceived
             | SenderAttachError::ExpectImmediateDetach
@@ -730,7 +797,10 @@ where
                     .send(SessionControl::End(Some(error)))
                     .await
                     .map(|_| attach_error)
-                    .unwrap_or(SenderAttachError::IllegalSessionState)
+                    .unwrap_or(match self.session_stop_reason.get() {
+                        Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+                        None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    })
             }
 
             SenderAttachError::SndSettleModeNotSupported
@@ -740,7 +810,10 @@ where
                     .send_detach(writer, true, None)
                     .await
                     .map(|_| attach_error)
-                    .unwrap_or(SenderAttachError::IllegalSessionState);
+                    .unwrap_or(match self.session_stop_reason.get() {
+                        Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+                        None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    });
                 recv_detach(self, reader, err).await
             }
 
@@ -758,14 +831,19 @@ where
     }
 }
 
-async fn try_detach_with_error<L>(
-    link: &mut L,
+async fn try_detach_with_error<T>(
+    link: &mut SenderLink<T>,
     attach_error: SenderAttachError,
     writer: &mpsc::Sender<LinkFrame>,
     reader: &mut mpsc::Receiver<LinkFrame>,
 ) -> SenderAttachError
 where
-    L: LinkDetach,
+    T: Into<TargetArchetype>
+        + TryFrom<TargetArchetype>
+        + VerifyTargetArchetype
+        + Clone
+        + Send
+        + Sync,
 {
     match (&attach_error).try_into() {
         Ok(err) => {
@@ -776,9 +854,15 @@ where
                         attach_error
                     }
                     Some(_) => SenderAttachError::NonAttachFrameReceived,
-                    None => SenderAttachError::IllegalSessionState,
+                    None => match link.session_stop_reason().get() {
+                        Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+                        None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                    },
                 },
-                Err(_) => SenderAttachError::IllegalSessionState,
+                Err(_) => match link.session_stop_reason().get() {
+                    Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+                    None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+                },
             }
         }
         Err(_) => attach_error,
@@ -804,6 +888,9 @@ where
             Err(detach_error) => detach_error.try_into().unwrap_or(err),
         },
         Some(_) => SenderAttachError::NonAttachFrameReceived,
-        None => SenderAttachError::IllegalSessionState,
+        None => match link.session_stop_reason.get() {
+            Some(reason) => SenderAttachError::SessionStopped(reason.clone()),
+            None => SenderAttachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        },
     }
 }

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -144,8 +144,12 @@ where
                         Err(LinkStateError::ExpectImmediateDetach)
                     }
                     None => {
-                        // Other frames should not forwarded to the sender by the session
-                        Err(LinkStateError::ExpectImmediateDetach)
+                        // The channel closed without a frame: the session (or its
+                        // connection) stopped and the engine dropped the relay.
+                        match self.session_stop_reason.get() {
+                            Some(reason) => Err(LinkStateError::SessionStopped(reason.clone())),
+                            None => Err(LinkStateError::ExpectImmediateDetach), // defensive: no stop reason recorded; failure is link-local
+                        }
                     }
                 }
             }

--- a/fe2o3-amqp/src/link/shared_inner.rs
+++ b/fe2o3-amqp/src/link/shared_inner.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{definitions, performatives::Detach};
 use tokio::sync::mpsc;
 
@@ -7,7 +9,7 @@ use crate::{
     session::{self, error::AllocLinkError},
 };
 
-use super::{state::LinkState, DetachError, LinkFrame, LinkRelay};
+use super::{state::LinkState, DetachError, LinkFrame, LinkRelay, SessionStopReason};
 
 pub(crate) trait LinkEndpointInner
 where
@@ -27,6 +29,9 @@ where
     fn as_new_link_relay(&self, tx: mpsc::Sender<LinkFrame>) -> LinkRelay<()>;
 
     fn session_control(&self) -> &mpsc::Sender<SessionControl>;
+
+    /// The shared cell holding why the session (or its connection) stopped
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>>;
 
     async fn exchange_attach(
         &mut self,
@@ -55,7 +60,13 @@ where
         let link_relay = self.as_new_link_relay(tx);
         *self.reader_mut() = incoming;
         let link_name = self.link().name().to_string();
-        let handle = session::allocate_link(self.session_control(), link_name, link_relay).await?; // FIXME: cancel safe?
+        let handle = session::allocate_link(
+            self.session_control(),
+            link_name,
+            link_relay,
+            self.session_stop_reason(),
+        )
+        .await?; // FIXME: cancel safe?
         *self.link_mut().output_handle_mut() = Some(handle);
         Ok(())
     }
@@ -193,7 +204,7 @@ where
                 // The sender will be dropped after close
                 self.send_detach(true, error)
                     .await // cancel safe
-                    .map_err(|_| DetachError::IllegalSessionState)?;
+                    .map_err(|_| detach_error_from_stop_reason(self))?;
 
                 // Wait for remote detach
                 let remote_detach = recv_remote_detach(self).await?; // cancel safe
@@ -215,7 +226,7 @@ where
             LinkState::DetachReceived => self
                 .send_detach(true, error)
                 .await // cancel safe
-                .map_err(|_| DetachError::IllegalSessionState),
+                .map_err(|_| detach_error_from_stop_reason(self)),
             LinkState::Detached => reattach_and_then_close(self).await, // FIXME: cancel safe? if oneshot channel is cancel safe
             LinkState::CloseSent => {
                 // Wait for remote detach
@@ -229,7 +240,7 @@ where
             LinkState::CloseReceived => self
                 .send_detach(true, error)
                 .await // cancel safe
-                .map_err(|_| DetachError::IllegalSessionState),
+                .map_err(|_| detach_error_from_stop_reason(self)),
             LinkState::Closed => Ok(()),
         }
     }
@@ -265,6 +276,18 @@ where
     Ok(())
 }
 
+/// The `DetachError` for a link operation that failed because the session (or its
+/// connection) stopped; `IllegalState` when no stop reason was recorded (defensive).
+fn detach_error_from_stop_reason<T>(inner: &T) -> DetachError
+where
+    T: LinkEndpointInner + ?Sized,
+{
+    match inner.session_stop_reason().get() {
+        Some(reason) => DetachError::SessionStopped(reason.clone()),
+        None => DetachError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+    }
+}
+
 /// # Cancel safety
 ///
 /// This is cancel safe because it only `.await` on `recv()` from a `tokio::mpsc::Receiver`
@@ -279,7 +302,7 @@ where
             .reader_mut()
             .recv()
             .await // cancel safe
-            .ok_or(DetachError::IllegalSessionState)?
+            .ok_or_else(|| detach_error_from_stop_reason(link_inner))?
         {
             LinkFrame::Detach(detach) => return Ok(detach),
             _frame => {

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -1,6 +1,7 @@
 //! Session builder
 
 use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::definitions::{Fields, Handle, TransferNumber};
 use serde_amqp::primitives::Symbol;
@@ -11,6 +12,7 @@ use crate::{
     connection::{AllocSessionError, ConnectionHandle},
     control::SessionControl,
     endpoint::OutgoingChannel,
+    link::SessionStopReason,
     session::{engine::SessionEngine, SessionState},
     util::Constant,
     Session,
@@ -88,11 +90,13 @@ cfg_transaction! {
                 outgoing_channel: OutgoingChannel,
                 control_link_acceptor: ControlLinkAcceptor,
                 local_state: SessionState,
+                session_stop_reason: Arc<OnceLock<SessionStopReason>>,
             ) -> TxnSession<Session> {
                 let txn_manager = TransactionManager::new(outgoing, control_link_acceptor);
                 let session = Session {
                     // control,
                     outgoing_channel,
+                    session_stop_reason,
                     local_state,
                     initial_outgoing_id: Constant::new(self.next_outgoing_id),
                     next_outgoing_id: self.next_outgoing_id,
@@ -135,9 +139,11 @@ impl Builder {
         // control: mpsc::Sender<SessionControl>,
         outgoing_channel: OutgoingChannel,
         local_state: SessionState,
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
     ) -> Session {
         Session {
             outgoing_channel,
+            session_stop_reason,
             local_state,
             initial_outgoing_id: Constant::new(self.next_outgoing_id),
             next_outgoing_id: self.next_outgoing_id,
@@ -260,6 +266,8 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
+            let conn_stop = connection.connection_stop_reason.clone();
+            let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
@@ -275,7 +283,11 @@ impl Builder {
 
             #[cfg(not(all(feature = "transaction", feature = "acceptor")))]
             let (engine_handle, outcome) = {
-                let session = self.into_session(outgoing_channel, local_state);
+                let session = self.into_session(
+                    outgoing_channel,
+                    local_state,
+                    session_stop_reason.clone(),
+                );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
                     session,
@@ -283,6 +295,7 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
+                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn()
@@ -299,6 +312,7 @@ impl Builder {
                             outgoing_channel,
                             control_link_acceptor,
                             local_state,
+                            session_stop_reason.clone(),
                         );
                         let engine = SessionEngine::begin_client_session(
                             connection.control.clone(),
@@ -307,12 +321,17 @@ impl Builder {
                             incoming_rx,
                             connection.outgoing.clone(),
                             outgoing_rx,
+                            conn_stop.clone(),
                         )
                         .await?;
                         engine.spawn()
                     }
                     None => {
-                        let session = this.into_session(outgoing_channel, local_state);
+                        let session = this.into_session(
+                            outgoing_channel,
+                            local_state,
+                            session_stop_reason.clone(),
+                        );
                         let engine = SessionEngine::begin_client_session(
                             connection.control.clone(),
                             session,
@@ -320,6 +339,7 @@ impl Builder {
                             incoming_rx,
                             connection.outgoing.clone(),
                             outgoing_rx,
+                            conn_stop.clone(),
                         )
                         .await?;
                         engine.spawn()
@@ -333,6 +353,7 @@ impl Builder {
                 engine_handle,
                 outcome,
                 outgoing: outgoing_tx,
+                session_stop_reason,
                 link_listener: (),
             };
             Ok(handle)
@@ -361,6 +382,8 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
+            let conn_stop = connection.connection_stop_reason.clone();
+            let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
@@ -375,7 +398,11 @@ impl Builder {
             };
 
             let (engine_handle, outcome) = {
-                let session = self.into_session(outgoing_channel, local_state);
+                let session = self.into_session(
+                    outgoing_channel,
+                    local_state,
+                    session_stop_reason.clone(),
+                );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
                     session,
@@ -383,6 +410,7 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
+                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn_on_local_set(local_set)
@@ -394,6 +422,7 @@ impl Builder {
                 engine_handle,
                 outcome,
                 outgoing: outgoing_tx,
+                session_stop_reason,
                 link_listener: (),
             };
             Ok(handle)
@@ -421,6 +450,8 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
+            let conn_stop = connection.connection_stop_reason.clone();
+            let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
@@ -435,7 +466,11 @@ impl Builder {
             };
 
             let (engine_handle, outcome) = {
-                let session = self.into_session(outgoing_channel, local_state);
+                let session = self.into_session(
+                    outgoing_channel,
+                    local_state,
+                    session_stop_reason.clone(),
+                );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
                     session,
@@ -443,6 +478,7 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
+                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn_local()
@@ -454,6 +490,7 @@ impl Builder {
                 engine_handle,
                 outcome,
                 outgoing: outgoing_tx,
+                session_stop_reason,
                 link_listener: (),
             };
             Ok(handle)

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -9,7 +9,7 @@ use slab::Slab;
 use tokio::sync::mpsc;
 
 use crate::{
-    connection::{AllocSessionError, ConnectionHandle},
+    connection::{AllocSessionError, ConnectionHandle, ConnectionStopReason},
     control::SessionControl,
     endpoint::OutgoingChannel,
     link::SessionStopReason,
@@ -83,6 +83,7 @@ cfg_transaction! {
         };
 
         impl Builder {
+            #[allow(clippy::too_many_arguments)]
             pub(crate) fn into_txn_session(
                 self,
                 control: mpsc::Sender<SessionControl>,
@@ -91,12 +92,14 @@ cfg_transaction! {
                 control_link_acceptor: ControlLinkAcceptor,
                 local_state: SessionState,
                 session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+                connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
             ) -> TxnSession<Session> {
                 let txn_manager = TransactionManager::new(outgoing, control_link_acceptor);
                 let session = Session {
                     // control,
                     outgoing_channel,
                     session_stop_reason,
+                    connection_stop_reason,
                     local_state,
                     initial_outgoing_id: Constant::new(self.next_outgoing_id),
                     next_outgoing_id: self.next_outgoing_id,
@@ -140,10 +143,12 @@ impl Builder {
         outgoing_channel: OutgoingChannel,
         local_state: SessionState,
         session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+        connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
     ) -> Session {
         Session {
             outgoing_channel,
             session_stop_reason,
+            connection_stop_reason,
             local_state,
             initial_outgoing_id: Constant::new(self.next_outgoing_id),
             next_outgoing_id: self.next_outgoing_id,
@@ -266,18 +271,17 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
-            let conn_stop = connection.connection_stop_reason.clone();
             let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
                 Ok(channel) => channel,
                 Err(alloc_error) => match alloc_error {
-                    AllocSessionError::IllegalState => return Err(BeginError::IllegalConnectionState),
                     AllocSessionError::ChannelMaxReached => {
                         // Locally initiating session exceeded channel max
                         return Err(BeginError::LocalChannelMaxReached);
                     }
+                    other => return Err(other.into()),
                 },
             };
 
@@ -287,6 +291,7 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     session_stop_reason.clone(),
+                    connection.connection_stop_reason.clone(),
                 );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
@@ -295,7 +300,6 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
-                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn()
@@ -313,6 +317,7 @@ impl Builder {
                             control_link_acceptor,
                             local_state,
                             session_stop_reason.clone(),
+                            connection.connection_stop_reason.clone(),
                         );
                         let engine = SessionEngine::begin_client_session(
                             connection.control.clone(),
@@ -321,7 +326,6 @@ impl Builder {
                             incoming_rx,
                             connection.outgoing.clone(),
                             outgoing_rx,
-                            conn_stop.clone(),
                         )
                         .await?;
                         engine.spawn()
@@ -331,6 +335,7 @@ impl Builder {
                             outgoing_channel,
                             local_state,
                             session_stop_reason.clone(),
+                            connection.connection_stop_reason.clone(),
                         );
                         let engine = SessionEngine::begin_client_session(
                             connection.control.clone(),
@@ -339,7 +344,6 @@ impl Builder {
                             incoming_rx,
                             connection.outgoing.clone(),
                             outgoing_rx,
-                            conn_stop.clone(),
                         )
                         .await?;
                         engine.spawn()
@@ -382,18 +386,17 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
-            let conn_stop = connection.connection_stop_reason.clone();
             let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
                 Ok(channel) => channel,
                 Err(alloc_error) => match alloc_error {
-                    AllocSessionError::IllegalState => return Err(BeginError::IllegalConnectionState),
                     AllocSessionError::ChannelMaxReached => {
                         // Locally initiating session exceeded channel max
                         return Err(BeginError::LocalChannelMaxReached);
                     }
+                    other => return Err(other.into()),
                 },
             };
 
@@ -402,6 +405,7 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     session_stop_reason.clone(),
+                    connection.connection_stop_reason.clone(),
                 );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
@@ -410,7 +414,6 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
-                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn_on_local_set(local_set)
@@ -450,18 +453,17 @@ impl Builder {
                 mpsc::channel::<SessionControl>(DEFAULT_SESSION_CONTROL_BUFFER_SIZE);
             let (incoming_tx, incoming_rx) = mpsc::channel(self.buffer_size);
             let (outgoing_tx, outgoing_rx) = mpsc::channel(self.buffer_size);
-            let conn_stop = connection.connection_stop_reason.clone();
             let session_stop_reason = Arc::new(OnceLock::new());
 
             // create session in connection::Engine
             let outgoing_channel = match connection.allocate_session(incoming_tx).await {
                 Ok(channel) => channel,
                 Err(alloc_error) => match alloc_error {
-                    AllocSessionError::IllegalState => return Err(BeginError::IllegalConnectionState),
                     AllocSessionError::ChannelMaxReached => {
                         // Locally initiating session exceeded channel max
                         return Err(BeginError::LocalChannelMaxReached);
                     }
+                    other => return Err(other.into()),
                 },
             };
 
@@ -470,6 +472,7 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     session_stop_reason.clone(),
+                    connection.connection_stop_reason.clone(),
                 );
                 let engine = SessionEngine::begin_client_session(
                     connection.control.clone(),
@@ -478,7 +481,6 @@ impl Builder {
                     incoming_rx,
                     connection.outgoing.clone(),
                     outgoing_rx,
-                    conn_stop.clone(),
                 )
                 .await?;
                 engine.spawn_local()

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -200,8 +200,15 @@ where
                 self.session.on_incoming_detach(detach).await?;
             }
             SessionFrameBody::End(end) => {
+                let end_error = end.error.clone();
                 let result = self.session.on_incoming_end(channel, end);
                 if matches!(self.session.local_state(), SessionState::EndReceived) {
+                    // Record the stop reason before the link channel is closed,
+                    // so links that fail on the closure observe the reason.
+                    self.session.set_session_stop_reason(match end_error {
+                        Some(error) => SessionStopReason::EndedWithError(error),
+                        None => self.session_stop_reason_from_connection(),
+                    });
                     // if control is closing, finish sending all buffered messages before closing
                     self.outgoing_link_frames.close();
                     while let Some(frame) = self.outgoing_link_frames.recv().await {
@@ -220,6 +227,18 @@ where
         }
     }
 
+    /// The session stop reason derived from the connection's recorded stop;
+    /// `Ended` when the connection has not stopped.
+    fn session_stop_reason_from_connection(&self) -> SessionStopReason {
+        match self.conn_stop.get() {
+            Some(ConnectionStopReason::Closed) => SessionStopReason::ConnectionClosed,
+            Some(ConnectionStopReason::ClosedWithError(error)) => {
+                SessionStopReason::ConnectionClosedWithError(error.clone())
+            }
+            None => SessionStopReason::Ended,
+        }
+    }
+
     #[inline]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn on_control(&mut self, control: SessionControl) -> Result<Running, SessionInnerError> {
@@ -229,6 +248,12 @@ where
         log::trace!("control: {}", control);
         match control {
             SessionControl::End(error) => {
+                // Record the stop reason before the link channel is closed, so
+                // links that fail on the closure observe the reason.
+                self.session.set_session_stop_reason(match &error {
+                    Some(error) => SessionStopReason::EndedWithError(error.clone()),
+                    None => self.session_stop_reason_from_connection(),
+                });
                 // if control is closing, finish sending all buffered messages before closing
                 self.outgoing_link_frames.close();
                 while let Some(frame) = self.outgoing_link_frames.recv().await {
@@ -494,6 +519,9 @@ where
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "Session::event_loop", skip(self), fields(outgoing_channel = %self.session.outgoing_channel().0)))]
     async fn event_loop(mut self, tx: oneshot::Sender<Result<(), Error>>) {
         let mut outcome = Ok(());
+        // Set when the connection stopped before the session ended; the
+        // connection's stop reason cell may not be recorded yet at that point.
+        let mut connection_stopped_first = false;
         loop {
             let result = tokio::select! {
                 incoming = self.incoming.recv() => {
@@ -503,6 +531,7 @@ where
                             // Check local state
                             match self.continue_or_stop_by_state() {
                                 Running::Continue => {
+                                    connection_stopped_first = true;
                                     // The connection stopped before the session ended;
                                     // the session ends with it. Connection-level errors
                                     // are reported through the `ConnectionHandle`.
@@ -575,6 +604,7 @@ where
                 Ok(running) => running,
                 Err(error) => {
                     if matches!(error, SessionInnerError::IllegalConnectionState) {
+                        connection_stopped_first = true;
                         // The connection stopped before the session ended; the session
                         // ends with it. Connection-level errors are reported through
                         // the `ConnectionHandle`.
@@ -623,6 +653,11 @@ where
             Some(ConnectionStopReason::Closed) => SessionStopReason::ConnectionClosed,
             Some(ConnectionStopReason::ClosedWithError(error)) => {
                 SessionStopReason::ConnectionClosedWithError(error.clone())
+            }
+            None if connection_stopped_first => {
+                // The connection stopped before the session ended but has not
+                // recorded its own stop reason yet.
+                SessionStopReason::ConnectionClosed
             }
             None => match &outcome {
                 Err(SessionInnerError::RemoteEndedWithError(error)) => {

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -223,10 +223,15 @@ where
                 let result = self.session.on_incoming_end(channel, end);
                 if matches!(self.session.local_state(), SessionState::EndReceived) {
                     // Record the stop reason before the link channel is closed,
-                    // so links that fail on the closure observe the reason.
+                    // so links that fail on the closure observe the reason. The
+                    // `EndReceived` state only results from a remote-initiated
+                    // end, so the error (if any) is the remote's.
                     self.session.set_session_stop_reason(match end_error {
-                        Some(error) => SessionStopReason::EndedWithError(error),
-                        None => self.session_stop_reason_from_connection(),
+                        Some(error) => SessionStopReason::RemoteEndedWithError(error),
+                        None => match self.session.connection_stop_reason().get() {
+                            Some(reason) => SessionStopReason::from(reason.clone()),
+                            None => SessionStopReason::RemoteEnded,
+                        },
                     });
                     // if control is closing, finish sending all buffered messages before closing
                     self.outgoing_link_frames.close();
@@ -689,8 +694,9 @@ where
                 SessionStopReason::from(reason.clone())
             }
             Err(SessionInnerError::RemoteEndedWithError(error)) => {
-                SessionStopReason::EndedWithError(error.clone())
+                SessionStopReason::RemoteEndedWithError(error.clone())
             }
+            Err(SessionInnerError::RemoteEnded) => SessionStopReason::RemoteEnded,
             _ => SessionStopReason::Ended,
         };
         self.session.set_session_stop_reason(session_stop_reason);

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -19,7 +19,9 @@ use crate::{
 };
 
 use super::{
-    error::{AllocLinkError, BeginError, Error, SessionInnerError},
+    error::{
+        connection_stop_reason_or_closed, AllocLinkError, BeginError, Error, SessionInnerError,
+    },
     frame::{SessionIncomingItem, SessionOutgoingItem},
     SessionFrame, SessionFrameBody, SessionState,
 };
@@ -27,6 +29,7 @@ use super::{
 async fn send_outgoing_item(
     outgoing: &mpsc::Sender<SessionFrame>,
     outgoing_item: SessionOutgoingItem,
+    conn_stop: &Arc<OnceLock<ConnectionStopReason>>,
 ) -> Result<(), SessionInnerError> {
     match outgoing_item {
         SessionOutgoingItem::SingleFrame(frame) => {
@@ -34,8 +37,12 @@ async fn send_outgoing_item(
                 .send(frame)
                 .await
                 // The receiving half must have dropped, and thus the `Connection`
-                // event loop has stopped. It should be treated as an io error
-                .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                // event loop has stopped.
+                .map_err(|_| {
+                    SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                        conn_stop,
+                    ))
+                })?;
         }
         SessionOutgoingItem::MultipleFrames(frames) => {
             for frame in frames {
@@ -43,8 +50,12 @@ async fn send_outgoing_item(
                     .send(frame)
                     .await
                     // The receiving half must have dropped, and thus the `Connection`
-                    // event loop has stopped. It should be treated as an io error
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                    // event loop has stopped.
+                    .map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            conn_stop,
+                        ))
+                    })?;
             }
         }
     }
@@ -59,8 +70,6 @@ pub(crate) struct SessionEngine<S: Session> {
     pub outgoing: mpsc::Sender<SessionFrame>,
 
     pub outgoing_link_frames: mpsc::Receiver<LinkFrame>,
-    /// Why the connection stopped, read at our own stop to derive the reason links observe
-    pub conn_stop: Arc<OnceLock<ConnectionStopReason>>,
 }
 
 impl<S> SessionEngine<S>
@@ -68,7 +77,6 @@ where
     S: endpoint::Session,
     BeginError: From<S::BeginError>,
 {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn begin_client_session(
         conn_control: mpsc::Sender<ConnectionControl>,
         session: S,
@@ -76,7 +84,6 @@ where
         incoming: mpsc::Receiver<SessionIncomingItem>,
         outgoing: mpsc::Sender<SessionFrame>,
         outgoing_link_frames: mpsc::Receiver<LinkFrame>,
-        conn_stop: Arc<OnceLock<ConnectionStopReason>>,
     ) -> Result<Self, BeginError> {
         let mut engine = Self {
             conn_control,
@@ -85,7 +92,6 @@ where
             incoming,
             outgoing,
             outgoing_link_frames,
-            conn_stop,
         };
 
         // send a begin
@@ -95,7 +101,9 @@ where
             Some(frame) => frame,
             None => {
                 // Connection sender must have dropped
-                return Err(BeginError::IllegalConnectionState);
+                return Err(BeginError::ConnectionStopped(
+                    connection_stop_reason_or_closed(engine.session.connection_stop_reason()),
+                ));
             }
         };
         let SessionFrame { channel, body } = frame;
@@ -172,7 +180,12 @@ where
             }
             SessionFrameBody::Flow(flow) => {
                 if let Some(outgoing_item) = self.session.on_incoming_flow(flow).await? {
-                    send_outgoing_item(&self.outgoing, outgoing_item).await?;
+                    send_outgoing_item(
+                        &self.outgoing,
+                        outgoing_item,
+                        self.session.connection_stop_reason(),
+                    )
+                    .await?;
                 }
             }
             SessionFrameBody::Transfer {
@@ -192,7 +205,13 @@ where
                             .await
                             // The receiving half must have dropped, and thus the `Connection`
                             // event loop has stopped. It should be treated as an io error
-                            .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                            .map_err(|_| {
+                                SessionInnerError::ConnectionStopped(
+                                    connection_stop_reason_or_closed(
+                                        self.session.connection_stop_reason(),
+                                    ),
+                                )
+                            })?;
                     }
                 }
             }
@@ -230,11 +249,8 @@ where
     /// The session stop reason derived from the connection's recorded stop;
     /// `Ended` when the connection has not stopped.
     fn session_stop_reason_from_connection(&self) -> SessionStopReason {
-        match self.conn_stop.get() {
-            Some(ConnectionStopReason::Closed) => SessionStopReason::ConnectionClosed,
-            Some(ConnectionStopReason::ClosedWithError(error)) => {
-                SessionStopReason::ConnectionClosedWithError(error.clone())
-            }
+        match self.session.connection_stop_reason().get() {
+            Some(reason) => SessionStopReason::from(reason.clone()),
             None => SessionStopReason::Ended,
         }
     }
@@ -297,21 +313,30 @@ where
                     .await
                     // The receiving half must have dropped, and thus the `Connection`
                     // event loop has stopped. It should be treated as an io error
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                    .map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            self.session.connection_stop_reason(),
+                        ))
+                    })?;
             }
             SessionControl::CloseConnectionWithError((condition, description)) => {
                 let error = definitions::Error::new(condition, description, None);
                 let control = ConnectionControl::Close(Some(error));
-                self.conn_control
-                    .send(control)
-                    .await
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                self.conn_control.send(control).await.map_err(|_| {
+                    SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                        self.session.connection_stop_reason(),
+                    ))
+                })?;
             }
             SessionControl::GetMaxFrameSize(resp) => {
                 self.conn_control
                     .send(ConnectionControl::GetMaxFrameSize(resp))
                     .await
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                    .map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            self.session.connection_stop_reason(),
+                        ))
+                    })?;
             }
 
             #[cfg(feature = "transaction")]
@@ -389,7 +414,12 @@ where
         };
 
         if let Some(outgoing_item) = outgoing_item {
-            send_outgoing_item(&self.outgoing, outgoing_item).await?;
+            send_outgoing_item(
+                &self.outgoing,
+                outgoing_item,
+                self.session.connection_stop_reason(),
+            )
+            .await?;
         }
 
         match self.session.local_state() {
@@ -427,7 +457,17 @@ where
                 let error = Error::new(AmqpError::IllegalState, None, None);
                 self.end_session(Some(error)).await
             }
-            SessionInnerError::IllegalConnectionState => Ok(Running::Stop),
+            SessionInnerError::ConnectionStopped(reason) => {
+                // The session cannot handle a connection stop; it ends with the
+                // connection. The outcome is sanitized before it reaches the
+                // handle, so connection-level errors are reported through the
+                // `ConnectionHandle` instead.
+                #[cfg(feature = "tracing")]
+                tracing::warn!("Connection stopped before the session ended; ending the session");
+                #[cfg(feature = "log")]
+                log::warn!("Connection stopped before the session ended; ending the session");
+                Err(SessionInnerError::ConnectionStopped(reason.clone()))
+            }
             SessionInnerError::TransferFrameToSender => {
                 let error = Error::new(
                     AmqpError::NotAllowed,
@@ -459,7 +499,11 @@ where
                 self.session
                     .send_end(&self.outgoing, error)
                     .await
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                    .map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            self.session.connection_stop_reason(),
+                        ))
+                    })?;
                 let (channel, end) = self.wait_for_remote_end(false).await?;
                 self.session.on_incoming_end(channel, end)?;
             }
@@ -470,7 +514,11 @@ where
                 self.session
                     .send_end(&self.outgoing, error)
                     .await
-                    .map_err(|_| SessionInnerError::IllegalConnectionState)?;
+                    .map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            self.session.connection_stop_reason(),
+                        ))
+                    })?;
             }
             SessionState::Discarding => {
                 // The DISCARDING state is a variant of the CLOSE SENT state where the close is triggered
@@ -492,7 +540,9 @@ where
                 .incoming
                 .recv()
                 .await
-                .ok_or(SessionInnerError::IllegalConnectionState)?;
+                .ok_or(SessionInnerError::ConnectionStopped(
+                    connection_stop_reason_or_closed(self.session.connection_stop_reason()),
+                ))?;
             match frame.body {
                 SessionFrameBody::End(end) => return Ok((IncomingChannel(frame.channel), end)),
                 _ => {
@@ -519,9 +569,6 @@ where
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "Session::event_loop", skip(self), fields(outgoing_channel = %self.session.outgoing_channel().0)))]
     async fn event_loop(mut self, tx: oneshot::Sender<Result<(), Error>>) {
         let mut outcome = Ok(());
-        // Set when the connection stopped before the session ended; the
-        // connection's stop reason cell may not be recorded yet at that point.
-        let mut connection_stopped_first = false;
         loop {
             let result = tokio::select! {
                 incoming = self.incoming.recv() => {
@@ -531,15 +578,15 @@ where
                             // Check local state
                             match self.continue_or_stop_by_state() {
                                 Running::Continue => {
-                                    connection_stopped_first = true;
                                     // The connection stopped before the session ended;
-                                    // the session ends with it. Connection-level errors
-                                    // are reported through the `ConnectionHandle`.
-                                    #[cfg(feature = "tracing")]
-                                    tracing::warn!("Connection stopped before the session ended; ending the session");
-                                    #[cfg(feature = "log")]
-                                    log::warn!("Connection stopped before the session ended; ending the session");
-                                    Ok(Running::Stop)
+                                    // yield the stop as an error so it flows through the
+                                    // generic error path. Connection-level errors are
+                                    // reported through the `ConnectionHandle`.
+                                    Err(SessionInnerError::ConnectionStopped(
+                                        connection_stop_reason_or_closed(
+                                            self.session.connection_stop_reason(),
+                                        ),
+                                    ))
                                 },
                                 Running::Stop => Ok(Running::Stop),
                             }
@@ -603,35 +650,23 @@ where
             let running = match result {
                 Ok(running) => running,
                 Err(error) => {
-                    if matches!(error, SessionInnerError::IllegalConnectionState) {
-                        connection_stopped_first = true;
-                        // The connection stopped before the session ended; the session
-                        // ends with it. Connection-level errors are reported through
-                        // the `ConnectionHandle`.
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(
-                            "Connection stopped before the session ended; ending the session"
-                        );
-                        #[cfg(feature = "log")]
-                        log::warn!(
-                            "Connection stopped before the session ended; ending the session"
-                        );
-                        Running::Stop
-                    } else {
+                    // A connection stop is logged as a warning (the session ends
+                    // with the connection) rather than as an unexpected error.
+                    if !matches!(error, SessionInnerError::ConnectionStopped(_)) {
                         #[cfg(feature = "tracing")]
                         tracing::error!("{:?}", error);
                         #[cfg(feature = "log")]
                         log::error!("{:?}", error);
-                        match self.on_error(&error).await {
-                            Ok(running) => {
-                                outcome = Err(error);
-                                running
-                            }
-                            Err(error) => {
-                                // Stop the session if error cannot be handled
-                                outcome = Err(error);
-                                Running::Stop
-                            }
+                    }
+                    match self.on_error(&error).await {
+                        Ok(running) => {
+                            outcome = Err(error);
+                            running
+                        }
+                        Err(error) => {
+                            // Stop the session if error cannot be handled
+                            outcome = Err(error);
+                            Running::Stop
                         }
                     }
                 }
@@ -649,28 +684,26 @@ where
         log::debug!("Stopped");
         // Publish the stop reason before the link relays and unsettled maps are dropped,
         // so every link that wakes on the channel closures sees it.
-        let session_stop_reason = match self.conn_stop.get() {
-            Some(ConnectionStopReason::Closed) => SessionStopReason::ConnectionClosed,
-            Some(ConnectionStopReason::ClosedWithError(error)) => {
-                SessionStopReason::ConnectionClosedWithError(error.clone())
+        let session_stop_reason = match &outcome {
+            Err(SessionInnerError::ConnectionStopped(reason)) => {
+                SessionStopReason::from(reason.clone())
             }
-            None if connection_stopped_first => {
-                // The connection stopped before the session ended but has not
-                // recorded its own stop reason yet.
-                SessionStopReason::ConnectionClosed
+            Err(SessionInnerError::RemoteEndedWithError(error)) => {
+                SessionStopReason::EndedWithError(error.clone())
             }
-            None => match &outcome {
-                Err(SessionInnerError::RemoteEndedWithError(error)) => {
-                    SessionStopReason::EndedWithError(error.clone())
-                }
-                _ => SessionStopReason::Ended,
-            },
+            _ => SessionStopReason::Ended,
         };
         self.session.set_session_stop_reason(session_stop_reason);
         let _ =
             connection::deallocate_session(&mut self.conn_control, self.session.outgoing_channel())
                 .await;
-        let result = outcome.map_err(Into::into);
+        // The session ends with the connection; sanitize the connection stop
+        // so the handle observes a clean end. Connection-level errors are
+        // reported through the `ConnectionHandle`.
+        let result = match outcome {
+            Err(SessionInnerError::ConnectionStopped(_)) => Ok(()),
+            other => other.map_err(Into::into),
+        };
         let _ = tx.send(result);
     }
 }

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::{self, AmqpError, SessionError},
     performatives::End,
@@ -8,10 +10,10 @@ use tokio::{
 };
 
 use crate::{
-    connection::{self},
+    connection::{self, ConnectionStopReason},
     control::{ConnectionControl, SessionControl},
     endpoint::{self, IncomingChannel, Session},
-    link::LinkFrame,
+    link::{LinkFrame, SessionStopReason},
     util::Running,
     SendBound,
 };
@@ -57,6 +59,8 @@ pub(crate) struct SessionEngine<S: Session> {
     pub outgoing: mpsc::Sender<SessionFrame>,
 
     pub outgoing_link_frames: mpsc::Receiver<LinkFrame>,
+    /// Why the connection stopped, read at our own stop to derive the reason links observe
+    pub conn_stop: Arc<OnceLock<ConnectionStopReason>>,
 }
 
 impl<S> SessionEngine<S>
@@ -64,6 +68,7 @@ where
     S: endpoint::Session,
     BeginError: From<S::BeginError>,
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn begin_client_session(
         conn_control: mpsc::Sender<ConnectionControl>,
         session: S,
@@ -71,6 +76,7 @@ where
         incoming: mpsc::Receiver<SessionIncomingItem>,
         outgoing: mpsc::Sender<SessionFrame>,
         outgoing_link_frames: mpsc::Receiver<LinkFrame>,
+        conn_stop: Arc<OnceLock<ConnectionStopReason>>,
     ) -> Result<Self, BeginError> {
         let mut engine = Self {
             conn_control,
@@ -79,6 +85,7 @@ where
             incoming,
             outgoing,
             outgoing_link_frames,
+            conn_stop,
         };
 
         // send a begin
@@ -496,8 +503,14 @@ where
                             // Check local state
                             match self.continue_or_stop_by_state() {
                                 Running::Continue => {
-                                    // The connection must have already stopped before session negotiated ending
-                                    Err(SessionInnerError::IllegalConnectionState)
+                                    // The connection stopped before the session ended;
+                                    // the session ends with it. Connection-level errors
+                                    // are reported through the `ConnectionHandle`.
+                                    #[cfg(feature = "tracing")]
+                                    tracing::warn!("Connection stopped before the session ended; ending the session");
+                                    #[cfg(feature = "log")]
+                                    log::warn!("Connection stopped before the session ended; ending the session");
+                                    Ok(Running::Stop)
                                 },
                                 Running::Stop => Ok(Running::Stop),
                             }
@@ -561,19 +574,34 @@ where
             let running = match result {
                 Ok(running) => running,
                 Err(error) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!("{:?}", error);
-                    #[cfg(feature = "log")]
-                    log::error!("{:?}", error);
-                    match self.on_error(&error).await {
-                        Ok(running) => {
-                            outcome = Err(error);
-                            running
-                        }
-                        Err(error) => {
-                            // Stop the session if error cannot be handled
-                            outcome = Err(error);
-                            Running::Stop
+                    if matches!(error, SessionInnerError::IllegalConnectionState) {
+                        // The connection stopped before the session ended; the session
+                        // ends with it. Connection-level errors are reported through
+                        // the `ConnectionHandle`.
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "Connection stopped before the session ended; ending the session"
+                        );
+                        #[cfg(feature = "log")]
+                        log::warn!(
+                            "Connection stopped before the session ended; ending the session"
+                        );
+                        Running::Stop
+                    } else {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!("{:?}", error);
+                        #[cfg(feature = "log")]
+                        log::error!("{:?}", error);
+                        match self.on_error(&error).await {
+                            Ok(running) => {
+                                outcome = Err(error);
+                                running
+                            }
+                            Err(error) => {
+                                // Stop the session if error cannot be handled
+                                outcome = Err(error);
+                                Running::Stop
+                            }
                         }
                     }
                 }
@@ -589,6 +617,21 @@ where
         tracing::debug!("Stopped");
         #[cfg(feature = "log")]
         log::debug!("Stopped");
+        // Publish the stop reason before the link relays and unsettled maps are dropped,
+        // so every link that wakes on the channel closures sees it.
+        let session_stop_reason = match self.conn_stop.get() {
+            Some(ConnectionStopReason::Closed) => SessionStopReason::ConnectionClosed,
+            Some(ConnectionStopReason::ClosedWithError(error)) => {
+                SessionStopReason::ConnectionClosedWithError(error.clone())
+            }
+            None => match &outcome {
+                Err(SessionInnerError::RemoteEndedWithError(error)) => {
+                    SessionStopReason::EndedWithError(error.clone())
+                }
+                _ => SessionStopReason::Ended,
+            },
+        };
+        self.session.set_session_stop_reason(session_stop_reason);
         let _ =
             connection::deallocate_session(&mut self.conn_control, self.session.outgoing_channel())
                 .await;

--- a/fe2o3-amqp/src/session/error.rs
+++ b/fe2o3-amqp/src/session/error.rs
@@ -1,8 +1,13 @@
 //! Error types for session operations
 
+use std::sync::OnceLock;
+
 use fe2o3_amqp_types::definitions::{self};
 
-use crate::link::LinkRelayError;
+use crate::{
+    connection::{AllocSessionError, ConnectionStopReason},
+    link::{LinkRelayError, SessionStopReason},
+};
 
 /// Error with ending a session
 #[derive(Debug, thiserror::Error)]
@@ -11,9 +16,9 @@ pub(crate) enum SessionStateError {
     #[error("Illegal session state")]
     IllegalState,
 
-    /// The associated connection must have been closed
-    #[error("Connection must have been closed")]
-    IllegalConnectionState,
+    /// The connection stopped before the operation completed
+    #[error("The connection stopped: {:?}", .0)]
+    ConnectionStopped(ConnectionStopReason),
 
     /// Remote session ended
     #[error("Remote session ended")]
@@ -31,9 +36,13 @@ pub enum BeginError {
     #[error("Illegal session state")]
     IllegalState,
 
-    /// The associated connection must have been closed
-    #[error("Connection must have been closed")]
-    IllegalConnectionState,
+    /// The connection stopped before the operation completed
+    #[error("The connection stopped: {:?}", .0)]
+    ConnectionStopped(ConnectionStopReason),
+
+    /// The connection has not been opened yet
+    #[error("The connection has not been opened")]
+    ConnectionNotOpened,
 
     /// Remote session ended
     #[error("Remote session ended")]
@@ -48,11 +57,21 @@ pub enum BeginError {
     LocalChannelMaxReached,
 }
 
+impl From<AllocSessionError> for BeginError {
+    fn from(error: AllocSessionError) -> Self {
+        match error {
+            AllocSessionError::ConnectionNotOpened => Self::ConnectionNotOpened,
+            AllocSessionError::ConnectionStopped(reason) => Self::ConnectionStopped(reason),
+            AllocSessionError::ChannelMaxReached => Self::LocalChannelMaxReached,
+        }
+    }
+}
+
 impl From<SessionStateError> for BeginError {
     fn from(error: SessionStateError) -> Self {
         match error {
             SessionStateError::IllegalState => Self::IllegalState,
-            SessionStateError::IllegalConnectionState => Self::IllegalConnectionState,
+            SessionStateError::ConnectionStopped(reason) => Self::ConnectionStopped(reason),
             SessionStateError::RemoteEnded => Self::RemoteEnded,
             SessionStateError::RemoteEndedWithError(err) => Self::RemoteEndedWithError(err),
         }
@@ -77,9 +96,9 @@ pub(crate) enum SessionInnerError {
     #[error("Illegal session state")]
     IllegalState,
 
-    /// The associated connection must have been closed
-    #[error("Connection must have been closed")]
-    IllegalConnectionState,
+    /// The connection stopped before the operation completed
+    #[error("The connection stopped: {:?}", .0)]
+    ConnectionStopped(ConnectionStopReason),
 
     /// Found a Transfer frame sent to a Sender
     #[error("Found Transfer frame being sent to a Sender")]
@@ -104,7 +123,7 @@ impl From<SessionStateError> for SessionInnerError {
     fn from(error: SessionStateError) -> Self {
         match error {
             SessionStateError::IllegalState => Self::IllegalState,
-            SessionStateError::IllegalConnectionState => Self::IllegalConnectionState,
+            SessionStateError::ConnectionStopped(reason) => Self::ConnectionStopped(reason),
             SessionStateError::RemoteEnded => Self::RemoteEnded,
             SessionStateError::RemoteEndedWithError(err) => Self::RemoteEndedWithError(err),
         }
@@ -140,9 +159,9 @@ pub enum Error {
     #[error("Illegal session state")]
     IllegalState,
 
-    /// The associated connection must have been closed
-    #[error("Connection must have been closed")]
-    IllegalConnectionState,
+    /// The connection stopped before the operation completed
+    #[error("The connection stopped: {:?}", .0)]
+    ConnectionStopped(ConnectionStopReason),
 
     /// Found a Transfer frame sent to a Sender
     #[error("Found Transfer frame being sent to a Sender")]
@@ -171,7 +190,7 @@ impl From<SessionInnerError> for Error {
             }
             SessionInnerError::HandleInUse => Self::HandleInUse,
             SessionInnerError::IllegalState => Self::IllegalState,
-            SessionInnerError::IllegalConnectionState => Self::IllegalConnectionState,
+            SessionInnerError::ConnectionStopped(reason) => Self::ConnectionStopped(reason),
             SessionInnerError::TransferFrameToSender => Self::TransferFrameToSender,
             SessionInnerError::RemoteEnded => Self::RemoteEnded,
             SessionInnerError::RemoteEndedWithError(err) => Self::RemoteEndedWithError(err),
@@ -198,9 +217,38 @@ impl From<SessionStateError> for Error {
     fn from(error: SessionStateError) -> Self {
         match error {
             SessionStateError::IllegalState => Self::IllegalState,
-            SessionStateError::IllegalConnectionState => Self::IllegalConnectionState,
+            SessionStateError::ConnectionStopped(reason) => Self::ConnectionStopped(reason),
             SessionStateError::RemoteEnded => Self::RemoteEnded,
             SessionStateError::RemoteEndedWithError(err) => Self::RemoteEndedWithError(err),
+        }
+    }
+}
+
+/// The connection's stop reason, or `Closed` when the cell has not been
+/// recorded yet (defensive fallback).
+pub(crate) fn connection_stop_reason_or_closed(
+    cell: &OnceLock<ConnectionStopReason>,
+) -> ConnectionStopReason {
+    match cell.get() {
+        Some(reason) => reason.clone(),
+        None => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "connection stop reason not recorded; reporting ConnectionStopped(Closed)"
+            );
+            #[cfg(feature = "log")]
+            log::warn!("connection stop reason not recorded; reporting ConnectionStopped(Closed)");
+            ConnectionStopReason::Closed
+        }
+    }
+}
+
+/// The session stop reason corresponding to a connection stop
+impl From<ConnectionStopReason> for SessionStopReason {
+    fn from(reason: ConnectionStopReason) -> Self {
+        match reason {
+            ConnectionStopReason::Closed => Self::ConnectionClosed,
+            ConnectionStopReason::ClosedWithError(error) => Self::ConnectionClosedWithError(error),
         }
     }
 }

--- a/fe2o3-amqp/src/session/error.rs
+++ b/fe2o3-amqp/src/session/error.rs
@@ -207,8 +207,12 @@ impl From<SessionStateError> for Error {
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AllocLinkError {
-    #[error("Illegal session state")]
-    IllegalSessionState,
+    /// The session is not in the `Mapped` state (e.g. not begun, or ending)
+    #[error("The session is not in a state that permits link allocation")]
+    SessionNotMapped,
+
+    #[error("The session stopped before the link was attached: {:?}", .0)]
+    SessionStopped(crate::link::SessionStopReason),
 
     #[error("Link name must be unique")]
     DuplicatedLinkName,

--- a/fe2o3-amqp/src/session/error.rs
+++ b/fe2o3-amqp/src/session/error.rs
@@ -246,10 +246,7 @@ pub(crate) fn connection_stop_reason_or_closed(
 /// The session stop reason corresponding to a connection stop
 impl From<ConnectionStopReason> for SessionStopReason {
     fn from(reason: ConnectionStopReason) -> Self {
-        match reason {
-            ConnectionStopReason::Closed => Self::ConnectionClosed,
-            ConnectionStopReason::ClosedWithError(error) => Self::ConnectionClosedWithError(error),
-        }
+        Self::ConnectionStopped(reason)
     }
 }
 

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -23,6 +23,7 @@ use tokio::{
 };
 
 use crate::{
+    connection::ConnectionStopReason,
     control::SessionControl,
     endpoint::{self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
     link::{LinkFrame, LinkRelay, SessionStopReason},
@@ -43,7 +44,9 @@ pub(crate) mod engine;
 pub(crate) mod frame;
 
 pub mod error;
-use error::{AllocLinkError, SessionInnerError, SessionStateError};
+use error::{
+    connection_stop_reason_or_closed, AllocLinkError, SessionInnerError, SessionStateError,
+};
 pub use error::{BeginError, Error, TryEndError};
 
 mod builder;
@@ -310,6 +313,10 @@ pub struct Session {
     /// and the session handle
     pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
 
+    /// Why the connection stopped, shared with the connection engine and the
+    /// connection handle
+    pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+
     // local amqp states
     pub(crate) local_state: SessionState,
     pub(crate) initial_outgoing_id: Constant<TransferNumber>,
@@ -553,6 +560,10 @@ impl endpoint::Session for Session {
 
     fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
         &self.session_stop_reason
+    }
+
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
+        &self.connection_stop_reason
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {
@@ -905,15 +916,20 @@ impl endpoint::Session for Session {
                     .send(frame)
                     .await
                     // The receiving half must have dropped, and thus the `Connection`
-                    // event loop has stopped. It should be treated as an io error
-                    .map_err(|_| SessionStateError::IllegalConnectionState)?;
+                    // event loop has stopped.
+                    .map_err(|_| {
+                        SessionStateError::ConnectionStopped(connection_stop_reason_or_closed(
+                            &self.connection_stop_reason,
+                        ))
+                    })?;
                 self.local_state = SessionState::BeginSent;
             }
             SessionState::BeginReceived => {
-                writer
-                    .send(frame)
-                    .await
-                    .map_err(|_| SessionStateError::IllegalConnectionState)?;
+                writer.send(frame).await.map_err(|_| {
+                    SessionStateError::ConnectionStopped(connection_stop_reason_or_closed(
+                        &self.connection_stop_reason,
+                    ))
+                })?;
                 self.local_state = SessionState::Mapped;
             }
             _ => return Err(SessionStateError::IllegalState),
@@ -941,8 +957,12 @@ impl endpoint::Session for Session {
             .send(frame)
             .await
             // The receiving half must have dropped, and thus the `Connection`
-            // event loop has stopped. It should be treated as an io error
-            .map_err(|_| SessionStateError::IllegalConnectionState)?;
+            // event loop has stopped.
+            .map_err(|_| {
+                SessionStateError::ConnectionStopped(connection_stop_reason_or_closed(
+                    &self.connection_stop_reason,
+                ))
+            })?;
         Ok(())
     }
 

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -1,6 +1,9 @@
 //! Implements AMQP1.0 Session
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, OnceLock},
+};
 
 use fe2o3_amqp_types::{
     definitions::{
@@ -22,7 +25,7 @@ use tokio::{
 use crate::{
     control::SessionControl,
     endpoint::{self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
-    link::{LinkFrame, LinkRelay},
+    link::{LinkFrame, LinkRelay, SessionStopReason},
     util::{is_consecutive, Constant},
     Payload,
 };
@@ -68,6 +71,8 @@ pub struct SessionHandle<R> {
 
     // outgoing for Link
     pub(crate) outgoing: mpsc::Sender<LinkFrame>,
+    /// Why the session (or its connection) stopped, shared with the links
+    pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
     pub(crate) link_listener: R,
 }
 
@@ -98,6 +103,11 @@ impl<R> Drop for SessionHandle<R> {
 }
 
 impl<R> SessionHandle<R> {
+    /// The shared stop reason cell, used by links to observe why the session stopped
+    pub(crate) fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        &self.session_stop_reason
+    }
+
     /// Checks if the underlying event loop has stopped
     pub fn is_ended(&self) -> bool {
         match self.is_ended {
@@ -135,6 +145,10 @@ impl<R> SessionHandle<R> {
 
     cfg_not_wasm32! {
         /// End the session
+        ///
+        /// If the connection stopped before the session, the session ends with it and
+        /// this method returns `Ok`; connection-level errors are reported through the
+        /// [`ConnectionHandle`](crate::connection::ConnectionHandle).
         ///
         /// An `Error::IllegalState` will be returned if called after any of [`end`](#method.end),
         /// [`end_with_error`](#method.end_with_error), [`on_end`](#on_end) has beend executed. This
@@ -213,8 +227,26 @@ pub(crate) async fn allocate_link(
     control: &mpsc::Sender<SessionControl>,
     link_name: String,
     link_relay: LinkRelay<()>,
+    session_stop_reason: &Arc<OnceLock<SessionStopReason>>,
 ) -> Result<OutputHandle, AllocLinkError> {
     let (responder, resp_rx) = oneshot::channel();
+
+    let reason = || match session_stop_reason.get() {
+        Some(reason) => reason.clone(),
+        None => {
+            // The session engine should always record a stop reason before its
+            // channels close; an unset cell here is a defensive fallback.
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "allocate_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+            );
+            #[cfg(feature = "log")]
+            log::warn!(
+                "allocate_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+            );
+            SessionStopReason::Ended
+        }
+    };
 
     control
         .send(SessionControl::AllocateLink {
@@ -227,13 +259,13 @@ pub(crate) async fn allocate_link(
         // dropped, meaning the `SessionEngine::event_loop` has stopped.
         // This would also mean the `Session` is Unmapped, and thus it
         // may be treated as illegal state
-        .map_err(|_| AllocLinkError::IllegalSessionState)?;
+        .map_err(|_| AllocLinkError::SessionStopped(reason()))?;
     resp_rx
         .await // FIXME: Is oneshot channel cancel safe?
         // The error could only occur when the sending half is dropped,
         // indicating the `SessionEngine::even_loop` has stopped or
         // unmapped. Thus it could be considered as illegal state
-        .map_err(|_| AllocLinkError::IllegalSessionState)?
+        .map_err(|_| AllocLinkError::SessionStopped(reason()))?
 }
 
 /// AMQP1.0 Session
@@ -273,6 +305,10 @@ pub(crate) async fn allocate_link(
 #[derive(Debug)]
 pub struct Session {
     pub(crate) outgoing_channel: OutgoingChannel,
+
+    /// Why this session (or its connection) stopped, shared with the links
+    /// and the session handle
+    pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
 
     // local amqp states
     pub(crate) local_state: SessionState,
@@ -511,6 +547,14 @@ impl endpoint::Session for Session {
         &self.local_state
     }
 
+    fn set_session_stop_reason(&mut self, reason: SessionStopReason) {
+        let _ = self.session_stop_reason.set(reason);
+    }
+
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        &self.session_stop_reason
+    }
+
     fn outgoing_channel(&self) -> OutgoingChannel {
         self.outgoing_channel
     }
@@ -522,7 +566,34 @@ impl endpoint::Session for Session {
     ) -> Result<OutputHandle, Self::AllocError> {
         match &self.local_state {
             SessionState::Mapped => {}
-            _ => return Err(AllocLinkError::IllegalSessionState),
+            _ => {
+                return Err(match self.session_stop_reason.get() {
+                    // The session (or its connection) stopped; the reason is
+                    // recorded before the session becomes Unmapped
+                    Some(reason) => AllocLinkError::SessionStopped(reason.clone()),
+                    None => match &self.local_state {
+                        // The session is ending while the engine still runs; the
+                        // stop reason is only recorded at engine exit, so `Ended`
+                        // is accurate here (defensive fallback)
+                        SessionState::EndSent
+                        | SessionState::EndReceived
+                        | SessionState::Discarding => {
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(
+                                "allocate_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+                            );
+                            #[cfg(feature = "log")]
+                            log::warn!(
+                                "allocate_link: session stop reason not recorded; reporting SessionStopped(Ended)"
+                            );
+                            AllocLinkError::SessionStopped(SessionStopReason::Ended)
+                        }
+                        // Not begun yet (or fully ended without a recorded stop):
+                        // the session exists but is not mapped
+                        _ => AllocLinkError::SessionNotMapped,
+                    },
+                });
+            }
         };
 
         // check whether link name is duplciated

--- a/fe2o3-amqp/src/transaction/controller.rs
+++ b/fe2o3-amqp/src/transaction/controller.rs
@@ -82,7 +82,10 @@ pub(crate) async fn declare_on_link(
     send_on_control_link(inner, sendable)
         .await?
         .await
-        .map_err(|_| LinkStateError::IllegalSessionState)?
+        .map_err(|_| match inner.link.session_stop_reason.get() {
+            Some(reason) => LinkStateError::SessionStopped(reason.clone()),
+            None => LinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })?
         .ok_or(ControllerSendError::NonTerminalDeliveryState)?
         .declared_or_else(|state| {
             if let DeliveryState::Rejected(rejected) = state {
@@ -110,7 +113,10 @@ pub(crate) async fn discharge_on_link(
     send_on_control_link(inner, sendable)
         .await?
         .await
-        .map_err(|_| LinkStateError::IllegalSessionState)?
+        .map_err(|_| match inner.link.session_stop_reason.get() {
+            Some(reason) => LinkStateError::SessionStopped(reason.clone()),
+            None => LinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
+        })?
         .ok_or(ControllerSendError::NonTerminalDeliveryState)?
         .accepted_or_else(|state| {
             if let DeliveryState::Rejected(rejected) = state {

--- a/fe2o3-amqp/src/transaction/coordinator.rs
+++ b/fe2o3-amqp/src/transaction/coordinator.rs
@@ -1,6 +1,7 @@
 //! Control link coordinator
 
 use std::collections::HashSet;
+use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{
     definitions::{self, AmqpError, LinkError},
@@ -20,6 +21,7 @@ use crate::{
         receiver::ReceiverInner,
         shared_inner::{LinkEndpointInner, LinkEndpointInnerDetach},
         IllegalLinkStateError, LinkFrame, ReceiverAttachError, ReceiverLink, RecvError,
+        SessionStopReason,
     },
     util::{Initialized, Running},
     Delivery,
@@ -71,9 +73,16 @@ impl ControlLinkAcceptor {
         remote_attach: Attach,
         control: mpsc::Sender<SessionControl>,
         outgoing: mpsc::Sender<LinkFrame>,
+        session_stop_reason: Arc<OnceLock<SessionStopReason>>,
     ) -> Result<TxnCoordinator, ReceiverAttachError> {
         self.inner
-            .accept_incoming_attach_inner(&self.shared, remote_attach, control, outgoing)
+            .accept_incoming_attach_inner(
+                &self.shared,
+                remote_attach,
+                control,
+                outgoing,
+                session_stop_reason,
+            )
             .await
             .map(|inner| TxnCoordinator {
                 inner,
@@ -178,7 +187,7 @@ impl TxnCoordinator {
                     let _ = self.inner.close_with_error(Some(error)).await;
                     Running::Stop
                 }
-                crate::link::LinkStateError::IllegalSessionState => {
+                crate::link::LinkStateError::SessionStopped(_) => {
                     #[cfg(feature = "tracing")]
                     tracing::error!(?error);
                     #[cfg(feature = "log")]
@@ -288,7 +297,7 @@ impl TxnCoordinator {
                     let _ = self.inner.close_with_error(Some(error)).await;
                     Running::Stop
                 }
-                IllegalLinkStateError::IllegalSessionState => {
+                IllegalLinkStateError::SessionStopped(_) => {
                     // Session must have already dropped
                     Running::Stop
                 }

--- a/fe2o3-amqp/src/transaction/error.rs
+++ b/fe2o3-amqp/src/transaction/error.rs
@@ -1,8 +1,9 @@
 use fe2o3_amqp_types::messaging::{Accepted, DeliveryState, Outcome, Rejected};
 
 use crate::link::{
-    delivery::{FromDeliveryState, FromOneshotRecvError, FromPreSettled},
+    delivery::{FromDeliveryFailure, FromDeliveryState, FromPreSettled},
     DetachError, IllegalLinkStateError, LinkStateError, SendError, SenderAttachError,
+    SessionStopReason,
 };
 
 /// Errors with allocation of new transacation ID
@@ -132,8 +133,8 @@ impl From<IllegalLinkStateError> for ControllerSendError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => LinkStateError::IllegalState.into(),
-            IllegalLinkStateError::IllegalSessionState => {
-                LinkStateError::IllegalSessionState.into()
+            IllegalLinkStateError::SessionStopped(reason) => {
+                LinkStateError::SessionStopped(reason).into()
             }
         }
     }
@@ -237,8 +238,8 @@ impl From<IllegalLinkStateError> for PostError {
     fn from(value: IllegalLinkStateError) -> Self {
         match value {
             IllegalLinkStateError::IllegalState => LinkStateError::IllegalState.into(),
-            IllegalLinkStateError::IllegalSessionState => {
-                LinkStateError::IllegalSessionState.into()
+            IllegalLinkStateError::SessionStopped(reason) => {
+                LinkStateError::SessionStopped(reason).into()
             }
         }
     }
@@ -276,10 +277,12 @@ impl FromPreSettled for PostResult {
     }
 }
 
-impl FromOneshotRecvError for PostResult {
+impl FromDeliveryFailure for PostResult {
     fn from_oneshot_recv_error(_: tokio::sync::oneshot::error::RecvError) -> Self {
-        Err(PostError::LinkStateError(
-            LinkStateError::IllegalSessionState,
-        ))
+        Err(PostError::LinkStateError(LinkStateError::IllegalState))
+    }
+
+    fn from_session_stop_reason(reason: SessionStopReason) -> Self {
+        Err(PostError::LinkStateError(LinkStateError::SessionStopped(reason)))
     }
 }

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -341,7 +341,7 @@ where
         .send_with_state::<T, PostError>(sendable, Some(state), batchable)
         .await?;
 
-    Ok(DeliveryFut::from(settlement))
+    Ok(DeliveryFut::new(settlement, sender.inner.link.session_stop_reason.clone()))
 }
 
 /// Send a ref of transactional posting with the given `batchable` flag.
@@ -370,7 +370,7 @@ where
         .send_ref_with_state::<T, PostError>(sendable, Some(state), batchable)
         .await?;
 
-    Ok(DeliveryFut::from(settlement))
+    Ok(DeliveryFut::new(settlement, sender.inner.link.session_stop_reason.clone()))
 }
 
 /// Transactional acquisition (AMQP 1.0 §4.4.3)

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -1,6 +1,8 @@
 //! Implements session that can handle transaction
 
 
+use std::sync::{Arc, OnceLock};
+
 use fe2o3_amqp_types::{
     definitions::{self},
     messaging::{Accepted, DeliveryState},
@@ -13,7 +15,7 @@ use uuid::Uuid;
 use crate::{
     control::SessionControl,
     endpoint::{self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
-    link::{target_archetype::VariantOfTargetArchetype, LinkRelay},
+    link::{target_archetype::VariantOfTargetArchetype, LinkRelay, SessionStopReason},
     session::{
         self,
         frame::{SessionFrame, SessionOutgoingItem},
@@ -102,11 +104,12 @@ where
         let acceptor = self.txn_manager.control_link_acceptor.clone();
         let control = self.control.clone();
         let outgoing = self.txn_manager.control_link_outgoing.clone();
+        let session_stop_reason = self.session.session_stop_reason().clone();
 
         tokio::spawn(async move {
             // Error accepting new control link is handled by acceptor
             if let Ok(coordinator) = acceptor
-                .accept_incoming_attach(remote_attach, control, outgoing)
+                .accept_incoming_attach(remote_attach, control, outgoing, session_stop_reason)
                 .await
             {
                 coordinator.event_loop().await
@@ -222,6 +225,14 @@ where
 
     fn local_state(&self) -> &Self::State {
         self.session.local_state()
+    }
+
+    fn set_session_stop_reason(&mut self, reason: SessionStopReason) {
+        self.session.set_session_stop_reason(reason)
+    }
+
+    fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
+        self.session.session_stop_reason()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -13,6 +13,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::{
+    connection::ConnectionStopReason,
     control::SessionControl,
     endpoint::{self, IncomingChannel, InputHandle, LinkFlow, OutgoingChannel, OutputHandle},
     link::{target_archetype::VariantOfTargetArchetype, LinkRelay, SessionStopReason},
@@ -233,6 +234,10 @@ where
 
     fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
         self.session.session_stop_reason()
+    }
+
+    fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
+        self.session.connection_stop_reason()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/tests/acceptor.rs
+++ b/fe2o3-amqp/tests/acceptor.rs
@@ -1,0 +1,123 @@
+//! Tests for the acceptor flow (connection, session, and link acceptors)
+//! over in-memory `tokio::io::duplex` streams, so no broker or network is
+//! required.
+
+#![cfg(feature = "acceptor")]
+
+use std::time::Duration;
+
+use fe2o3_amqp::{
+    acceptor::{
+        error::AcceptorAttachError,
+        {ConnectionAcceptor, LinkAcceptor, SessionAcceptor},
+    },
+    connection::Connection,
+    link::SessionStopReason,
+    Session,
+};
+
+/// When the connection stops while the listener session is waiting for an
+/// incoming link, `LinkAcceptor::accept` must surface the connection-level
+/// stop reason rather than a fabricated one.
+#[tokio::test]
+async fn listener_acceptor_reports_connection_closed() {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let mut client_connection = Connection::builder()
+        .container_id("test-client")
+        .open_with_stream(client_io)
+        .await
+        .expect("client connection failed");
+
+    let mut server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    // The listener session is accepted concurrently with the client beginning
+    // its session; the connection handle stays in scope so the connection
+    // stays alive.
+    let session_acceptor = SessionAcceptor::new();
+    let (session_result, begin_result) = tokio::join!(
+        session_acceptor.accept(&mut server_connection),
+        Session::begin(&mut client_connection),
+    );
+    let _client_session = begin_result.expect("client session begin failed");
+    let mut listener_session = session_result.expect("session accept failed");
+
+    let link_acceptor = LinkAcceptor::builder().build();
+    let accept_task =
+        tokio::spawn(async move { link_acceptor.accept(&mut listener_session).await });
+
+    // Stopping the connection must surface as `ConnectionClosed` on the
+    // acceptor side.
+    drop(client_connection);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), accept_task)
+        .await
+        .expect("accept task timed out")
+        .expect("accept task panicked");
+
+    match result {
+        Err(AcceptorAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+        other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
+    }
+}
+
+/// When only the session ends (the remote sends `End`) while the connection
+/// stays alive, `LinkAcceptor::accept` must report a session-level stop
+/// rather than a connection-level one.
+#[tokio::test]
+async fn listener_acceptor_reports_session_ended() {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let mut client_connection = Connection::builder()
+        .container_id("test-client")
+        .open_with_stream(client_io)
+        .await
+        .expect("client connection failed");
+
+    let mut server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    // The listener session is accepted concurrently with the client beginning
+    // its session; the connection handle stays in scope so the connection
+    // stays alive.
+    let session_acceptor = SessionAcceptor::new();
+    let (session_result, begin_result) = tokio::join!(
+        session_acceptor.accept(&mut server_connection),
+        Session::begin(&mut client_connection),
+    );
+    let client_session = begin_result.expect("client session begin failed");
+    let mut listener_session = session_result.expect("session accept failed");
+
+    let link_acceptor = LinkAcceptor::builder().build();
+    let accept_task =
+        tokio::spawn(async move { link_acceptor.accept(&mut listener_session).await });
+
+    // Ending only the session must surface as `Ended`, with the connection
+    // still alive.
+    drop(client_session);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), accept_task)
+        .await
+        .expect("accept task timed out")
+        .expect("accept task panicked");
+
+    match result {
+        Err(AcceptorAttachError::SessionStopped(SessionStopReason::Ended)) => {}
+        other => panic!("expected SessionStopped(Ended), got {:?}", other),
+    }
+}

--- a/fe2o3-amqp/tests/acceptor.rs
+++ b/fe2o3-amqp/tests/acceptor.rs
@@ -11,7 +11,7 @@ use fe2o3_amqp::{
         error::AcceptorAttachError,
         {ConnectionAcceptor, LinkAcceptor, SessionAcceptor},
     },
-    connection::Connection,
+    connection::{Connection, ConnectionStopReason},
     link::SessionStopReason,
     Session,
 };
@@ -64,7 +64,9 @@ async fn listener_acceptor_reports_connection_closed() {
         .expect("accept task panicked");
 
     match result {
-        Err(AcceptorAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+        Err(AcceptorAttachError::SessionStopped(SessionStopReason::ConnectionStopped(
+            ConnectionStopReason::RemoteClosed,
+        ))) => {}
         other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
     }
 }
@@ -117,7 +119,7 @@ async fn listener_acceptor_reports_session_ended() {
         .expect("accept task panicked");
 
     match result {
-        Err(AcceptorAttachError::SessionStopped(SessionStopReason::Ended)) => {}
-        other => panic!("expected SessionStopped(Ended), got {:?}", other),
+        Err(AcceptorAttachError::SessionStopped(SessionStopReason::RemoteEnded)) => {}
+        other => panic!("expected SessionStopped(RemoteEnded), got {:?}", other),
     }
 }

--- a/fe2o3-amqp/tests/clean_teardown.rs
+++ b/fe2o3-amqp/tests/clean_teardown.rs
@@ -1,0 +1,137 @@
+//! Tests that a locally initiated end/close (with or without an error) does
+//! not surface as an error on the session/connection handle.
+//!
+//! These run over an in-memory `tokio::io::duplex` stream, so no broker or
+//! network is required.
+
+#![cfg(feature = "acceptor")]
+
+use std::time::Duration;
+
+use fe2o3_amqp::{
+    acceptor::{ConnectionAcceptor, SessionAcceptor},
+    connection::{Connection, ConnectionHandle},
+    session::{Session, SessionHandle},
+    types::definitions::{self, AmqpError},
+};
+
+fn test_error() -> definitions::Error {
+    definitions::Error::new(
+        AmqpError::InternalError,
+        Some("test error".to_string()),
+        None,
+    )
+}
+
+async fn establish_connection_pair() -> (
+    fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    ConnectionHandle<()>,
+) {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let client_connection = Connection::builder()
+        .container_id("test-client")
+        .open_with_stream(client_io)
+        .await
+        .expect("client connection failed");
+
+    let server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    (server_connection, client_connection)
+}
+
+async fn establish_session_pair(
+    server_connection: &mut fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    client_connection: &mut ConnectionHandle<()>,
+) -> SessionHandle<()> {
+    let session_acceptor = SessionAcceptor::new();
+    let (session_result, begin_result) = tokio::join!(
+        session_acceptor.accept(server_connection),
+        Session::begin(client_connection),
+    );
+    let client_session = begin_result.expect("client session begin failed");
+    session_result.expect("session accept failed");
+    client_session
+}
+
+/// A locally initiated session end must not surface as an error on the
+/// session handle.
+#[tokio::test]
+async fn local_session_end_returns_ok() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let mut client_session =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+
+    let result = tokio::time::timeout(Duration::from_secs(10), client_session.end())
+        .await
+        .expect("end timed out");
+
+    assert!(result.is_ok(), "local end must not error, got {:?}", result);
+}
+
+/// A locally initiated session end with an error must not surface as an error
+/// on the session handle (the error is delivered to the remote).
+#[tokio::test]
+async fn local_session_end_with_error_returns_ok() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let mut client_session =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        client_session.end_with_error(test_error()),
+    )
+    .await
+    .expect("end timed out");
+
+    assert!(
+        result.is_ok(),
+        "local end with error must not error, got {:?}",
+        result
+    );
+}
+
+/// A locally initiated connection close must not surface as an error on the
+/// connection handle.
+#[tokio::test]
+async fn local_connection_close_returns_ok() {
+    let (_server_connection, mut client_connection) = establish_connection_pair().await;
+
+    let result = tokio::time::timeout(Duration::from_secs(10), client_connection.close())
+        .await
+        .expect("close timed out");
+
+    assert!(
+        result.is_ok(),
+        "local close must not error, got {:?}",
+        result
+    );
+}
+
+/// A locally initiated connection close with an error must not surface as an
+/// error on the connection handle (the error is delivered to the remote).
+#[tokio::test]
+async fn local_connection_close_with_error_returns_ok() {
+    let (_server_connection, mut client_connection) = establish_connection_pair().await;
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        client_connection.close_with_error(test_error()),
+    )
+    .await
+    .expect("close timed out");
+
+    assert!(
+        result.is_ok(),
+        "local close with error must not error, got {:?}",
+        result
+    );
+}

--- a/fe2o3-amqp/tests/link_stop_reason.rs
+++ b/fe2o3-amqp/tests/link_stop_reason.rs
@@ -12,12 +12,23 @@ use fe2o3_amqp::{
         ConnectionAcceptor, LinkAcceptor, ListenerConnectionHandle, ListenerSessionHandle,
         SessionAcceptor,
     },
-    connection::{Connection, ConnectionHandle},
+    connection::{Connection, ConnectionHandle, ConnectionStopReason},
     link::{LinkStateError, RecvError, SendError, SenderAttachError, SessionStopReason},
     session::{Session, SessionHandle},
-    types::messaging::{Source, Target},
+    types::{
+        definitions::{self, AmqpError},
+        messaging::{Source, Target},
+    },
     Receiver, Sendable, Sender,
 };
+
+fn test_error() -> definitions::Error {
+    definitions::Error::new(
+        AmqpError::InternalError,
+        Some("test error".to_string()),
+        None,
+    )
+}
 
 async fn establish_connection_pair() -> (ListenerConnectionHandle, ConnectionHandle<()>) {
     let (client_io, server_io) = tokio::io::duplex(4096);
@@ -136,7 +147,11 @@ async fn link_send_surfaces_connection_closed() {
 
     drop(client_connection);
 
-    expect_send_stop_reason(&mut sender, SessionStopReason::ConnectionClosed).await;
+    expect_send_stop_reason(
+        &mut sender,
+        SessionStopReason::ConnectionStopped(ConnectionStopReason::Closed),
+    )
+    .await;
 }
 
 /// When only the session ends while the connection stays alive, a send on an
@@ -171,7 +186,7 @@ async fn link_recv_surfaces_connection_closed() {
 
     match result {
         Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
-            SessionStopReason::ConnectionClosed,
+            SessionStopReason::ConnectionStopped(ConnectionStopReason::RemoteClosed),
         ))) => {}
         other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
     }
@@ -195,9 +210,9 @@ async fn link_recv_surfaces_session_ended() {
 
     match result {
         Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
-            SessionStopReason::Ended,
+            SessionStopReason::RemoteEnded,
         ))) => {}
-        other => panic!("expected SessionStopped(Ended), got {:?}", other),
+        other => panic!("expected SessionStopped(RemoteEnded), got {:?}", other),
     }
 }
 
@@ -223,7 +238,103 @@ async fn attach_after_stop_reports_stop_reason() {
     .expect("attach timed out");
 
     match result {
-        Err(SenderAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+        Err(SenderAttachError::SessionStopped(SessionStopReason::ConnectionStopped(
+            ConnectionStopReason::RemoteClosed,
+        ))) => {}
         other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
     }
+}
+
+/// A locally ended session with an error must surface as `EndedWithError`
+/// with the local error.
+#[tokio::test]
+async fn link_send_surfaces_local_end_with_error() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    let error = test_error();
+    client_session
+        .end_with_error(error.clone())
+        .await
+        .expect("end failed");
+
+    expect_send_stop_reason(&mut sender, SessionStopReason::EndedWithError(error)).await;
+}
+
+/// A remote-initiated session end with an error must surface as
+/// `RemoteEndedWithError` with the remote error.
+#[tokio::test]
+async fn link_send_surfaces_remote_end_with_error() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    let error = test_error();
+    listener_session
+        .end_with_error(error.clone())
+        .await
+        .expect("end failed");
+
+    expect_send_stop_reason(&mut sender, SessionStopReason::RemoteEndedWithError(error)).await;
+}
+
+/// A remote-initiated clean session end must surface as `RemoteEnded`.
+#[tokio::test]
+async fn link_send_surfaces_remote_end() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    drop(listener_session);
+
+    expect_send_stop_reason(&mut sender, SessionStopReason::RemoteEnded).await;
+}
+
+/// A locally closed connection with an error must surface as
+/// `ConnectionStopped(ClosedWithError(..))` with the local error, regardless
+/// of how the peer responds.
+#[tokio::test]
+async fn link_send_surfaces_local_close_with_error() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    let error = test_error();
+    client_connection
+        .close_with_error(error.clone())
+        .await
+        .expect("close failed");
+
+    expect_send_stop_reason(
+        &mut sender,
+        SessionStopReason::ConnectionStopped(ConnectionStopReason::ClosedWithError(error)),
+    )
+    .await;
+}
+
+/// A remote-initiated connection close with an error must surface as
+/// `ConnectionStopped(RemoteClosedWithError(..))` with the remote error.
+#[tokio::test]
+async fn link_send_surfaces_remote_close_with_error() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    let error = test_error();
+    server_connection
+        .close_with_error(error.clone())
+        .await
+        .expect("close failed");
+
+    expect_send_stop_reason(
+        &mut sender,
+        SessionStopReason::ConnectionStopped(ConnectionStopReason::RemoteClosedWithError(error)),
+    )
+    .await;
 }

--- a/fe2o3-amqp/tests/link_stop_reason.rs
+++ b/fe2o3-amqp/tests/link_stop_reason.rs
@@ -1,0 +1,229 @@
+//! Tests that link operations surface the session/connection stop reason.
+//!
+//! These run over an in-memory `tokio::io::duplex` stream, so no broker or
+//! network is required.
+
+#![cfg(feature = "acceptor")]
+
+use std::time::Duration;
+
+use fe2o3_amqp::{
+    acceptor::{
+        ConnectionAcceptor, LinkAcceptor, ListenerConnectionHandle, ListenerSessionHandle,
+        SessionAcceptor,
+    },
+    connection::{Connection, ConnectionHandle},
+    link::{LinkStateError, RecvError, SendError, SenderAttachError, SessionStopReason},
+    session::{Session, SessionHandle},
+    types::messaging::{Source, Target},
+    Receiver, Sendable, Sender,
+};
+
+async fn establish_connection_pair() -> (ListenerConnectionHandle, ConnectionHandle<()>) {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let client_connection = Connection::builder()
+        .container_id("test-client")
+        .open_with_stream(client_io)
+        .await
+        .expect("client connection failed");
+
+    let server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    (server_connection, client_connection)
+}
+
+/// The listener session is accepted concurrently with the client beginning its
+/// session; the connection handles stay in scope so the connections stay alive.
+async fn establish_session_pair(
+    server_connection: &mut ListenerConnectionHandle,
+    client_connection: &mut ConnectionHandle<()>,
+) -> (SessionHandle<()>, ListenerSessionHandle) {
+    let session_acceptor = SessionAcceptor::new();
+    let (session_result, begin_result) = tokio::join!(
+        session_acceptor.accept(server_connection),
+        Session::begin(client_connection),
+    );
+    let client_session = begin_result.expect("client session begin failed");
+    let listener_session = session_result.expect("session accept failed");
+    (client_session, listener_session)
+}
+
+/// Attach a client sender link, with the listener accepting it concurrently.
+async fn attach_sender(
+    client_session: &mut SessionHandle<()>,
+    listener_session: &mut ListenerSessionHandle,
+    name: &str,
+) -> Sender {
+    let link_acceptor = LinkAcceptor::new();
+    let (link_result, attach_result) = tokio::join!(
+        link_acceptor.accept(listener_session),
+        Sender::builder()
+            .name(name)
+            .source(Source::builder().build())
+            .target(Target::builder().build())
+            .attach(client_session),
+    );
+    let _server_receiver = link_result.expect("link accept failed");
+    attach_result.expect("sender attach failed")
+}
+
+/// Attach a client receiver link, with the listener accepting it concurrently.
+async fn attach_receiver(
+    client_session: &mut SessionHandle<()>,
+    listener_session: &mut ListenerSessionHandle,
+    name: &str,
+) -> Receiver {
+    let link_acceptor = LinkAcceptor::new();
+    let (link_result, attach_result) = tokio::join!(
+        link_acceptor.accept(listener_session),
+        Receiver::builder()
+            .name(name)
+            .source(Source::builder().build())
+            .target(Target::builder().build())
+            .attach(client_session),
+    );
+    let _server_sender = link_result.expect("link accept failed");
+    attach_result.expect("receiver attach failed")
+}
+
+/// Sends until the teardown has propagated and the send surfaces the expected
+/// stop reason.
+///
+/// The teardown is asynchronous: a send may win the race and be settled by the
+/// still-alive remote before the session/connection engine exits. Once the
+/// engine exits, every send fails with the stop reason, so retrying is
+/// deterministic.
+async fn expect_send_stop_reason(sender: &mut Sender, expected: SessionStopReason) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let result = sender
+            .send(Sendable::builder().message("hello").settled(true).build())
+            .await;
+        match result {
+            Ok(_) => {
+                // Teardown has not propagated yet; retry.
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for the stop reason to propagate"
+                );
+            }
+            Err(SendError::LinkStateError(LinkStateError::SessionStopped(reason))) => {
+                assert_eq!(reason, expected, "unexpected stop reason");
+                return;
+            }
+            Err(other) => panic!("unexpected send error: {:?}", other),
+        }
+    }
+}
+
+/// When the connection stops, a send on an attached sender link must surface
+/// the connection-level stop reason.
+#[tokio::test]
+async fn link_send_surfaces_connection_closed() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    drop(client_connection);
+
+    expect_send_stop_reason(&mut sender, SessionStopReason::ConnectionClosed).await;
+}
+
+/// When only the session ends while the connection stays alive, a send on an
+/// attached sender link must surface the session-level stop reason.
+#[tokio::test]
+async fn link_send_surfaces_session_ended() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+
+    drop(client_session);
+
+    expect_send_stop_reason(&mut sender, SessionStopReason::Ended).await;
+}
+
+/// When the connection stops, a receive on an attached receiver link must
+/// surface the connection-level stop reason.
+#[tokio::test]
+async fn link_recv_surfaces_connection_closed() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut receiver =
+        attach_receiver(&mut client_session, &mut listener_session, "receiver-1").await;
+
+    drop(server_connection);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), receiver.recv::<String>())
+        .await
+        .expect("recv timed out");
+
+    match result {
+        Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
+            SessionStopReason::ConnectionClosed,
+        ))) => {}
+        other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
+    }
+}
+
+/// When only the session ends while the connection stays alive, a receive on
+/// an attached receiver link must surface the session-level stop reason.
+#[tokio::test]
+async fn link_recv_surfaces_session_ended() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, mut listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let mut receiver =
+        attach_receiver(&mut client_session, &mut listener_session, "receiver-1").await;
+
+    drop(listener_session);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), receiver.recv::<String>())
+        .await
+        .expect("recv timed out");
+
+    match result {
+        Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
+            SessionStopReason::Ended,
+        ))) => {}
+        other => panic!("expected SessionStopped(Ended), got {:?}", other),
+    }
+}
+
+/// Attaching a new link after the connection stopped must surface the
+/// connection-level stop reason.
+#[tokio::test]
+async fn attach_after_stop_reports_stop_reason() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut client_session, _listener_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+
+    drop(server_connection);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        Sender::builder()
+            .name("sender-2")
+            .source(Source::builder().build())
+            .target(Target::builder().build())
+            .attach(&mut client_session),
+    )
+    .await
+    .expect("attach timed out");
+
+    match result {
+        Err(SenderAttachError::SessionStopped(SessionStopReason::ConnectionClosed)) => {}
+        other => panic!("expected SessionStopped(ConnectionClosed), got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

When a connection or session stops before its links, link operations previously failed with generic errors that carried no reason and no origin. This PR propagates the real stop reason — including whether the error is local or remote — down to links and acceptors, and fixes two latent bugs in the close exchange that the new tests surfaced.

## Changes

- **Stop-reason types** — new public `SessionStopReason` and `ConnectionStopReason` distinguishing a local from a remote-originated stop (`EndedWithError`/`ClosedWithError` vs `RemoteEndedWithError`/`RemoteClosedWithError`); the session reason embeds the connection reason via `ConnectionStopped(ConnectionStopReason)`.
- **Variant sweep** — `IllegalSessionState` → `SessionStopped(reason)` on the link error types; `IllegalConnectionState` → `ConnectionStopped(reason)` on `BeginError`/`Error`; `SessionNotMapped` and `ConnectionNotOpened` for never-begun sessions / not-yet-opened connections.
- **Clean teardown** — a session ends cleanly when its connection stops first (errors stay on the `ConnectionHandle`); local `end_with_error`/`close_with_error` errors are recorded in the stop cells so links observe them regardless of how the peer responds.
- **Fixes** — the close exchange no longer fails when draining buffered session frames during `CloseReceived`, and frames arriving in the `Discarding` state are silently discarded per AMQP §2.4.6 instead of poisoning the close outcome.

## Breaking

`IllegalSessionState`/`IllegalConnectionState` replacements, the new public stop reason types, `SessionNotMapped`/`ConnectionNotOpened`, and the `FromOneshotRecvError` → `FromDeliveryFailure` rename.

## Tests

New origin-differentiation tests (local/remote end and close, with and without error), clean-teardown tests (local end/close stays clean on the handle), and acceptor/link stop-reason tests over in-memory duplex streams.