### PR TITLE
feat: Use native-tls as the default connector for amqps when both TLS features are enabled

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -68,6 +68,8 @@
     sent on the transaction discharge path.
 21. **Breaking**: [`DEFAULT_WINDOW`] is changed from `2048` to `5000`, matching the default
     used by Microsoft.Azure.Amqp (.NET) and Azure/go-amqp.
+22. `amqps://` with both the `"rustls"` and `"native-tls"` features enabled now uses the
+    `"native-tls"` default connector instead of failing with `TlsConnectorNotFound`.
 
 ## 0.16.2
 

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -803,11 +803,10 @@ impl Builder<'_, mode::ConnectorWithId, ()> {
         self.connect_with_stream(tls_stream, spawn_engine_fn).await
     }
 
-    #[cfg(all(
-        feature = "native-tls",
-        not(feature = "rustls"),
-        not(target_arch = "wasm32")
-    ))]
+    // Also the default backend when both `"rustls"` and `"native-tls"` are enabled
+    // (matching reqwest). The `rustls` default path stays exclusive to rustls-only
+    // builds to avoid dead code in the both-enabled case.
+    #[cfg(all(feature = "native-tls", not(target_arch = "wasm32")))]
     async fn connect_tls_with_native_tls_default<Io, F>(
         self,
         stream: Io,
@@ -847,10 +846,15 @@ cfg_not_wasm32! {
         ///
         /// # TLS
         ///
-        /// TLS is not supported unless one and only one of the following feature must be enabled
+        /// TLS requires at least one of the following features to be enabled:
         ///
         /// 1. "rustls"
         /// 2. "native-tls"
+        ///
+        /// If both are enabled, `"native-tls"` is used as the default TLS connector
+        /// for `amqps://`; to pick the `"rustls"` stack explicitly, supply a connector
+        /// via [`Builder::rustls_connector`] (or [`Builder::native_tls_connector`] for
+        /// native-tls).
         ///
         /// If no custom `TlsConnector` is supplied, the following default connector will be used.
         ///
@@ -973,6 +977,9 @@ cfg_not_wasm32! {
                     self.connect_with_stream(stream, spawn_engine).await
                 },
                 "amqps" => {
+                    // With both TLS features enabled, `native-tls` is the default
+                    // backend for `amqps://` (matching reqwest). Explicit selection is
+                    // available via `rustls_connector`/`native_tls_connector`.
                     #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
                     {
                         let domain = self.domain.ok_or(OpenError::InvalidDomain)?;
@@ -981,9 +988,10 @@ cfg_not_wasm32! {
                             .await;
                     }
 
+                    // Covers the native-tls-only build and, as the default, the
+                    // both-features-enabled build.
                     #[cfg(all(
                         feature = "native-tls",
-                        not(feature = "rustls"),
                         not(target_arch = "wasm32")
                     ))]
                     {

--- a/fe2o3-amqp/src/lib.rs
+++ b/fe2o3-amqp/src/lib.rs
@@ -39,6 +39,11 @@
 //! `rustls::crypto::CryptoProvider::install_default` and supply your own
 //! `tokio_rustls::TlsConnector` to the connection builder.
 //!
+//! When both the `"rustls"` and `"native-tls"` features are enabled, `"native-tls"`
+//! is used as the default TLS connector for `amqps://` when no connector is supplied
+//! to the builder. Pick a specific stack with
+//! [`Connection::builder().rustls_connector(..)`] / `native_tls_connector(..)`.
+//!
 //! The default features also include `prefer-post-quantum`. A client therefore
 //! sends an `X25519MLKEM768` key share in the first ClientHello. To send an
 //! `X25519` key share instead, build the config with

--- a/fe2o3-amqp/tests/tls_dual_stack.rs
+++ b/fe2o3-amqp/tests/tls_dual_stack.rs
@@ -1,0 +1,37 @@
+//! Verifies that `amqps://` works when both TLS features are enabled.
+//!
+//! With both `"rustls"` and `"native-tls"` enabled, the `()`-builder default for
+//! `amqps://` is the `native-tls` connector (matching reqwest), instead of failing
+//! with `TlsConnectorNotFound`. This smoke test asserts that the default path is
+//! taken: the connection proceeds into the native-tls handshake (which fails against
+//! a dead duplex) rather than erroring with `TlsConnectorNotFound`.
+
+#![cfg(all(feature = "rustls", feature = "native-tls"))]
+
+use std::time::Duration;
+
+use fe2o3_amqp::connection::{Connection, OpenError};
+
+#[tokio::test]
+async fn amqps_with_both_tls_features_uses_native_tls_default() {
+    let (client_io, server_io) = tokio::io::duplex(1024);
+    // Closing the server end makes the client's TLS handshake fail immediately.
+    drop(server_io);
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(10),
+        Connection::builder()
+            .container_id("test")
+            .scheme("amqps")
+            .domain("localhost")
+            .open_with_stream(client_io),
+    )
+    .await
+    .expect("timed out")
+    .expect_err("expected the TLS handshake to fail");
+
+    assert!(
+        !matches!(err, OpenError::TlsConnectorNotFound),
+        "both-enabled amqps must not error with TlsConnectorNotFound"
+    );
+}


### PR DESCRIPTION
With both the `rustls` and `native-tls` features enabled, `amqps://` used to fall through to `TlsConnectorNotFound`. Following `reqwest`, `native-tls` is now the default connector when both stacks are enabled; explicit selection remains available via `rustls_connector`/`native_tls_connector`.
