### PR TITLE
feature: Re-advertise the session window with a session-only auto flow

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -59,6 +59,10 @@
 18. **Breaking**: [`BeginError`] gains a `ConnectionNotOpened` variant: beginning a session
     on a connection that has not been opened yet reports `ConnectionNotOpened`, while one
     on a stopped connection reports `ConnectionStopped(reason)`.
+19. A session now re-advertises its window (a session-only flow with no link handle) when
+    half of the incoming-window has been consumed by received transfers, so a peer sending
+    continuously never stalls on the session window even when no link-level flow is
+    generated.
 
 ## 0.16.2
 

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -631,6 +631,10 @@ impl endpoint::Session for ListenerSession {
         self.session.on_outgoing_flow(flow)
     }
 
+    fn maybe_outgoing_session_flow(&mut self) -> Option<SessionOutgoingItem> {
+        self.session.maybe_outgoing_session_flow()
+    }
+
     fn on_outgoing_transfer(
         &mut self,
         input_handle: InputHandle,

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -113,6 +113,11 @@ pub(crate) trait Session {
 
     fn on_outgoing_flow(&mut self, flow: LinkFlow) -> Result<SessionFrame, Self::Error>;
 
+    /// Returns a session-only flow (no link handle) when the session should proactively
+    /// re-advertise its window after receiving transfers. Called by the session engine after
+    /// every incoming transfer; returns `None` when no flow is due.
+    fn maybe_outgoing_session_flow(&mut self) -> Option<SessionOutgoingItem>;
+
     fn on_outgoing_transfer(
         &mut self,
         input_handle: InputHandle,

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -30,9 +30,16 @@ pub struct Builder {
     pub next_outgoing_id: TransferNumber,
 
     /// The initial incoming-window of the sender
+    ///
+    /// Defaults to [`DEFAULT_WINDOW`]. Once half of the window has been consumed
+    /// by received transfers, the session re-advertises its window with a
+    /// session-only flow (no link handle), so a peer sending continuously never
+    /// stalls even when no link-level flow is generated.
     pub incoming_window: TransferNumber,
 
     /// The initial outgoing-window of the sender
+    ///
+    /// Defaults to [`DEFAULT_WINDOW`].
     pub outgoing_window: TransferNumber,
 
     /// The maximum handle value that can be used on the session
@@ -108,6 +115,7 @@ cfg_transaction! {
                     handle_max: self.handle_max,
                     incoming_channel: None,
                     next_incoming_id: 0,
+                    need_flow_count: 0,
                     remote_incoming_window: 0,
                     remote_incoming_window_exhausted_buffer: VecDeque::new(),
                     remote_outgoing_window: 0,
@@ -157,6 +165,7 @@ impl Builder {
             handle_max: self.handle_max,
             incoming_channel: None,
             next_incoming_id: 0,
+            need_flow_count: 0,
             remote_incoming_window: 0,
             remote_incoming_window_exhausted_buffer: VecDeque::new(),
             remote_outgoing_window: 0,
@@ -178,12 +187,19 @@ impl Builder {
     }
 
     /// The initial incoming-window of the sender
+    ///
+    /// Defaults to [`DEFAULT_WINDOW`]. Once half of the window has been consumed
+    /// by received transfers, the session re-advertises its window with a
+    /// session-only flow (no link handle), so a peer sending continuously never
+    /// stalls even when no link-level flow is generated.
     pub fn incoming_window(mut self, value: TransferNumber) -> Self {
         self.incoming_window = value;
         self
     }
 
     /// The initial outgoing-window of the sender
+    ///
+    /// Defaults to [`DEFAULT_WINDOW`].
     pub fn outgoing_window(mut self, value: TransferNumber) -> Self {
         self.outgoing_window = value;
         self

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -195,6 +195,19 @@ where
                 self.session
                     .on_incoming_transfer(performative, payload)
                     .await?;
+
+                // Re-advertise the session window (session-only flow) once half of the
+                // incoming-window has been consumed by received transfers, mirroring
+                // go-amqp's proactive top-up. This keeps the peer's send window sliding
+                // even when no link-level flow is generated.
+                if let Some(outgoing_item) = self.session.maybe_outgoing_session_flow() {
+                    send_outgoing_item(
+                        &self.outgoing,
+                        outgoing_item,
+                        self.session.connection_stop_reason(),
+                    )
+                    .await?;
+                }
             }
             SessionFrameBody::Disposition(disposition) => {
                 if let Some(dispositions) = self.session.on_incoming_disposition(disposition)? {

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -329,6 +329,11 @@ pub struct Session {
     pub(crate) incoming_channel: Option<IncomingChannel>,
     // initialize with 0 first and change after receiving the remote Begin
     pub(crate) next_incoming_id: TransferNumber,
+    // Number of transfer frames received since the last session flow was sent.
+    // Used to re-advertise the session window (advancing next-incoming-id) when half
+    // of the incoming-window has been consumed, mirroring go-amqp's approach. This
+    // keeps the peer's send window sliding even when no link-level flow is generated.
+    pub(crate) need_flow_count: u32,
     pub(crate) remote_incoming_window: SequenceNo,
     // Outgoing transfers that are blocked by the remote-incoming-window
     pub(crate) remote_incoming_window_exhausted_buffer: VecDeque<(InputHandle, Transfer, Payload)>,
@@ -443,6 +448,30 @@ impl Session {
         };
         let frame = SessionFrame::new(self.outgoing_channel, body);
         Ok(frame)
+    }
+
+    /// Build a session-only flow that re-advertises the session window. It carries no link
+    /// state (`handle` and the link fields are unset), so it only updates the peer's view of
+    /// our session window via the advanced `next-incoming-id`.
+    fn on_outgoing_session_flow(&self) -> SessionFrame {
+        let flow = Flow {
+            // Session flow states
+            next_incoming_id: Some(self.next_incoming_id),
+            incoming_window: self.incoming_window,
+            next_outgoing_id: self.next_outgoing_id,
+            outgoing_window: self.outgoing_window,
+            // No link flow states: this is a session-only flow
+            handle: None,
+            delivery_count: None,
+            link_credit: None,
+            available: None,
+            drain: false,
+            echo: false,
+            properties: None,
+        };
+
+        let body = SessionFrameBody::Flow(flow);
+        SessionFrame::new(self.outgoing_channel, body)
     }
 
     async fn on_incoming_flow_inner(
@@ -740,6 +769,7 @@ impl endpoint::Session for Session {
         // remote-outgoing-window, and MAY (depending on policy) decrement its incoming-window.
         self.next_incoming_id = self.next_incoming_id.wrapping_add(1);
         self.remote_outgoing_window = self.remote_outgoing_window.saturating_sub(1);
+        self.need_flow_count = self.need_flow_count.saturating_add(1);
 
         // TODO: allow user to define whether the incoming window should be decremented
 
@@ -994,6 +1024,27 @@ impl endpoint::Session for Session {
         Ok(frame)
     }
 
+    /// Returns a session-only flow to send when half of the incoming-window has been consumed
+    /// by received transfer frames, mirroring go-amqp's proactive window top-up. The advertised
+    /// window size is constant; the peer's remaining allowance is recomputed from the advanced
+    /// `next-incoming-id`, so a peer that relies on continuous sending never stalls when no
+    /// link-level flow is generated.
+    fn maybe_outgoing_session_flow(&mut self) -> Option<SessionOutgoingItem> {
+        // Only send while the session is fully mapped; no flows are emitted during teardown.
+        if !matches!(self.local_state, SessionState::Mapped) {
+            return None;
+        }
+
+        if self.need_flow_count >= self.incoming_window / 2 {
+            self.need_flow_count = 0;
+            Some(SessionOutgoingItem::SingleFrame(
+                self.on_outgoing_session_flow(),
+            ))
+        } else {
+            None
+        }
+    }
+
     fn on_outgoing_transfer(
         &mut self,
         input_handle: InputHandle,
@@ -1116,7 +1167,25 @@ fn consecutive_chunk_indices(delivery_ids: &[DeliveryNumber]) -> Vec<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::num_messages_settled_by_disposition;
+    use std::sync::{Arc, OnceLock};
+
+    use super::{
+        num_messages_settled_by_disposition, Builder, Session, SessionFrame, SessionFrameBody,
+        SessionOutgoingItem, SessionState,
+    };
+    use crate::endpoint::{OutgoingChannel, Session as _};
+
+    fn mapped_session() -> Session {
+        Builder::new()
+            .incoming_window(2048)
+            .outgoing_window(2048)
+            .into_session(
+                OutgoingChannel(0),
+                SessionState::Mapped,
+                Arc::new(OnceLock::new()),
+                Arc::new(OnceLock::new()),
+            )
+    }
 
     #[test]
     fn number_of_message_settled_by_disposition() {
@@ -1135,5 +1204,53 @@ mod tests {
         let last = Some(1);
         let count = num_messages_settled_by_disposition(first, last);
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn maybe_outgoing_session_flow_fires_at_half_window() {
+        let mut session = mapped_session();
+
+        // Below half of the incoming window: no flow is due.
+        session.need_flow_count = 1023;
+        assert!(session.maybe_outgoing_session_flow().is_none());
+
+        // At half of the incoming window: a session-only flow is due and the
+        // counter is reset.
+        session.need_flow_count = 1024;
+        let item = session
+            .maybe_outgoing_session_flow()
+            .expect("session flow should be due");
+        let flow = match item {
+            SessionOutgoingItem::SingleFrame(SessionFrame {
+                body: SessionFrameBody::Flow(flow),
+                ..
+            }) => flow,
+            _ => panic!("expected a single session flow frame"),
+        };
+
+        // Session-only flow: no link handle and no link fields.
+        assert!(flow.handle.is_none());
+        assert!(flow.delivery_count.is_none());
+        assert!(flow.link_credit.is_none());
+
+        // The session window is re-advertised from the current session state.
+        assert_eq!(flow.next_incoming_id, Some(session.next_incoming_id));
+        assert_eq!(flow.incoming_window, session.incoming_window);
+        assert_eq!(flow.next_outgoing_id, session.next_outgoing_id);
+        assert_eq!(flow.outgoing_window, session.outgoing_window);
+
+        // The counter must be reset after the flow is emitted, so no flow is
+        // due immediately after.
+        assert_eq!(session.need_flow_count, 0);
+        assert!(session.maybe_outgoing_session_flow().is_none());
+    }
+
+    #[test]
+    fn maybe_outgoing_session_flow_skips_when_not_mapped() {
+        let mut session = mapped_session();
+        session.local_state = SessionState::EndSent;
+        session.need_flow_count = u32::MAX;
+
+        assert!(session.maybe_outgoing_session_flow().is_none());
     }
 }

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -379,6 +379,10 @@ where
         self.session.on_outgoing_flow(flow)
     }
 
+    fn maybe_outgoing_session_flow(&mut self) -> Option<SessionOutgoingItem> {
+        self.session.maybe_outgoing_session_flow()
+    }
+
     fn on_outgoing_transfer(
         &mut self,
         input_handle: InputHandle,


### PR DESCRIPTION
## Summary

A session now re-advertises its window with a **session-only flow** (no link handle) once half of the `incoming-window` has been consumed by received transfers, so a peer that sends continuously never stalls on the session window even when no link-level flow is generated.

## Motivation

The session window (`incoming-window` / `outgoing-window`, default `DEFAULT_WINDOW = 2048`) has a constant advertised size; the peer's remaining send allowance is recomputed from the advanced `next-incoming-id` on every flow it receives (AMQP 1.0 §2.5.6).

Previously the session window was only ever re-advertised as a side effect of link-level flow frames (receiver auto credit-refill, manual `send_flow`, or echo replies). A session whose links never generate flows had no backstop, so a peer sending more than a full window would stall at 2048 until some other flow happened to go out.

This mirrors the proactive top-up used by **Azure/go-amqp** (`needFlowCount >= incomingWindow/2`, `session.go`), which keeps the window sliding independently of link activity.

## Changes

- `Session` tracks `need_flow_count`, incremented on every received transfer frame alongside `next-incoming-id`.
- When `need_flow_count >= incoming_window / 2`, the session emits a session-only flow carrying `next_incoming_id`, `incoming_window`, `next_outgoing_id`, and `outgoing_window`, then resets the counter (`fe2o3-amqp/src/session/mod.rs`).
- The session engine sends this flow after each incoming transfer, suppressed unless the session is fully `Mapped` (`fe2o3-amqp/src/session/engine.rs`).
- Added `maybe_outgoing_session_flow` to the `endpoint::Session` trait, delegated by the listener and transaction sessions.
- Documented the constant default and the auto-refresh behavior on the session builder's `incoming_window` / `outgoing_window` fields and setters.

No public API or wire-format changes.

## Testing

- Two unit tests on the session decision logic: fires exactly at half the incoming window (correct session-only flow contents, counter reset), and is skipped when the session is not `Mapped`.
- `cargo fmt`, `clippy --all-features --all-targets -D warnings`, the full lib test suite, and the in-memory integration suites (acceptor, clean_teardown, link_stop_reason, sasl_acceptor) all pass.