### PR TITLE
fix: split large messages at max-frame-size instead of max-message-size

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Unreleased
+
+1. **Breaking**: `SendError` and `RecvError` gain a `MessageSizeExceeded` variant: the
+   sender rejects oversized messages locally, and the receiver rejects deliveries
+   larger than the advertised max-message-size (with `amqp:link:message-size-exceeded`)
+   without detaching the link.
+2. **Bugfix**: large messages are now split at the negotiated **max-frame-size** boundary
+   instead of the link's max-message-size, keeping the session's transfer-id and window
+   accounting consistent with the wire. The frame size is refreshed when a link resumes
+   on a different connection.
+3. Continuation frames of a split delivery now always omit the delivery-id, delivery-tag,
+   message-format, settled and rcv-settle-mode fields (previously a two-frame delivery
+   could carry a delivery-tag on its last frame, which peers such as Qpid Broker-J
+   reject).
+
 ## 0.17.0
 
 1. **Breaking**: Added the [`TransactionBase`] trait, which provides the `txn_id()`

--- a/fe2o3-amqp/src/acceptor/connection.rs
+++ b/fe2o3-amqp/src/acceptor/connection.rs
@@ -208,6 +208,7 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
         let engine = ConnectionEngine::open(transport, listener_connection, control_rx, outgoing_rx)
             .await?;
         let connection_stop_reason = engine.connection_stop_reason().clone();
+        let max_frame_size = engine.max_frame_size();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -217,6 +218,7 @@ impl<Tls, Sasl> ConnectionAcceptor<Tls, Sasl> {
             outcome,
             outgoing: outgoing_tx,
             connection_stop_reason,
+            max_frame_size,
             session_listener: begin_rx,
         };
         Ok(connection_handle)

--- a/fe2o3-amqp/src/acceptor/link.rs
+++ b/fe2o3-amqp/src/acceptor/link.rs
@@ -282,6 +282,7 @@ mod tests {
             outcome,
             outgoing,
             session_stop_reason: stop_reason_cell,
+            max_frame_size: 4096,
             link_listener,
         }
     }

--- a/fe2o3-amqp/src/acceptor/local_receiver_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_receiver_link.rs
@@ -94,6 +94,7 @@ where
             session.control.clone(),
             session.outgoing.clone(),
             session.session_stop_reason().clone(),
+            session.max_frame_size(),
         )
         .await
         .map(|inner| Receiver { inner })
@@ -113,6 +114,7 @@ where
         control: mpsc::Sender<SessionControl>,
         outgoing: mpsc::Sender<LinkFrame>,
         session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+        max_frame_size: usize,
     ) -> Result<ReceiverInner<ReceiverLink<T>>, ReceiverAttachError>
     where
         T: Into<TargetArchetype>
@@ -221,6 +223,7 @@ where
             flow_state: flow_state_consumer,
             unsettled,
             session_stop_reason,
+            max_frame_size,
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         };
@@ -229,7 +232,7 @@ where
         match (err, link.on_incoming_attach(remote_attach)) {
             (Some(attach_error), _) | (_, Err(attach_error)) => {
                 // Complete attach anyway
-                link.send_attach(&outgoing, &control, false).await?;
+                link.send_attach(&outgoing, false).await?;
                 return Err(link
                     .handle_attach_error(
                         attach_error,
@@ -239,7 +242,7 @@ where
                     )
                     .await)
             }
-            _ => link.send_attach(&outgoing, &control, false).await?,
+            _ => link.send_attach(&outgoing, false).await?,
         }
 
         let mut inner = ReceiverInner {

--- a/fe2o3-amqp/src/acceptor/local_sender_link.rs
+++ b/fe2o3-amqp/src/acceptor/local_sender_link.rs
@@ -163,6 +163,7 @@ where
             flow_state: flow_state_consumer,
             unsettled,
             session_stop_reason: session.session_stop_reason().clone(),
+            max_frame_size: session.max_frame_size(),
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         };
@@ -170,10 +171,10 @@ where
         let outgoing = session.outgoing.clone();
 
         match link.on_incoming_attach(remote_attach) {
-            Ok(_) => link.send_attach(&outgoing, &session.control, false).await?,
+            Ok(_) => link.send_attach(&outgoing, false).await?,
             Err(attach_error) => {
                 // Complete attach then detach should any error happen
-                link.send_attach(&outgoing, &session.control, false).await?;
+                link.send_attach(&outgoing, false).await?;
                 match attach_error {
                     SenderAttachError::SndSettleModeNotSupported => {
                         // FIXME: The initiating side is responsible for checking whether the desired modes are supported?

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -208,6 +208,7 @@ impl SessionAcceptor {
                         control: session_control_tx.clone(),
                         session: listener_session,
                         txn_manager,
+                        max_frame_size: connection.max_frame_size(),
                     };
     
                     let engine = SessionEngine::begin_listener_session(
@@ -295,7 +296,6 @@ impl SessionAcceptor {
             outgoing_channel,
             local_state,
             connection.connection_stop_reason.clone(),
-            max_frame_size,
         );
         let session_stop_reason = session.session_stop_reason().clone();
         session.on_incoming_begin(
@@ -418,10 +418,6 @@ impl endpoint::Session for ListenerSession {
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         self.session.connection_stop_reason()
-    }
-
-    fn max_frame_size(&self) -> usize {
-        self.session.max_frame_size()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -290,10 +290,12 @@ impl SessionAcceptor {
         // `into_session` creates the shared stop-reason cell; the engine
         // publishes the reason on the session at exit, and the handle (and the
         // links attached through it) read the same cell via a clone.
+        let max_frame_size = connection.max_frame_size();
         let mut session = self.0.clone().into_session(
             outgoing_channel,
             local_state,
             connection.connection_stop_reason.clone(),
+            max_frame_size,
         );
         let session_stop_reason = session.session_stop_reason().clone();
         session.on_incoming_begin(
@@ -326,6 +328,7 @@ impl SessionAcceptor {
             outcome,
             outgoing: outgoing_tx,
             session_stop_reason,
+            max_frame_size,
             link_listener: link_listener_rx,
         };
         Ok(handle)
@@ -415,6 +418,10 @@ impl endpoint::Session for ListenerSession {
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         self.session.connection_stop_reason()
+    }
+
+    fn max_frame_size(&self) -> usize {
+        self.session.max_frame_size()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/connection/builder.rs
+++ b/fe2o3-amqp/src/connection/builder.rs
@@ -1347,6 +1347,7 @@ cfg_not_wasm32! {
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
     {
         let connection_stop_reason = engine.connection_stop_reason().clone();
+        let max_frame_size = engine.max_frame_size();
         let (handle, outcome) = engine.spawn();
 
         let connection_handle = ConnectionHandle {
@@ -1356,6 +1357,7 @@ cfg_not_wasm32! {
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
             connection_stop_reason,
+            max_frame_size,
             session_listener: (),
         };
 
@@ -1374,6 +1376,7 @@ cfg_wasm32! {
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
         let connection_stop_reason = engine.connection_stop_reason().clone();
+        let max_frame_size = engine.max_frame_size();
         let (handle, outcome) = engine.spawn_on_local_set(local_set);
 
         let connection_handle = ConnectionHandle {
@@ -1383,6 +1386,7 @@ cfg_wasm32! {
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
             connection_stop_reason,
+            max_frame_size,
             session_listener: (),
         };
 
@@ -1398,6 +1402,7 @@ cfg_wasm32! {
         Io: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + 'static,
     {
         let connection_stop_reason = engine.connection_stop_reason().clone();
+        let max_frame_size = engine.max_frame_size();
         let (handle, outcome) = engine.spawn_local();
 
         let connection_handle = ConnectionHandle {
@@ -1407,6 +1412,7 @@ cfg_wasm32! {
             outcome,
             outgoing: outgoing_tx, // session_control: session_control_tx
             connection_stop_reason,
+            max_frame_size,
             session_listener: (),
         };
 

--- a/fe2o3-amqp/src/connection/engine.rs
+++ b/fe2o3-amqp/src/connection/engine.rs
@@ -36,12 +36,32 @@ pub(crate) struct ConnectionEngine<Io, C> {
 
 impl<Io, C> ConnectionEngine<Io, C>
 where
+    Io: AsyncRead + AsyncWrite + Unpin,
     C: endpoint::Connection,
 {
     /// The shared cell holding why the connection stopped, on the connection
     /// object and shared with the sessions and the handle
     pub(crate) fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         self.connection.connection_stop_reason()
+    }
+
+    /// The negotiated max frame size (encoder max frame length) of this
+    /// connection, i.e. the maximum length of the frame data (excluding the
+    /// 4-byte size prefix) that the transport encoder will emit.
+    ///
+    /// Per AMQP 1.0 §2.7.1 the `max-frame-size` field of the Open performative
+    /// is directional: it is the largest frame the advertising peer can
+    /// accept, and a peer MUST NOT send frames larger than its partner can
+    /// handle. The outbound limit is therefore derived from the *remote*
+    /// value (clamped to at least `MIN_MAX_FRAME_SIZE`), not from the minimum
+    /// of the two advertised values. This is the same value the transport
+    /// encoder enforces, so link-level splitting that respects it guarantees
+    /// every frame fits.
+    ///
+    /// The value is final once the Open exchange completes in `open_inner`,
+    /// i.e. before any `ConnectionHandle` is created.
+    pub(crate) fn max_frame_size(&self) -> usize {
+        self.transport.encoder_max_frame_size()
     }
 }
 
@@ -418,16 +438,6 @@ where
             }
             ConnectionControl::DeallocateSession(session_id) => {
                 self.connection.deallocate_session(session_id)
-            }
-            ConnectionControl::GetMaxFrameSize(resp) => {
-                let max_frame_size = self.transport.encoder_max_frame_size();
-                #[allow(unused_variables)]
-                if let Err(error) = resp.send(max_frame_size) {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!(?error);
-                    #[cfg(feature = "log")]
-                    log::error!("{:?}", error);
-                }
             }
         }
 

--- a/fe2o3-amqp/src/connection/mod.rs
+++ b/fe2o3-amqp/src/connection/mod.rs
@@ -96,6 +96,9 @@ pub struct ConnectionHandle<R> {
     pub(crate) outgoing: Sender<SessionFrame>,
     /// Why the connection stopped, shared with the sessions
     pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+    /// The negotiated max frame size (encoder max frame length), shared with
+    /// the sessions and the links
+    pub(crate) max_frame_size: usize,
     pub(crate) session_listener: R,
 }
 
@@ -132,6 +135,12 @@ impl<R> ConnectionHandle<R> {
             true => true,
             false => self.control.is_closed(),
         }
+    }
+
+    /// The negotiated max frame size (encoder max frame length) of this
+    /// connection
+    pub(crate) fn max_frame_size(&self) -> usize {
+        self.max_frame_size
     }
 
     /// Tries to close the connection

--- a/fe2o3-amqp/src/control.rs
+++ b/fe2o3-amqp/src/control.rs
@@ -30,7 +30,6 @@ pub(crate) enum ConnectionControl {
         responder: oneshot::Sender<Result<OutgoingChannel, AllocSessionError>>,
     },
     DeallocateSession(OutgoingChannel),
-    GetMaxFrameSize(oneshot::Sender<usize>),
 }
 
 impl std::fmt::Display for ConnectionControl {
@@ -42,7 +41,6 @@ impl std::fmt::Display for ConnectionControl {
                 responder: _,
             } => write!(f, "AllocateSession"),
             Self::DeallocateSession(id) => write!(f, "DeallocateSession({})", id.0),
-            Self::GetMaxFrameSize(_) => write!(f, "GetMaxFrameSize"),
         }
     }
 }
@@ -64,7 +62,6 @@ pub(crate) enum SessionControl {
     DeallocateLink(OutputHandle),
     Disposition(Disposition),
     CloseConnectionWithError((ConnectionError, Option<String>)),
-    GetMaxFrameSize(oneshot::Sender<usize>),
 
     // Transaction related controls
     #[cfg(feature = "transaction")]
@@ -103,7 +100,6 @@ impl std::fmt::Display for SessionControl {
             SessionControl::DeallocateLink(name) => write!(f, "DeallocateLink({:?})", name),
             SessionControl::Disposition(_) => write!(f, "Disposition"),
             SessionControl::CloseConnectionWithError(_) => write!(f, "CloseConnectionWithError"),
-            SessionControl::GetMaxFrameSize(_) => write!(f, "GetMaxFrameSize"),
 
             #[cfg(feature = "transaction")]
             SessionControl::AllocateTransactionId { .. } => write!(f, "AllocateTransactionId"),

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -48,7 +48,6 @@ pub(crate) trait LinkAttach {
     async fn send_attach(
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<(), Self::AttachError>;
 }
@@ -89,7 +88,6 @@ pub(crate) trait LinkExt: Link {
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
         reader: &mut mpsc::Receiver<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<Self::AttachExchange, Self::AttachError>;
 

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -41,6 +41,11 @@ pub(crate) trait Session {
     /// The shared cell holding why the connection stopped
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>>;
 
+    /// The shared value holding the negotiated max frame size (encoder max
+    /// frame length), shared from the connection and used by links to split
+    /// transfers and attach frames
+    fn max_frame_size(&self) -> usize;
+
     fn outgoing_channel(&self) -> OutgoingChannel;
 
     // Allocate new local handle for new Link

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -41,11 +41,6 @@ pub(crate) trait Session {
     /// The shared cell holding why the connection stopped
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>>;
 
-    /// The shared value holding the negotiated max frame size (encoder max
-    /// frame length), shared from the connection and used by links to split
-    /// transfers and attach frames
-    fn max_frame_size(&self) -> usize;
-
     fn outgoing_channel(&self) -> OutgoingChannel;
 
     // Allocate new local handle for new Link

--- a/fe2o3-amqp/src/frames/amqp.rs
+++ b/fe2o3-amqp/src/frames/amqp.rs
@@ -95,6 +95,19 @@ impl FrameEncoder {
         let more = remaining_bytes > self.max_frame_body_size;
 
         if more {
+            // DEFENSIVE PATH — likely never taken.
+            //
+            // The sender link (`SenderLink::send_transfer_without_modifying_unsettled_map`)
+            // already splits payloads with the same bound as this encoder
+            // (`max_frame_size - 4 - performative_size`, including worst-case
+            // delivery-id headroom), so every link-level transfer produces
+            // exactly one physical frame. If this branch ever triggers, it
+            // indicates a sizing mismatch (e.g. a new field added to the
+            // `Transfer` performative or a code path that bypasses the link
+            // split). Note that frames split here are NOT counted by the
+            // session (`next-outgoing-id` / `remote-incoming-window` are only
+            // updated once per link-level transfer), so this path must stay a
+            // safety net rather than the primary splitting mechanism.
             let orig_more = transfer.more; // If the transfer is pre-split at link
             transfer.more = true;
             buf.clear();

--- a/fe2o3-amqp/src/link/builder.rs
+++ b/fe2o3-amqp/src/link/builder.rs
@@ -420,6 +420,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
         output_handle: OutputHandle,
         flow_state_consumer: C,
         session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+        max_frame_size: usize,
         // state_code: Arc<AtomicU8>,
     ) -> Link<Role, T, C, M> {
         let local_state = LinkState::Unattached;
@@ -448,6 +449,7 @@ impl<Role, T, NameState, SS, TS> Builder<Role, T, NameState, SS, TS> {
             flow_state: flow_state_consumer,
             unsettled,
             session_stop_reason,
+            max_frame_size,
             verify_incoming_source: self.verify_incoming_source,
             verify_incoming_target: self.verify_incoming_target,
         }
@@ -550,10 +552,11 @@ where
             output_handle,
             consumer,
             session.session_stop_reason().clone(),
+            session.max_frame_size(),
         );
 
         match link
-            .exchange_attach(&session.outgoing, &mut incoming_rx, &session.control, false)
+            .exchange_attach(&session.outgoing, &mut incoming_rx, false)
             .await
         {
             Ok(exchange) => {
@@ -672,10 +675,11 @@ where
             output_handle,
             flow_state,
             session.session_stop_reason().clone(),
+            session.max_frame_size(),
         );
 
         match link
-            .exchange_attach(&session.outgoing, &mut incoming_rx, &session.control, false)
+            .exchange_attach(&session.outgoing, &mut incoming_rx, false)
             .await
         {
             Ok(outcome) => outcome.complete_or(ReceiverAttachError::IllegalState)?,

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -143,6 +143,40 @@ pub enum SenderAttachError {
     RemoteClosedWithError(definitions::Error),
 }
 
+/// The encoded message is larger than the maximum message size negotiated on
+/// the link.
+///
+/// The maximum message size is the minimum of the local and remote
+/// `max-message-size` advertised at link attach (see `get_max_message_size`);
+/// a value of zero means no limit is imposed. The error is produced on both
+/// sides of the link:
+///
+/// - On the **sender** side, [`Sender::send`](crate::Sender::send) rejects
+///   the message locally before any transfer frame is sent, mirroring other
+///   AMQP client implementations (e.g. go-amqp surfaces the
+///   `amqp:link:message-size-exceeded` error condition in this case).
+/// - On the **receiver** side, [`Receiver::recv`](crate::Receiver::recv)
+///   returns this error when the peer sends a delivery larger than the
+///   advertised `max_message_size`. The delivery is rejected with a
+///   `Rejected` disposition carrying `amqp:link:message-size-exceeded`, but
+///   the link is **not** detached: only the oversized delivery is discarded
+///   and the receiver can be used to receive subsequent messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageSizeExceeded {
+    /// Size of the encoded message in bytes
+    pub size: u64,
+    /// The maximum message size of the link in bytes
+    pub max_size: u64,
+}
+
+impl std::fmt::Display for MessageSizeExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "message size exceeds max of {}", self.max_size)
+    }
+}
+
+impl std::error::Error for MessageSizeExceeded {}
+
 /// Error associated with sending a message
 #[derive(Debug, thiserror::Error)]
 pub enum SendError {
@@ -163,6 +197,11 @@ pub enum SendError {
     #[error("Transactional state found on non-transactional delivery")]
     IllegalDeliveryState,
 
+    /// The encoded message is larger than the maximum message size
+    /// negotiated on the link
+    #[error(transparent)]
+    MessageSizeExceeded(MessageSizeExceeded),
+
     /// Error serializing message
     #[error("Error encoding message")]
     MessageEncodeError,
@@ -171,6 +210,12 @@ pub enum SendError {
 impl From<serde_amqp::Error> for SendError {
     fn from(_: serde_amqp::Error) -> Self {
         Self::MessageEncodeError
+    }
+}
+
+impl From<MessageSizeExceeded> for SendError {
+    fn from(error: MessageSizeExceeded) -> Self {
+        Self::MessageSizeExceeded(error)
     }
 }
 
@@ -535,6 +580,16 @@ pub enum RecvError {
     /// Field is inconsisten in multi-frame delivery
     #[error("Field is inconsisten in multi-frame delivery")]
     InconsistentFieldInMultiFrameDelivery,
+
+    /// A delivery larger than the negotiated `max_message_size` of the link
+    /// was rejected with the `amqp:link:message-size-exceeded` error
+    /// condition.
+    ///
+    /// The rejection is delivery-scoped: the link is **not** detached and
+    /// remains usable, so subsequent [`Receiver::recv`](crate::Receiver::recv)
+    /// calls continue to receive normally.
+    #[error(transparent)]
+    MessageSizeExceeded(MessageSizeExceeded),
 
     /// Transactional acquision is not supported yet
     #[error("Transactional acquisition is not implemented")]

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -606,11 +606,12 @@ impl LinkRelay<OutputHandle> {
     pub(crate) async fn send(
         &mut self,
         frame: LinkFrame,
-    ) -> Result<(), mpsc::error::SendError<LinkFrame>> {
+    ) -> Result<(), Box<mpsc::error::SendError<LinkFrame>>> {
         match self {
             LinkRelay::Sender { tx, .. } => tx.send(frame).await,
             LinkRelay::Receiver { tx, .. } => tx.send(frame).await,
         }
+        .map_err(Box::new)
     }
 
     #[allow(unused_variables)]
@@ -804,13 +805,13 @@ impl LinkRelay<OutputHandle> {
     pub async fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> Result<(), mpsc::error::SendError<LinkFrame>> {
+    ) -> Result<(), Box<mpsc::error::SendError<LinkFrame>>> {
         match self {
             LinkRelay::Sender { tx, .. } => {
-                tx.send(LinkFrame::Detach(detach)).await?;
+                tx.send(LinkFrame::Detach(detach)).await.map_err(Box::new)?;
             }
             LinkRelay::Receiver { tx, .. } => {
-                tx.send(LinkFrame::Detach(detach)).await?;
+                tx.send(LinkFrame::Detach(detach)).await.map_err(Box::new)?;
             }
         }
         Ok(())

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -2,7 +2,6 @@
 
 use std::{marker::PhantomData, sync::Arc, sync::OnceLock};
 
-use bytes::{BufMut, BytesMut};
 use fe2o3_amqp_types::{
     definitions::{
         self, DeliveryNumber, DeliveryTag, MessageFormat, ReceiverSettleMode, Role,
@@ -18,8 +17,7 @@ pub use error::*;
 use parking_lot::RwLock;
 pub use receiver::{CreditMode, Receiver, ReceiverDisposer};
 pub use sender::Sender;
-use serde::Serialize;
-use serde_amqp::ser::Serializer;
+use serde_amqp::serialized_size;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
@@ -212,6 +210,11 @@ pub(crate) struct Link<R, T, F, M> {
     /// Why the session (or its connection) stopped, shared from the session
     pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
 
+    /// The negotiated max frame size (encoder max frame length), shared from
+    /// the session and the connection; used to split transfers and attach
+    /// frames that must fit within the frame size
+    pub(crate) max_frame_size: usize,
+
     pub(crate) verify_incoming_source: bool,
     pub(crate) verify_incoming_target: bool,
 }
@@ -305,23 +308,16 @@ where
         is_reattaching: bool,
     ) -> Result<Attach, SendAttachErrorKind> {
         let mut denominator = 1usize; // This is going to be the denominator
-        let mut buf = BytesMut::new();
 
         let mut attach = self.as_attach_inner(handle.clone(), is_reattaching, denominator);
-        let mut serializer = Serializer::from((&mut buf).writer());
-        attach
-            .serialize(&mut serializer)
-            .map_err(|_| SendAttachErrorKind::IllegalState)?; // This should not happen
-
-        while buf.len() > max_frame_size {
-            buf.clear();
+        // `SizeSerializer` computes the serialized size without allocating a
+        // buffer; only the size is needed here.
+        while serialized_size(&attach).map_err(|_| SendAttachErrorKind::IllegalState)? // This should not happen
+            > max_frame_size
+        {
             denominator *= 2;
 
             attach = self.as_attach_inner(handle.clone(), is_reattaching, denominator);
-            let mut serializer = Serializer::from((&mut buf).writer());
-            attach
-                .serialize(&mut serializer)
-                .map_err(|_| SendAttachErrorKind::IllegalState)?; // This should not happen
         }
 
         Ok(attach)
@@ -329,11 +325,11 @@ where
 
     /// # Cancel safety
     ///
-    /// This is cancel safe if oneshot channel is cancel safe
+    /// This is cancel safe: the only `.await` is on sending over
+    /// `tokio::mpsc::Sender`, which is cancel safe.
     pub(crate) async fn send_attach_inner(
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<(), SendAttachErrorKind> {
         // Create Attach frame
@@ -358,8 +354,11 @@ where
         let attach = match unsettled_map_len {
             Some(0) | None => self.as_complete_attach(handle, is_reattaching),
             Some(_) => {
-                let max_frame_size = get_max_frame_size(session, &self.session_stop_reason).await?; // FIXME: cancel safe?
-                self.as_maybe_incomplete_attach(max_frame_size, handle, is_reattaching)?
+                // The connection engine publishes the negotiated encoder max
+                // frame size before the connection handle is created; links
+                // are only attached after the connection is opened, so the
+                // value is always populated.
+                self.as_maybe_incomplete_attach(self.max_frame_size, handle, is_reattaching)?
             }
         };
         let incomplete_unsettled = attach.incomplete_unsettled;
@@ -397,28 +396,6 @@ where
 
         Ok(())
     }
-}
-
-/// # Cancel safety
-///
-/// This should cancel safe if oneshot channel is cancel safe
-pub(crate) async fn get_max_frame_size(
-    control: &mpsc::Sender<SessionControl>,
-    session_stop_reason: &OnceLock<SessionStopReason>,
-) -> Result<usize, SendAttachErrorKind> {
-    let (tx, rx) = oneshot::channel();
-    control
-        .send(SessionControl::GetMaxFrameSize(tx))
-        .await // cancel safe
-        .map_err(|_| match session_stop_reason.get() {
-            Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
-            None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
-        })?;
-    rx.await // FIXME: is oneshot channel cancel safe?
-        .map_err(|_| match session_stop_reason.get() {
-            Some(reason) => SendAttachErrorKind::SessionStopped(reason.clone()),
-            None => SendAttachErrorKind::IllegalState, // defensive: no stop reason recorded; failure is link-local
-        })
 }
 
 impl<R, T, F, M> endpoint::LinkDetach for Link<R, T, F, M>

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -360,8 +360,8 @@ impl Receiver {
     /// re-attach and then close by exchanging closing Detach performatives.
     pub async fn detach(mut self) -> Result<DetachedReceiver, (DetachedReceiver, DetachError)> {
         match self.inner.detach_with_error(None).await {
-            Ok(_) => Ok(DetachedReceiver { inner: self.inner }),
-            Err(err) => Err((DetachedReceiver { inner: self.inner }, err)),
+            Ok(_) => Ok(DetachedReceiver { inner: Box::new(self.inner) }),
+            Err(err) => Err((DetachedReceiver { inner: Box::new(self.inner) }, err)),
         }
     }
 
@@ -375,8 +375,8 @@ impl Receiver {
         error: impl Into<definitions::Error>,
     ) -> Result<DetachedReceiver, (DetachedReceiver, DetachError)> {
         match self.inner.detach_with_error(Some(error.into())).await {
-            Ok(_) => Ok(DetachedReceiver { inner: self.inner }),
-            Err(err) => Err((DetachedReceiver { inner: self.inner }, err)),
+            Ok(_) => Ok(DetachedReceiver { inner: Box::new(self.inner) }),
+            Err(err) => Err((DetachedReceiver { inner: Box::new(self.inner) }, err)),
         }
     }
 
@@ -1512,7 +1512,7 @@ impl ReceiverInner<ReceiverLink<Target>> {
 /// ```
 #[derive(Debug)]
 pub struct DetachedReceiver {
-    inner: ReceiverInner<ReceiverLink<Target>>,
+    inner: Box<ReceiverInner<ReceiverLink<Target>>>,
 }
 
 macro_rules! try_as_recver {
@@ -1647,7 +1647,7 @@ impl DetachedReceiver {
                 .resume_incoming_attach(None, is_reattaching)
                 .await
         );
-        let receiver = Receiver { inner: self.inner };
+        let receiver = Receiver { inner: *self.inner };
         let resuming_receiver = match exchange {
             ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
             ReceiverAttachExchange::IncompleteUnsettled => {
@@ -1677,7 +1677,7 @@ impl DetachedReceiver {
 
             match tokio::time::timeout(duration, fut).await {
                 Ok(Ok(exchange)) => {
-                    let receiver = Receiver { inner: self.inner };
+                    let receiver = Receiver { inner: *self.inner };
                     let resuming_receiver = match exchange {
                         ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
                         ReceiverAttachExchange::IncompleteUnsettled => {
@@ -1743,7 +1743,7 @@ impl DetachedReceiver {
                 .resume_incoming_attach(Some(remote_attach), false)
                 .await
         );
-        let receiver = Receiver { inner: self.inner };
+        let receiver = Receiver { inner: *self.inner };
         let resuming_receiver = match exchange {
             ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
             ReceiverAttachExchange::IncompleteUnsettled => {
@@ -1771,7 +1771,7 @@ impl DetachedReceiver {
                 .resume_incoming_attach(Some(remote_attach), is_reattaching)
                 .await
         );
-        let receiver = Receiver { inner: self.inner };
+        let receiver = Receiver { inner: *self.inner };
         let resuming_receiver = match exchange {
             ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
             ReceiverAttachExchange::IncompleteUnsettled => {
@@ -1809,7 +1809,7 @@ impl DetachedReceiver {
 
             match tokio::time::timeout(duration, fut).await {
                 Ok(Ok(exchange)) => {
-                    let receiver = Receiver { inner: self.inner };
+                    let receiver = Receiver { inner: *self.inner };
                     let resuming_receiver = match exchange {
                         ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
                         ReceiverAttachExchange::IncompleteUnsettled => {
@@ -1849,7 +1849,7 @@ impl DetachedReceiver {
 
             match tokio::time::timeout(duration, fut).await {
                 Ok(Ok(exchange)) => {
-                    let receiver = Receiver { inner: self.inner };
+                    let receiver = Receiver { inner: *self.inner };
                     let resuming_receiver = match exchange {
                         ReceiverAttachExchange::Complete => ResumingReceiver::Complete(receiver),
                         ReceiverAttachExchange::IncompleteUnsettled => {

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -4,11 +4,12 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{
-    definitions::{self, DeliveryTag, Fields, Handle, ReceiverSettleMode, Role, SequenceNo},
+    definitions::{self, DeliveryTag, Fields, Handle, LinkError, ReceiverSettleMode, Role, SequenceNo},
     messaging::{
         Accepted, Address, DeliveryState, FromBody, Modified, Rejected, Released, Source, Target,
     },
     performatives::{Attach, Detach, Disposition, Transfer},
+    primitives::OrderedMap,
 };
 use tokio::sync::mpsc;
 
@@ -21,6 +22,7 @@ use crate::{
     control::SessionControl,
     endpoint::{self, LinkAttach, LinkDetach, LinkExt, LinkFlow, OutputHandle},
     session::SessionHandle,
+    util::Sealed,
     Payload,
 };
 
@@ -33,9 +35,10 @@ use super::{
     role,
     shared_inner::{LinkEndpointInner, LinkEndpointInnerDetach, LinkEndpointInnerReattach},
     ArcReceiverUnsettledMap, DetachThenResumeReceiverError, DispositionError, FlowError,
-    IllegalLinkStateError, LinkFrame, LinkRelay, LinkStateError, ReceiverAttachError,
-    ReceiverAttachExchange, ReceiverFlowState, ReceiverLink, ReceiverResumeError,
-    ReceiverResumeErrorKind, ReceiverTransferError, RecvError, SessionStopReason, DEFAULT_CREDIT,
+    IllegalLinkStateError, LinkFrame, LinkRelay, LinkStateError, MessageSizeExceeded,
+    ReceiverAttachError, ReceiverAttachExchange, ReceiverFlowState, ReceiverLink,
+    ReceiverResumeError, ReceiverResumeErrorKind, ReceiverTransferError, RecvError,
+    SessionStopReason, DEFAULT_CREDIT,
 };
 
 cfg_transaction! {
@@ -132,6 +135,11 @@ impl Receiver {
 
     /// Returns the `max_message_size` of the link. A value of zero indicates that the link has no
     /// maximum message size, and thus a zero value is turned into a `None`
+    ///
+    /// When this value is set, deliveries larger than it are rejected on
+    /// receive with `amqp:link:message-size-exceeded` and [`recv`](#method.recv)
+    /// returns [`RecvError::MessageSizeExceeded`]; the link itself is not
+    /// detached.
     pub fn max_message_size(&self) -> Option<u64> {
         self.inner.link.max_message_size()
     }
@@ -303,6 +311,17 @@ impl Receiver {
     /// receiver.accept(&delivery).await.unwrap();
     /// ```
     ///
+    /// # Message size
+    ///
+    /// When the link advertises a `max_message_size` (see
+    /// [`max_message_size`](#method.max_message_size)) and the peer sends a
+    /// delivery larger than it, the receiver rejects the delivery with a
+    /// `Rejected` disposition carrying `amqp:link:message-size-exceeded` and
+    /// this method returns [`RecvError::MessageSizeExceeded`]. The rejection
+    /// is delivery-scoped: **the link is not detached** — only the oversized
+    /// delivery is discarded, and subsequent calls to this method continue to
+    /// receive normally.
+    ///
     /// # Cancel safety
     ///
     /// This function is cancel-safe. See [#22](https://github.com/minghuaw/fe2o3-amqp/issues/22)
@@ -388,11 +407,8 @@ impl Receiver {
             .await
             .map_err(DetachThenResumeReceiverError::from);
 
-        let is_reattaching = !self.inner.session.same_channel(&new_session.control);
-
         // re-attach the link
-        self.inner.session = new_session.control.clone();
-        self.inner.outgoing = new_session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(new_session);
         let exchange_result = self
             .inner
             .resume_incoming_attach(None, is_reattaching)
@@ -883,12 +899,7 @@ where
         is_reattaching: bool,
     ) -> Result<ReceiverAttachExchange, <Self::Link as LinkAttach>::AttachError> {
         self.link
-            .exchange_attach(
-                &self.outgoing,
-                &mut self.incoming,
-                &self.session,
-                is_reattaching,
-            )
+            .exchange_attach(&self.outgoing, &mut self.incoming, is_reattaching)
             .await
     }
 
@@ -956,8 +967,8 @@ where
         for<'de> T: FromBody<'de> + Send,
     {
         loop {
-            match self.recv_inner().await? // FIXME: cancel safe? if oneshot channel is cancel safe
-            {
+            match self.recv_inner().await? {
+
                 Some(delivery) => return Ok(delivery),
                 None => continue, // Incomplete transfer, there are more transfer frames coming
             }
@@ -966,7 +977,8 @@ where
 
     /// # Cancel safety
     ///
-    /// This should be cancel safe if oneshot channel is cancel safe
+    /// This is cancel safe because all internal `.await` point(s) are cancel
+    /// safe (`tokio::sync::mpsc` operations and synchronous processing)
     #[inline]
     pub(crate) async fn recv_inner<T>(&mut self) -> Result<Option<Delivery<T>>, RecvError>
     where
@@ -1134,6 +1146,111 @@ where
         }
     }
 
+    /// The bytes of the delivery accumulated so far that belong to the same
+    /// delivery as `transfer` (i.e. the buffered chunks of the incomplete
+    /// multi-frame delivery, when the transfer is a continuation of it).
+    fn accumulated_message_size(&self, transfer: &Transfer) -> u64 {
+        match &self.incomplete_transfer {
+            Some(incomplete) if incomplete.performative.delivery_tag == transfer.delivery_tag => {
+                incomplete
+                    .buffer
+                    .iter()
+                    .map(|p| p.len() as u64)
+                    .sum::<u64>()
+            }
+            _ => 0,
+        }
+    }
+
+    /// Reject a delivery that exceeds the negotiated max-message-size of the
+    /// link with the `amqp:link:message-size-exceeded` error condition and
+    /// discard the buffered chunks, so the oversized message is neither
+    /// buffered further nor surfaced to the application.
+    ///
+    /// If the sender pre-settled the delivery there is nothing to reply with;
+    /// otherwise a terminal `Rejected` disposition is sent. The
+    /// [`RecvError::MessageSizeExceeded`] error is returned in both cases so
+    /// `recv()` observes the rejected delivery; the link itself is not
+    /// detached and remains usable.
+    async fn reject_oversized_message<T>(
+        &mut self,
+        transfer: Transfer,
+        total_size: u64,
+        max_size: u64,
+    ) -> Result<Option<Delivery<T>>, RecvError>
+    where
+        for<'de> T: FromBody<'de> + Send,
+    {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            "Rejected delivery of {total_size} bytes: exceeds the link's max message size of {max_size}"
+        );
+        #[cfg(feature = "log")]
+        log::warn!(
+            "Rejected delivery of {total_size} bytes: exceeds the link's max message size of {max_size}"
+        );
+
+        let delivery_id = transfer.delivery_id.or_else(|| {
+            self.incomplete_transfer
+                .as_ref()
+                .and_then(|i| i.performative.delivery_id)
+        });
+        let delivery_tag = transfer
+            .delivery_tag
+            .clone()
+            .or_else(|| {
+                self.incomplete_transfer
+                    .as_ref()
+                    .and_then(|i| i.performative.delivery_tag.clone())
+            });
+
+        // Discard the buffered chunks of the oversized delivery
+        self.incomplete_transfer.take();
+
+        // If the sender pre-settled the delivery, there is nothing to reply with
+        if !transfer.settled.unwrap_or(false) {
+            if let (Some(delivery_id), Some(delivery_tag)) = (delivery_id, delivery_tag) {
+                let error = definitions::Error::new(LinkError::MessageSizeExceeded, None, None);
+                let state = DeliveryState::Rejected(Rejected {
+                    error: Some(error),
+                });
+                let info = DeliveryInfo {
+                    delivery_id,
+                    delivery_tag,
+                    rcv_settle_mode: None,
+                    _sealed: Sealed {},
+                };
+                // Track the delivery: `link.dispose` only sends the disposition when
+                // the delivery is in the unsettled map. First/single frames aren't
+                // tracked yet: the entry is only inserted by
+                // `ReceiverLink::on_incomplete_transfer` (first partial frame of a
+                // multi-frame delivery) or `ReceiverLink::on_complete_transfer` (final
+                // assembly), and this size check runs before either of those.
+                {
+                    let mut lock = self.link.unsettled().write();
+                    lock.get_or_insert(OrderedMap::new())
+                        .insert(info.delivery_tag.clone(), Some(state.clone()));
+                }
+                self.dispose(info, Some(true), state).await?;
+            } else {
+                // The frame could not be identified (missing delivery-id and
+                // delivery-tag), so no disposition can be sent. This should not
+                // happen with a well-behaved peer.
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "Cannot send rejection disposition: missing delivery-id or delivery-tag"
+                );
+                #[cfg(feature = "log")]
+                log::warn!("Cannot send rejection disposition: missing delivery-id or delivery-tag");
+            }
+        }
+
+        Err(RecvError::MessageSizeExceeded(MessageSizeExceeded {
+            size: total_size,
+            max_size,
+        }))
+    }
+
     /// # Cancel safety
     ///
     /// This is cancel safe because all internal `.await` point(s) are cancel safe
@@ -1145,6 +1262,15 @@ where
     where
         for<'de> T: FromBody<'de> + Send,
     {
+        // Enforce the negotiated max-message-size of the link before
+        // assembling the delivery
+        if let Some(max_size) = self.link.max_message_size() {
+            let total = self.accumulated_message_size(&transfer) + payload.len() as u64;
+            if total > max_size {
+                return self.reject_oversized_message(transfer, total, max_size).await;
+            }
+        }
+
         let delivery = match self.incomplete_transfer.take() {
             Some(mut incomplete) => {
                 incomplete.or_assign(transfer)?;
@@ -1206,6 +1332,18 @@ where
         }
 
         if transfer.more {
+            // Enforce the negotiated max-message-size of the link: reject the
+            // delivery with the `amqp:link:message-size-exceeded` error
+            // condition once the accumulated message size would exceed it,
+            // discarding the buffered chunks instead of buffering the
+            // oversized message.
+            if let Some(max_size) = self.link.max_message_size() {
+                let total = self.accumulated_message_size(&transfer) + payload.len() as u64;
+                if total > max_size {
+                    return self.reject_oversized_message(transfer, total, max_size).await;
+                }
+            }
+
             // Partial transfer of the delivery
             // There is only ONE incomplet transfer locally, so the partial transfer must belong to the
             // same delivery
@@ -1317,6 +1455,21 @@ where
 }
 
 impl ReceiverInner<ReceiverLink<Target>> {
+    /// Switch the link to a new session, returning whether the link is being
+    /// reattached (i.e. the new session is a different session from the
+    /// current one).
+    ///
+    /// The new session may belong to a different connection whose negotiated
+    /// max frame size differs, so the link's `max_frame_size` is refreshed
+    /// from the new session before any attach/transfer frame is sent.
+    pub(crate) fn switch_session<R>(&mut self, new_session: &SessionHandle<R>) -> bool {
+        let is_reattaching = !self.session.same_channel(&new_session.control);
+        self.session = new_session.control.clone();
+        self.outgoing = new_session.outgoing.clone();
+        self.link.max_frame_size = new_session.max_frame_size();
+        is_reattaching
+    }
+
     pub(crate) async fn resume_incoming_attach(
         &mut self,
         mut initial_remote_attach: Option<Attach>,
@@ -1327,7 +1480,7 @@ impl ReceiverInner<ReceiverLink<Target>> {
         let exchange = match initial_remote_attach.take() {
             Some(remote_attach) => {
                 self.link
-                    .send_attach(&self.outgoing, &self.session, is_reattaching)
+                    .send_attach(&self.outgoing, is_reattaching)
                     .await?;
                 self.link.on_incoming_attach(remote_attach)?
             }
@@ -1569,10 +1722,7 @@ impl DetachedReceiver {
         mut self,
         session: &SessionHandle<R>,
     ) -> Result<ResumingReceiver, ReceiverResumeError> {
-        let is_reattaching = !self.inner.session.same_channel(&session.control);
-
-        self.inner.session = session.control.clone();
-        self.inner.outgoing = session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(session);
 
         self.resume_inner(is_reattaching).await
     }
@@ -1611,10 +1761,7 @@ impl DetachedReceiver {
         remote_attach: Attach,
         session: &SessionHandle<R>,
     ) -> Result<ResumingReceiver, ReceiverResumeError> {
-        let is_reattaching = !self.inner.session.same_channel(&session.control);
-
-        self.inner.session = session.control.clone();
-        self.inner.outgoing = session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(session);
 
         let exchange = try_as_recver!(
             self,
@@ -1643,9 +1790,7 @@ impl DetachedReceiver {
             session: &SessionHandle<R>,
             duration: Duration,
         ) -> Result<ResumingReceiver, ReceiverResumeError> {
-            let is_reattaching = !self.inner.session.same_channel(&session.control);
-            self.inner.session = session.control.clone();
-            self.inner.outgoing = session.outgoing.clone();
+            let is_reattaching = self.inner.switch_session(session);
             self.resume_with_timeout_inner(duration, is_reattaching).await
         }
 
@@ -1696,10 +1841,7 @@ impl DetachedReceiver {
             session: &SessionHandle<R>,
             duration: Duration,
         ) -> Result<ResumingReceiver, ReceiverResumeError> {
-            let is_reattaching = !self.inner.session.same_channel(&session.control);
-
-            self.inner.session = session.control.clone();
-            self.inner.outgoing = session.outgoing.clone();
+            let is_reattaching = self.inner.switch_session(session);
 
             let fut = self.inner.resume_incoming_attach(Some(remote_attach), is_reattaching);
 
@@ -1735,8 +1877,10 @@ impl DetachedReceiver {
 mod tests {
     use super::*;
     use crate::endpoint::OutputHandle;
-    use crate::link::state::{LinkFlowState, LinkFlowStateInner};
+    use crate::link::state::{LinkFlowState, LinkFlowStateInner, LinkState};
     use crate::util::Sealed;
+    use fe2o3_amqp_types::definitions::SenderSettleMode;
+    use tokio::sync::oneshot;
 
     fn make_flow_state(link_credit: u32) -> ReceiverFlowState {
         Arc::new(LinkFlowState::receiver(LinkFlowStateInner {
@@ -1977,5 +2121,78 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 100);
+    }
+
+    fn make_receiver_inner(max_frame_size: usize) -> ReceiverInner<ReceiverLink<Target>> {
+        let (session_tx, _session_rx) = mpsc::channel::<SessionControl>(16);
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel::<LinkFrame>(16);
+        let (incoming_tx, incoming_rx) = mpsc::channel::<LinkFrame>(16);
+        let _ = incoming_tx; // the link relay side is not needed by the test
+        let unsettled: ArcReceiverUnsettledMap = Arc::new(parking_lot::RwLock::new(None));
+        let link = ReceiverLink::<Target> {
+            role: std::marker::PhantomData,
+            local_state: LinkState::Attached,
+            name: String::from("test-receiver"),
+            output_handle: None,
+            input_handle: None,
+            snd_settle_mode: SenderSettleMode::Mixed,
+            rcv_settle_mode: ReceiverSettleMode::First,
+            source: None,
+            target: None,
+            max_message_size: 0,
+            offered_capabilities: None,
+            desired_capabilities: None,
+            flow_state: make_flow_state(200),
+            unsettled,
+            session_stop_reason: Arc::new(OnceLock::new()),
+            max_frame_size,
+            verify_incoming_source: true,
+            verify_incoming_target: true,
+        };
+        ReceiverInner {
+            link,
+            buffer_size: 16,
+            credit_mode: CreditMode::Auto(200),
+            processed: Arc::new(AtomicU32::new(0)),
+            auto_accept: false,
+            session: session_tx,
+            outgoing: outgoing_tx,
+            incoming: incoming_rx,
+            incomplete_transfer: None,
+        }
+    }
+
+    fn make_session_handle(max_frame_size: usize) -> SessionHandle<()> {
+        let (control, _control_rx) = mpsc::channel::<SessionControl>(16);
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel::<LinkFrame>(16);
+        let (outcome_tx, outcome) = oneshot::channel::<Result<(), crate::session::error::Error>>();
+        drop(outcome_tx);
+        SessionHandle {
+            is_ended: false,
+            control,
+            engine_handle: tokio::spawn(async {}),
+            outcome,
+            outgoing: outgoing_tx,
+            session_stop_reason: Arc::new(OnceLock::new()),
+            max_frame_size,
+            link_listener: (),
+        }
+    }
+
+    #[tokio::test]
+    async fn switch_session_refreshes_max_frame_size() {
+        let mut inner = make_receiver_inner(4092);
+        let session_b = make_session_handle(1020);
+
+        // Switching to a different session marks the link as reattaching and
+        // refreshes the link's max frame size from the new session
+        let is_reattaching = inner.switch_session(&session_b);
+        assert!(is_reattaching);
+        assert_eq!(inner.link.max_frame_size, 1020);
+
+        // Switching to the same session does not mark the link as reattaching
+        let is_reattaching = inner.switch_session(&session_b);
+        assert!(!is_reattaching);
+        assert_eq!(inner.link.max_frame_size, 1020);
     }
 }

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -360,8 +360,15 @@ impl Receiver {
     /// re-attach and then close by exchanging closing Detach performatives.
     pub async fn detach(mut self) -> Result<DetachedReceiver, (DetachedReceiver, DetachError)> {
         match self.inner.detach_with_error(None).await {
-            Ok(_) => Ok(DetachedReceiver { inner: Box::new(self.inner) }),
-            Err(err) => Err((DetachedReceiver { inner: Box::new(self.inner) }, err)),
+            Ok(_) => Ok(DetachedReceiver {
+                inner: Box::new(self.inner),
+            }),
+            Err(err) => Err((
+                DetachedReceiver {
+                    inner: Box::new(self.inner),
+                },
+                err,
+            )),
         }
     }
 
@@ -375,8 +382,15 @@ impl Receiver {
         error: impl Into<definitions::Error>,
     ) -> Result<DetachedReceiver, (DetachedReceiver, DetachError)> {
         match self.inner.detach_with_error(Some(error.into())).await {
-            Ok(_) => Ok(DetachedReceiver { inner: Box::new(self.inner) }),
-            Err(err) => Err((DetachedReceiver { inner: Box::new(self.inner) }, err)),
+            Ok(_) => Ok(DetachedReceiver {
+                inner: Box::new(self.inner),
+            }),
+            Err(err) => Err((
+                DetachedReceiver {
+                    inner: Box::new(self.inner),
+                },
+                err,
+            )),
         }
     }
 

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -4,7 +4,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{
-    definitions::{self, DeliveryTag, Fields, Handle, LinkError, ReceiverSettleMode, Role, SequenceNo},
+    definitions::{
+        self, DeliveryTag, Fields, Handle, LinkError, ReceiverSettleMode, Role, SequenceNo,
+    },
     messaging::{
         Accepted, Address, DeliveryState, FromBody, Modified, Rejected, Released, Source, Target,
     },
@@ -968,7 +970,6 @@ where
     {
         loop {
             match self.recv_inner().await? {
-
                 Some(delivery) => return Ok(delivery),
                 None => continue, // Incomplete transfer, there are more transfer frames coming
             }
@@ -1195,14 +1196,11 @@ where
                 .as_ref()
                 .and_then(|i| i.performative.delivery_id)
         });
-        let delivery_tag = transfer
-            .delivery_tag
-            .clone()
-            .or_else(|| {
-                self.incomplete_transfer
-                    .as_ref()
-                    .and_then(|i| i.performative.delivery_tag.clone())
-            });
+        let delivery_tag = transfer.delivery_tag.clone().or_else(|| {
+            self.incomplete_transfer
+                .as_ref()
+                .and_then(|i| i.performative.delivery_tag.clone())
+        });
 
         // Discard the buffered chunks of the oversized delivery
         self.incomplete_transfer.take();
@@ -1211,9 +1209,7 @@ where
         if !transfer.settled.unwrap_or(false) {
             if let (Some(delivery_id), Some(delivery_tag)) = (delivery_id, delivery_tag) {
                 let error = definitions::Error::new(LinkError::MessageSizeExceeded, None, None);
-                let state = DeliveryState::Rejected(Rejected {
-                    error: Some(error),
-                });
+                let state = DeliveryState::Rejected(Rejected { error: Some(error) });
                 let info = DeliveryInfo {
                     delivery_id,
                     delivery_tag,
@@ -1241,7 +1237,9 @@ where
                     "Cannot send rejection disposition: missing delivery-id or delivery-tag"
                 );
                 #[cfg(feature = "log")]
-                log::warn!("Cannot send rejection disposition: missing delivery-id or delivery-tag");
+                log::warn!(
+                    "Cannot send rejection disposition: missing delivery-id or delivery-tag"
+                );
             }
         }
 
@@ -1267,7 +1265,9 @@ where
         if let Some(max_size) = self.link.max_message_size() {
             let total = self.accumulated_message_size(&transfer) + payload.len() as u64;
             if total > max_size {
-                return self.reject_oversized_message(transfer, total, max_size).await;
+                return self
+                    .reject_oversized_message(transfer, total, max_size)
+                    .await;
             }
         }
 
@@ -1340,7 +1340,9 @@ where
             if let Some(max_size) = self.link.max_message_size() {
                 let total = self.accumulated_message_size(&transfer) + payload.len() as u64;
                 if total > max_size {
-                    return self.reject_oversized_message(transfer, total, max_size).await;
+                    return self
+                        .reject_oversized_message(transfer, total, max_size)
+                        .await;
                 }
             }
 

--- a/fe2o3-amqp/src/link/receiver_link.rs
+++ b/fe2o3-amqp/src/link/receiver_link.rs
@@ -747,15 +747,15 @@ where
 
     /// # Cancel safety
     ///
-    /// This is cancel safe if oneshot channel is cancel safe
+    /// This is cancel safe: it only awaits on sending over `tokio::mpsc::Sender`
+    /// (see `send_attach_inner`) and on `tokio::sync::mpsc::Receiver::recv`,
+    /// both of which are cancel safe.
     async fn send_attach(
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<(), Self::AttachError> {
-        self.send_attach_inner(writer, session, is_reattaching)
-            .await?; // FIXME: cancel safe? if oneshot channel is cancel safe
+        self.send_attach_inner(writer, is_reattaching).await?;
         Ok(())
     }
 }
@@ -836,16 +836,16 @@ where
 
     /// # Cancel safety
     ///
-    /// This should be cancel safe if oneshot channel is cancel safe
+    /// This is cancel safe: it only awaits on sending over `tokio::mpsc::Sender`
+    /// and on `tokio::sync::mpsc::Receiver::recv`, both of which are cancel safe.
     async fn exchange_attach(
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
         reader: &mut mpsc::Receiver<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<Self::AttachExchange, ReceiverAttachError> {
         // Send out local attach
-        self.send_attach(writer, session, is_reattaching).await?; // FIXME: cancel safe? if oneshot channel is cancel safe
+        self.send_attach(writer, is_reattaching).await?;
 
         // Wait for remote attach
         let remote_attach = match reader

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -1078,7 +1078,9 @@ macro_rules! try_as_sender {
 
 impl DetachedSender {
     fn new(inner: SenderInner<SenderLink<Target>>) -> Self {
-        Self { inner: Box::new(inner) }
+        Self {
+            inner: Box::new(inner),
+        }
     }
 
     /// Get a reference to the link's source field

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -37,8 +37,8 @@ use super::{
         recv_remote_detach, LinkEndpointInner, LinkEndpointInnerDetach, LinkEndpointInnerReattach,
     },
     ArcSenderUnsettledMap, DetachThenResumeSenderError, LinkFrame, LinkRelay, LinkStateError,
-    SendError, SenderAttachError, SenderAttachExchange, SenderFlowState, SenderLink,
-    SenderResumeError, SenderResumeErrorKind, SessionStopReason,
+    MessageSizeExceeded, SendError, SenderAttachError, SenderAttachExchange, SenderFlowState,
+    SenderLink, SenderResumeError, SenderResumeErrorKind, SessionStopReason,
 };
 
 #[cfg(docsrs)]
@@ -255,11 +255,8 @@ impl Sender {
         // Detach the link
         let detach_result = self.inner.detach_with_error(None).await;
 
-        let is_reattaching = !self.inner.session.same_channel(&new_session.control);
-
         // Re-attach the link
-        self.inner.session = new_session.control.clone();
-        self.inner.outgoing = new_session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(new_session);
         let attach_result = self
             .inner
             .resume_incoming_attach(None, is_reattaching)
@@ -587,12 +584,7 @@ where
         is_reattaching: bool,
     ) -> Result<SenderAttachExchange, <Self::Link as LinkAttach>::AttachError> {
         self.link
-            .exchange_attach(
-                &self.outgoing,
-                &mut self.incoming,
-                &self.session,
-                is_reattaching,
-            )
+            .exchange_attach(&self.outgoing, &mut self.incoming, is_reattaching)
             .await
     }
 
@@ -659,7 +651,7 @@ where
     ) -> Result<Settlement, E>
     where
         T: SerializableBody,
-        E: From<L::TransferError> + From<serde_amqp::Error>,
+        E: From<L::TransferError> + From<serde_amqp::Error> + From<MessageSizeExceeded>,
     {
         use bytes::BufMut;
         use serde::Serialize;
@@ -689,7 +681,7 @@ where
     ) -> Result<Settlement, E>
     where
         T: SerializableBody,
-        E: From<L::TransferError> + From<serde_amqp::Error>,
+        E: From<L::TransferError> + From<serde_amqp::Error> + From<MessageSizeExceeded>,
     {
         use bytes::BufMut;
         use serde::Serialize;
@@ -720,8 +712,19 @@ where
         batchable: bool,
     ) -> Result<Settlement, E>
     where
-        E: From<L::TransferError> + From<serde_amqp::Error>,
+        E: From<L::TransferError> + From<serde_amqp::Error> + From<MessageSizeExceeded>,
     {
+        // Reject the message locally before any transfer frame is sent when it
+        // exceeds the negotiated max-message-size of the link. The payload is
+        // the already-encoded message, so its length is the encoded message
+        // size. A max-message-size of zero means no limit is imposed.
+        if let Some(max_size) = self.link.max_message_size() {
+            let size = payload.len() as u64;
+            if size > max_size {
+                return Err(E::from(MessageSizeExceeded { size, max_size }));
+            }
+        }
+
         // send a transfer, checking state will be implemented in SenderLink
         let detached_fut = self.incoming.recv(); // cancel safe
         let settlement = self
@@ -741,6 +744,21 @@ where
 }
 
 impl SenderInner<SenderLink<Target>> {
+    /// Switch the link to a new session, returning whether the link is being
+    /// reattached (i.e. the new session is a different session from the
+    /// current one).
+    ///
+    /// The new session may belong to a different connection whose negotiated
+    /// max frame size differs, so the link's `max_frame_size` is refreshed
+    /// from the new session before any attach/transfer frame is sent.
+    pub(crate) fn switch_session<R>(&mut self, new_session: &SessionHandle<R>) -> bool {
+        let is_reattaching = !self.session.same_channel(&new_session.control);
+        self.session = new_session.control.clone();
+        self.outgoing = new_session.outgoing.clone();
+        self.link.max_frame_size = new_session.max_frame_size();
+        is_reattaching
+    }
+
     /// Resumes a delivery with the given state and payload.
     ///
     /// The resume operation should not replace the unsettled map entry.
@@ -991,7 +1009,7 @@ impl SenderInner<SenderLink<Target>> {
             let attach_exchange = match initial_remote_attach.take() {
                 Some(remote_attach) => {
                     self.link
-                        .send_attach(&self.outgoing, &self.session, is_reattaching)
+                        .send_attach(&self.outgoing, is_reattaching)
                         .await?;
                     self.link.on_incoming_attach(remote_attach)?
                 }
@@ -1184,9 +1202,7 @@ impl DetachedSender {
         mut self,
         session: &SessionHandle<R>,
     ) -> Result<Sender, SenderResumeError> {
-        let is_reattaching = !self.inner.session.same_channel(&session.control);
-        self.inner.session = session.control.clone();
-        self.inner.outgoing = session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(session);
         self.resume_inner(is_reattaching).await
     }
 
@@ -1196,9 +1212,7 @@ impl DetachedSender {
         remote_attach: Attach,
         session: &SessionHandle<R>,
     ) -> Result<Sender, SenderResumeError> {
-        let is_reattaching = !self.inner.session.same_channel(&session.control);
-        self.inner.session = session.control.clone();
-        self.inner.outgoing = session.outgoing.clone();
+        let is_reattaching = self.inner.switch_session(session);
 
         try_as_sender!(
             self,
@@ -1216,9 +1230,7 @@ impl DetachedSender {
             session: &SessionHandle<R>,
             duration: Duration,
         ) -> Result<Sender, SenderResumeError> {
-            let is_reattaching = !self.inner.session.same_channel(&session.control);
-            self.inner.session = session.control.clone();
-            self.inner.outgoing = session.outgoing.clone();
+            let is_reattaching = self.inner.switch_session(session);
             self.resume_with_timeout_inner(duration, is_reattaching).await
         }
 
@@ -1229,11 +1241,104 @@ impl DetachedSender {
             session: &SessionHandle<R>,
             duration: Duration,
         ) -> Result<Sender, SenderResumeError> {
-            let is_reattaching = !self.inner.session.same_channel(&session.control);
-            self.inner.session = session.control.clone();
-            self.inner.outgoing = session.outgoing.clone();
+            let is_reattaching = self.inner.switch_session(session);
             self.resume_incoming_attach_with_timeout_inner(remote_attach, duration, is_reattaching)
                 .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use fe2o3_amqp_types::definitions::ReceiverSettleMode;
+    use parking_lot::RwLock;
+    use tokio::sync::Notify;
+
+    use super::*;
+    use crate::{
+        link::state::{LinkFlowState, LinkFlowStateInner, LinkState},
+        util::Consumer,
+    };
+
+    fn make_sender_inner(max_frame_size: usize) -> SenderInner<SenderLink<Target>> {
+        let (session_tx, _session_rx) = mpsc::channel::<SessionControl>(16);
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel::<LinkFrame>(16);
+        let (incoming_tx, incoming_rx) = mpsc::channel::<LinkFrame>(16);
+        let _ = incoming_tx; // the link relay side is not needed by the test
+
+        let flow_state_inner = LinkFlowStateInner {
+            initial_delivery_count: 0,
+            delivery_count: 0,
+            link_credit: 0,
+            available: 0,
+            drain: false,
+            properties: None,
+        };
+        let flow_state = Arc::new(LinkFlowState::sender(flow_state_inner));
+        let consumer = Consumer::new(Arc::new(Notify::new()), flow_state);
+
+        let link = SenderLink::<Target> {
+            role: PhantomData,
+            local_state: LinkState::Attached,
+            name: String::from("test-sender"),
+            output_handle: None,
+            input_handle: None,
+            snd_settle_mode: SenderSettleMode::Mixed,
+            rcv_settle_mode: ReceiverSettleMode::First,
+            source: None,
+            target: None,
+            max_message_size: 0,
+            offered_capabilities: None,
+            desired_capabilities: None,
+            flow_state: consumer,
+            unsettled: Arc::new(RwLock::new(None)),
+            session_stop_reason: Arc::new(OnceLock::new()),
+            max_frame_size,
+            verify_incoming_source: true,
+            verify_incoming_target: true,
+        };
+        SenderInner {
+            link,
+            buffer_size: 16,
+            session: session_tx,
+            outgoing: outgoing_tx,
+            incoming: incoming_rx,
+        }
+    }
+
+    fn make_session_handle(max_frame_size: usize) -> SessionHandle<()> {
+        let (control, _control_rx) = mpsc::channel::<SessionControl>(16);
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel::<LinkFrame>(16);
+        let (outcome_tx, outcome) = oneshot::channel::<Result<(), crate::session::error::Error>>();
+        drop(outcome_tx);
+        SessionHandle {
+            is_ended: false,
+            control,
+            engine_handle: tokio::spawn(async {}),
+            outcome,
+            outgoing: outgoing_tx,
+            session_stop_reason: Arc::new(OnceLock::new()),
+            max_frame_size,
+            link_listener: (),
+        }
+    }
+
+    #[tokio::test]
+    async fn switch_session_refreshes_max_frame_size() {
+        let mut inner = make_sender_inner(4092);
+        let session_b = make_session_handle(1020);
+
+        // Switching to a different session marks the link as reattaching and
+        // refreshes the link's max frame size from the new session
+        let is_reattaching = inner.switch_session(&session_b);
+        assert!(is_reattaching);
+        assert_eq!(inner.link.max_frame_size, 1020);
+
+        // Switching to the same session does not mark the link as reattaching
+        let is_reattaching = inner.switch_session(&session_b);
+        assert!(!is_reattaching);
+        assert_eq!(inner.link.max_frame_size, 1020);
     }
 }

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -1058,7 +1058,8 @@ impl SenderInner<SenderLink<Target>> {
 /// ```
 #[derive(Debug)]
 pub struct DetachedSender {
-    inner: SenderInner<SenderLink<Target>>,
+    // Boxed to keep the link-reattachment result small
+    inner: Box<SenderInner<SenderLink<Target>>>,
 }
 
 macro_rules! try_as_sender {
@@ -1077,7 +1078,7 @@ macro_rules! try_as_sender {
 
 impl DetachedSender {
     fn new(inner: SenderInner<SenderLink<Target>>) -> Self {
-        Self { inner }
+        Self { inner: Box::new(inner) }
     }
 
     /// Get a reference to the link's source field
@@ -1107,7 +1108,7 @@ impl DetachedSender {
                 .resume_incoming_attach(None, is_reattaching)
                 .await
         );
-        Ok(Sender { inner: self.inner })
+        Ok(Sender { inner: *self.inner })
     }
 
     /// Resume the sender link on the original session
@@ -1127,7 +1128,7 @@ impl DetachedSender {
                 .resume_incoming_attach(Some(remote_attach), false)
                 .await
         );
-        Ok(Sender { inner: self.inner })
+        Ok(Sender { inner: *self.inner })
     }
 
     cfg_not_wasm32! {
@@ -1139,7 +1140,7 @@ impl DetachedSender {
             let fut = self.inner.resume_incoming_attach(None, is_reattaching);
 
             match tokio::time::timeout(duration, fut).await {
-                Ok(Ok(_)) => Ok(Sender { inner: self.inner }),
+                Ok(Ok(_)) => Ok(Sender { inner: *self.inner }),
                 Ok(Err(kind)) => Err(SenderResumeError {
                     detached_sender: self,
                     kind,
@@ -1172,7 +1173,7 @@ impl DetachedSender {
             let fut = self.inner.resume_incoming_attach(Some(remote_attach), is_reattaching);
 
             match tokio::time::timeout(duration, fut).await {
-                Ok(Ok(_)) => Ok(Sender { inner: self.inner }),
+                Ok(Ok(_)) => Ok(Sender { inner: *self.inner }),
                 Ok(Err(kind)) => Err(SenderResumeError {
                     detached_sender: self,
                     kind,
@@ -1220,7 +1221,7 @@ impl DetachedSender {
                 .resume_incoming_attach(Some(remote_attach), is_reattaching)
                 .await
         );
-        Ok(Sender { inner: self.inner })
+        Ok(Sender { inner: *self.inner })
     }
 
     cfg_not_wasm32! {

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::{definitions::Fields, messaging::MESSAGE_FORMAT};
 use futures_util::Future;
+use serde_amqp::serialized_size;
 
 use crate::endpoint::LinkExt;
 
@@ -35,9 +36,40 @@ where
             .clone()
             .ok_or(LinkStateError::IllegalState)?;
 
-        // Check message size
-        // If this field is zero or unset, there is no maximum size imposed by the link endpoint.
-        let more = (self.max_message_size != 0) && (payload.len() as u64 > self.max_message_size);
+        // The connection engine publishes the negotiated encoder max frame
+        // length before the connection handle is created; links are only
+        // attached after the connection is opened, so the value is always
+        // populated. Per AMQP 1.0 §2.7.1 `max-frame-size` is directional: a
+        // peer MUST NOT send frames larger than its partner can accept, so
+        // the outbound limit is the remote's advertised value as enforced by
+        // the transport encoder (see `ConnectionEngine::max_frame_size`).
+        //
+        // Maximum payload bytes per transfer frame. The frame body (serialized
+        // transfer performative + payload) must fit within the encoder's
+        // `max_frame_body_size` (i.e. `self.max_frame_size - 4`): the 4-byte
+        // frame header (doff, type, channel) is written by the encoder and the
+        // 4-byte size prefix is added by the length-delimited codec, so a
+        // frame that respects this bound never exceeds the negotiated max
+        // frame size. The delivery-id is only assigned by the session *after*
+        // the link splits, so its worst-case size (a uint, 0x70 + 4 bytes) is
+        // reserved to guarantee that the first frame still fits. The transfer
+        // is measured in place with the worst-case delivery-id set (and
+        // restored afterwards) so the real serializer decides the list
+        // encoding; `serialized_size` computes the size without allocating a
+        // buffer. The first frame of a split delivery is sent with `more=true`
+        // (the single-frame branch below explicitly resets it to `false`).
+        transfer.more = true;
+        let orig_delivery_id = transfer.delivery_id; // None on all send paths
+        transfer.delivery_id = Some(u32::MAX);
+        let performative_size = serialized_size(&transfer)
+            .map_err(|_| LinkStateError::IllegalState)?; // This should not happen
+        transfer.delivery_id = orig_delivery_id;
+        let max_payload = self.max_frame_size - 4 - performative_size;
+
+        // Split the payload so that every transfer frame fits within the
+        // negotiated max frame size, keeping the session's transfer-id and
+        // window accounting consistent with the frames actually sent.
+        let more = payload.len() > max_payload;
         if !more {
             transfer.more = false;
             send_transfer(
@@ -51,7 +83,7 @@ where
         // cancel safe
         } else {
             // Send the first frame
-            let partial = payload.split_to(self.max_message_size as usize);
+            let partial = payload.split_to(max_payload);
             transfer.more = true;
             send_transfer(
                 writer,
@@ -62,12 +94,19 @@ where
             )
             .await?; // cancel safe
 
+            // AMQP 1.0 §2.7.5: on continuation transfers the delivery-id may be
+            // omitted and the delivery-tag / message-format can only be omitted.
+            // Clear them *before* the loop so the last transfer is also cleared
+            // even when there is no middle frame (i.e. the delivery spans exactly
+            // two frames).
+            transfer.delivery_tag = None;
+            transfer.message_format = None;
+            transfer.settled = None;
+            transfer.rcv_settle_mode = None;
+
             // Send the transfers in the middle
-            while payload.len() > self.max_message_size as usize {
-                let partial = payload.split_to(self.max_message_size as usize);
-                transfer.delivery_tag = None;
-                transfer.message_format = None;
-                transfer.settled = None;
+            while payload.len() > max_payload {
+                let partial = payload.split_to(max_payload);
                 send_transfer(
                     writer,
                     input_handle.clone(),
@@ -666,11 +705,9 @@ where
     async fn send_attach(
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<(), Self::AttachError> {
-        self.send_attach_inner(writer, session, is_reattaching)
-            .await?;
+        self.send_attach_inner(writer, is_reattaching).await?;
         Ok(())
     }
 }
@@ -753,11 +790,10 @@ where
         &mut self,
         writer: &mpsc::Sender<LinkFrame>,
         reader: &mut mpsc::Receiver<LinkFrame>,
-        session: &mpsc::Sender<SessionControl>,
         is_reattaching: bool,
     ) -> Result<Self::AttachExchange, SenderAttachError> {
         // Send out local attach
-        self.send_attach(writer, session, is_reattaching).await?;
+        self.send_attach(writer, is_reattaching).await?;
 
         // Wait for remote attach
         let remote_attach =

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -61,8 +61,8 @@ where
         transfer.more = true;
         let orig_delivery_id = transfer.delivery_id; // None on all send paths
         transfer.delivery_id = Some(u32::MAX);
-        let performative_size = serialized_size(&transfer)
-            .map_err(|_| LinkStateError::IllegalState)?; // This should not happen
+        let performative_size =
+            serialized_size(&transfer).map_err(|_| LinkStateError::IllegalState)?; // This should not happen
         transfer.delivery_id = orig_delivery_id;
         let max_payload = self.max_frame_size - 4 - performative_size;
 

--- a/fe2o3-amqp/src/link/shared_inner.rs
+++ b/fe2o3-amqp/src/link/shared_inner.rs
@@ -89,7 +89,7 @@ where
         &mut self,
     ) -> Result<&mut Self, <Self::Link as LinkAttach>::AttachError> {
         self.reallocate_output_handle().await?; // FIXME: cancel safe? if oneshot channel is cancel safe
-        match self.exchange_attach(true).await // FIXME: cancel safe? if oneshot channel is cancel safe
+        match self.exchange_attach(true).await // cancel safe: the attach exchange only awaits on mpsc operations
         {
             Ok(attach_exchange) => self.handle_reattach_outcome(attach_exchange),
             Err(attach_error) => Err(self.handle_attach_error(attach_error).await),

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -106,7 +106,6 @@ cfg_transaction! {
                     outgoing_channel,
                     session_stop_reason: Arc::new(OnceLock::new()),
                     connection_stop_reason,
-                    max_frame_size,
                     local_state,
                     initial_outgoing_id: Constant::new(self.next_outgoing_id),
                     next_outgoing_id: self.next_outgoing_id,
@@ -133,6 +132,7 @@ cfg_transaction! {
                     control,
                     session,
                     txn_manager,
+                    max_frame_size,
                 }
             }
         }
@@ -150,13 +150,11 @@ impl Builder {
         outgoing_channel: OutgoingChannel,
         local_state: SessionState,
         connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
-        max_frame_size: usize,
     ) -> Session {
         Session {
             outgoing_channel,
             session_stop_reason: Arc::new(OnceLock::new()),
             connection_stop_reason,
-            max_frame_size,
             local_state,
             initial_outgoing_id: Constant::new(self.next_outgoing_id),
             next_outgoing_id: self.next_outgoing_id,
@@ -307,7 +305,6 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
-                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(
@@ -357,7 +354,6 @@ impl Builder {
                             outgoing_channel,
                             local_state,
                             connection.connection_stop_reason.clone(),
-                            max_frame_size,
                         );
                         let session_stop_reason = session.session_stop_reason().clone();
                         let (handle, outcome) = SessionEngine::begin_client_session(
@@ -430,7 +426,6 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
-                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(
@@ -500,7 +495,6 @@ impl Builder {
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
-                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -98,6 +98,7 @@ cfg_transaction! {
                 control_link_acceptor: ControlLinkAcceptor,
                 local_state: SessionState,
                 connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+                max_frame_size: usize,
             ) -> TxnSession<Session> {
                 let txn_manager = TransactionManager::new(outgoing, control_link_acceptor);
                 let session = Session {
@@ -105,6 +106,7 @@ cfg_transaction! {
                     outgoing_channel,
                     session_stop_reason: Arc::new(OnceLock::new()),
                     connection_stop_reason,
+                    max_frame_size,
                     local_state,
                     initial_outgoing_id: Constant::new(self.next_outgoing_id),
                     next_outgoing_id: self.next_outgoing_id,
@@ -148,11 +150,13 @@ impl Builder {
         outgoing_channel: OutgoingChannel,
         local_state: SessionState,
         connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+        max_frame_size: usize,
     ) -> Session {
         Session {
             outgoing_channel,
             session_stop_reason: Arc::new(OnceLock::new()),
             connection_stop_reason,
+            max_frame_size,
             local_state,
             initial_outgoing_id: Constant::new(self.next_outgoing_id),
             next_outgoing_id: self.next_outgoing_id,
@@ -297,11 +301,13 @@ impl Builder {
             };
 
             #[cfg(not(all(feature = "transaction", feature = "acceptor")))]
-            let (engine_handle, outcome, session_stop_reason) = {
+            let (engine_handle, outcome, session_stop_reason, max_frame_size) = {
+                let max_frame_size = connection.max_frame_size();
                 let session = self.into_session(
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
+                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(
@@ -314,14 +320,15 @@ impl Builder {
                 )
                 .await?
                 .spawn();
-                (handle, outcome, session_stop_reason)
+                (handle, outcome, session_stop_reason, max_frame_size)
             };
 
             #[cfg(all(feature = "transaction", feature = "acceptor"))]
-            let (engine_handle, outcome, session_stop_reason) = {
+            let (engine_handle, outcome, session_stop_reason, max_frame_size) = {
                 let mut this = self;
                 match this.control_link_acceptor.take() {
                     Some(control_link_acceptor) => {
+                        let max_frame_size = connection.max_frame_size();
                         let session = this.into_txn_session(
                             session_control_tx.clone(),
                             outgoing_tx.clone(),
@@ -329,6 +336,7 @@ impl Builder {
                             control_link_acceptor,
                             local_state,
                             connection.connection_stop_reason.clone(),
+                            max_frame_size,
                         );
                         let session_stop_reason = session.session_stop_reason().clone();
                         let (handle, outcome) = SessionEngine::begin_client_session(
@@ -341,13 +349,15 @@ impl Builder {
                         )
                         .await?
                         .spawn();
-                        (handle, outcome, session_stop_reason)
+                        (handle, outcome, session_stop_reason, max_frame_size)
                     }
                     None => {
+                        let max_frame_size = connection.max_frame_size();
                         let session = this.into_session(
                             outgoing_channel,
                             local_state,
                             connection.connection_stop_reason.clone(),
+                            max_frame_size,
                         );
                         let session_stop_reason = session.session_stop_reason().clone();
                         let (handle, outcome) = SessionEngine::begin_client_session(
@@ -360,7 +370,7 @@ impl Builder {
                         )
                         .await?
                         .spawn();
-                        (handle, outcome, session_stop_reason)
+                        (handle, outcome, session_stop_reason, max_frame_size)
                     }
                 }
             };
@@ -372,6 +382,7 @@ impl Builder {
                 outcome,
                 outgoing: outgoing_tx,
                 session_stop_reason,
+                max_frame_size,
                 link_listener: (),
             };
             Ok(handle)
@@ -413,11 +424,13 @@ impl Builder {
                 },
             };
 
-            let (engine_handle, outcome, session_stop_reason) = {
+            let (engine_handle, outcome, session_stop_reason, max_frame_size) = {
+                let max_frame_size = connection.max_frame_size();
                 let session = self.into_session(
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
+                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(
@@ -430,7 +443,7 @@ impl Builder {
                 )
                 .await?
                 .spawn_on_local_set(local_set);
-                (handle, outcome, session_stop_reason)
+                (handle, outcome, session_stop_reason, max_frame_size)
             };
 
             let handle = SessionHandle {
@@ -440,6 +453,7 @@ impl Builder {
                 outcome,
                 outgoing: outgoing_tx,
                 session_stop_reason,
+                max_frame_size,
                 link_listener: (),
             };
             Ok(handle)
@@ -480,11 +494,13 @@ impl Builder {
                 },
             };
 
-            let (engine_handle, outcome, session_stop_reason) = {
+            let (engine_handle, outcome, session_stop_reason, max_frame_size) = {
+                let max_frame_size = connection.max_frame_size();
                 let session = self.into_session(
                     outgoing_channel,
                     local_state,
                     connection.connection_stop_reason.clone(),
+                    max_frame_size,
                 );
                 let session_stop_reason = session.session_stop_reason().clone();
                 let (handle, outcome) = SessionEngine::begin_client_session(
@@ -497,7 +513,7 @@ impl Builder {
                 )
                 .await?
                 .spawn_local();
-                (handle, outcome, session_stop_reason)
+                (handle, outcome, session_stop_reason, max_frame_size)
             };
 
             let handle = SessionHandle {
@@ -507,6 +523,7 @@ impl Builder {
                 outcome,
                 outgoing: outgoing_tx,
                 session_stop_reason,
+                max_frame_size,
                 link_listener: (),
             };
             Ok(handle)

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -360,16 +360,6 @@ where
                     ))
                 })?;
             }
-            SessionControl::GetMaxFrameSize(resp) => {
-                self.conn_control
-                    .send(ConnectionControl::GetMaxFrameSize(resp))
-                    .await
-                    .map_err(|_| {
-                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
-                            self.session.connection_stop_reason(),
-                        ))
-                    })?;
-            }
 
             #[cfg(feature = "transaction")]
             SessionControl::AllocateTransactionId { resp } => {

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -327,10 +327,6 @@ pub struct Session {
     /// connection handle
     pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
 
-    /// The negotiated max frame size (encoder max frame length), shared from
-    /// the connection and with the links
-    pub(crate) max_frame_size: usize,
-
     // local amqp states
     pub(crate) local_state: SessionState,
     pub(crate) initial_outgoing_id: Constant<TransferNumber>,
@@ -607,10 +603,6 @@ impl endpoint::Session for Session {
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         &self.connection_stop_reason
-    }
-
-    fn max_frame_size(&self) -> usize {
-        self.max_frame_size
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {
@@ -1207,7 +1199,6 @@ mod tests {
                 OutgoingChannel(0),
                 SessionState::Mapped,
                 Arc::new(OnceLock::new()),
-                4096,
             )
     }
 

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -76,6 +76,9 @@ pub struct SessionHandle<R> {
     pub(crate) outgoing: mpsc::Sender<LinkFrame>,
     /// Why the session (or its connection) stopped, shared with the links
     pub(crate) session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+    /// The negotiated max frame size (encoder max frame length), shared from
+    /// the connection and with the links
+    pub(crate) max_frame_size: usize,
     pub(crate) link_listener: R,
 }
 
@@ -109,6 +112,13 @@ impl<R> SessionHandle<R> {
     /// The shared stop reason cell, used by links to observe why the session stopped
     pub(crate) fn session_stop_reason(&self) -> &Arc<OnceLock<SessionStopReason>> {
         &self.session_stop_reason
+    }
+
+    /// The negotiated max frame size (encoder max frame length) of the
+    /// session's connection, used by links to split transfers and attach
+    /// frames
+    pub(crate) fn max_frame_size(&self) -> usize {
+        self.max_frame_size
     }
 
     /// Checks if the underlying event loop has stopped
@@ -316,6 +326,10 @@ pub struct Session {
     /// Why the connection stopped, shared with the connection engine and the
     /// connection handle
     pub(crate) connection_stop_reason: Arc<OnceLock<ConnectionStopReason>>,
+
+    /// The negotiated max frame size (encoder max frame length), shared from
+    /// the connection and with the links
+    pub(crate) max_frame_size: usize,
 
     // local amqp states
     pub(crate) local_state: SessionState,
@@ -593,6 +607,10 @@ impl endpoint::Session for Session {
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         &self.connection_stop_reason
+    }
+
+    fn max_frame_size(&self) -> usize {
+        self.max_frame_size
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {
@@ -1189,6 +1207,7 @@ mod tests {
                 OutgoingChannel(0),
                 SessionState::Mapped,
                 Arc::new(OnceLock::new()),
+                4096,
             )
     }
 

--- a/fe2o3-amqp/src/transaction/coordinator.rs
+++ b/fe2o3-amqp/src/transaction/coordinator.rs
@@ -74,6 +74,7 @@ impl ControlLinkAcceptor {
         control: mpsc::Sender<SessionControl>,
         outgoing: mpsc::Sender<LinkFrame>,
         session_stop_reason: Arc<OnceLock<SessionStopReason>>,
+        max_frame_size: usize,
     ) -> Result<TxnCoordinator, ReceiverAttachError> {
         self.inner
             .accept_incoming_attach_inner(
@@ -82,6 +83,7 @@ impl ControlLinkAcceptor {
                 control,
                 outgoing,
                 session_stop_reason,
+                max_frame_size,
             )
             .await
             .map(|inner| TxnCoordinator {
@@ -235,6 +237,7 @@ impl TxnCoordinator {
             | RecvError::MessageDecode(_)
             | RecvError::IllegalRcvSettleModeInTransfer
             | RecvError::InconsistentFieldInMultiFrameDelivery
+            | RecvError::MessageSizeExceeded(_)
             | RecvError::TransactionalAcquisitionIsNotImeplemented => {
                 #[cfg(feature = "tracing")]
                 tracing::error!(?error);

--- a/fe2o3-amqp/src/transaction/error.rs
+++ b/fe2o3-amqp/src/transaction/error.rs
@@ -2,8 +2,8 @@ use fe2o3_amqp_types::messaging::{Accepted, DeliveryState, Outcome, Rejected};
 
 use crate::link::{
     delivery::{FromDeliveryFailure, FromDeliveryState, FromPreSettled},
-    DetachError, IllegalLinkStateError, LinkStateError, SendError, SenderAttachError,
-    SessionStopReason,
+    DetachError, IllegalLinkStateError, LinkStateError, MessageSizeExceeded, SendError,
+    SenderAttachError, SessionStopReason,
 };
 
 /// Errors with allocation of new transacation ID
@@ -112,6 +112,11 @@ pub enum ControllerSendError {
     #[error("Transactional state found on non-transactional delivery")]
     IllegalDeliveryState,
 
+    /// The encoded message is larger than the maximum message size
+    /// negotiated on the link
+    #[error(transparent)]
+    MessageSizeExceeded(MessageSizeExceeded),
+
     /// Error serializing message
     #[error("Error encoding message")]
     MessageEncodeError,
@@ -124,6 +129,7 @@ impl From<SendError> for ControllerSendError {
             SendError::Detached(value) => Self::Detached(value),
             SendError::NonTerminalDeliveryState => Self::NonTerminalDeliveryState,
             SendError::IllegalDeliveryState => Self::IllegalDeliveryState,
+            SendError::MessageSizeExceeded(error) => Self::MessageSizeExceeded(error),
             SendError::MessageEncodeError => Self::MessageEncodeError,
         }
     }
@@ -217,6 +223,11 @@ pub enum PostError {
     #[error("Transactional state found on non-transactional delivery")]
     IllegalDeliveryState,
 
+    /// The encoded message is larger than the maximum message size
+    /// negotiated on the link
+    #[error(transparent)]
+    MessageSizeExceeded(MessageSizeExceeded),
+
     /// Error serializing message
     #[error("Error encoding message")]
     MessageEncodeError,
@@ -225,6 +236,12 @@ pub enum PostError {
 impl From<serde_amqp::Error> for PostError {
     fn from(_: serde_amqp::Error) -> Self {
         Self::MessageEncodeError
+    }
+}
+
+impl From<MessageSizeExceeded> for PostError {
+    fn from(error: MessageSizeExceeded) -> Self {
+        Self::MessageSizeExceeded(error)
     }
 }
 

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -85,6 +85,9 @@ where
     pub(crate) control: mpsc::Sender<SessionControl>,
     pub(crate) session: S,
     pub(crate) txn_manager: TransactionManager,
+    /// The negotiated max frame size of the session's connection, used when
+    /// accepting the transaction control link
+    pub(crate) max_frame_size: usize,
 }
 
 impl<S> TxnSession<S> where
@@ -106,7 +109,7 @@ where
         let control = self.control.clone();
         let outgoing = self.txn_manager.control_link_outgoing.clone();
         let session_stop_reason = self.session.session_stop_reason().clone();
-        let max_frame_size = self.session.max_frame_size();
+        let max_frame_size = self.max_frame_size;
 
         tokio::spawn(async move {
             // Error accepting new control link is handled by acceptor
@@ -245,10 +248,6 @@ where
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         self.session.connection_stop_reason()
-    }
-
-    fn max_frame_size(&self) -> usize {
-        self.session.max_frame_size()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -106,11 +106,18 @@ where
         let control = self.control.clone();
         let outgoing = self.txn_manager.control_link_outgoing.clone();
         let session_stop_reason = self.session.session_stop_reason().clone();
+        let max_frame_size = self.session.max_frame_size();
 
         tokio::spawn(async move {
             // Error accepting new control link is handled by acceptor
             if let Ok(coordinator) = acceptor
-                .accept_incoming_attach(remote_attach, control, outgoing, session_stop_reason)
+                .accept_incoming_attach(
+                    remote_attach,
+                    control,
+                    outgoing,
+                    session_stop_reason,
+                    max_frame_size,
+                )
                 .await
             {
                 coordinator.event_loop().await
@@ -238,6 +245,10 @@ where
 
     fn connection_stop_reason(&self) -> &Arc<OnceLock<ConnectionStopReason>> {
         self.session.connection_stop_reason()
+    }
+
+    fn max_frame_size(&self) -> usize {
+        self.session.max_frame_size()
     }
 
     fn outgoing_channel(&self) -> OutgoingChannel {

--- a/fe2o3-amqp/tests/large_message_split.rs
+++ b/fe2o3-amqp/tests/large_message_split.rs
@@ -1,0 +1,339 @@
+//! Tests that large messages are split across multiple transfer frames
+//! bounded by the negotiated max frame size (not the max message size).
+//!
+//! These run over an in-memory `tokio::io::duplex` stream, so no broker or
+//! network is required. The scenarios are modeled on how brokers exercise
+//! multi-frame deliveries themselves (e.g. Apache Artemis
+//! `AmqpLargeMessageTest`, which parameterizes the frame size against
+//! payload sizes spanning multiple frames and verifies byte-identical
+//! round trips).
+//!
+//! Note: unlike real brokers, the fe2o3 acceptor receiver does not
+//! auto-accept at ingress, so the sender's `send()` only completes after
+//! the receiver accepts the delivery. The tests therefore receive/accept
+//! concurrently with sending.
+
+#![cfg(feature = "acceptor")]
+
+use std::time::Duration;
+
+use fe2o3_amqp::{
+    acceptor::{
+        ConnectionAcceptor, LinkAcceptor, LinkEndpoint, ListenerSessionHandle, SessionAcceptor,
+    },
+    connection::{Connection, ConnectionHandle},
+    link::SendError,
+    session::{Session, SessionHandle},
+    types::messaging::Message,
+    Sender,
+};
+
+const FRAME_SIZE: usize = 1024;
+
+async fn establish_connection_pair(
+    frame_size: usize,
+) -> (
+    fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    ConnectionHandle<()>,
+) {
+    let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .max_frame_size(frame_size as u32)
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let client_connection = Connection::builder()
+        .container_id("test-client")
+        .max_frame_size(frame_size as u32)
+        .open_with_stream(client_io)
+        .await
+        .expect("client connection failed");
+
+    let server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    (server_connection, client_connection)
+}
+
+async fn establish_session_pair(
+    server_connection: &mut fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    client_connection: &mut ConnectionHandle<()>,
+    session_incoming_window: u32,
+) -> (ListenerSessionHandle, SessionHandle<()>) {
+    let session_acceptor = SessionAcceptor::builder()
+        .incoming_window(session_incoming_window)
+        .build();
+    let (session_result, begin_result) = tokio::join!(
+        session_acceptor.accept(server_connection),
+        Session::builder()
+            .incoming_window(session_incoming_window)
+            .begin(client_connection),
+    );
+    let client_session = begin_result.expect("client session begin failed");
+    let listener_session = session_result.expect("session accept failed");
+    (listener_session, client_session)
+}
+
+/// Attach the client sender concurrently with the acceptor accepting the
+/// incoming link, returning both ends.
+async fn establish_link_pair(
+    listener_session: &mut ListenerSessionHandle,
+    client_session: &mut SessionHandle<()>,
+) -> (Sender, fe2o3_amqp::Receiver) {
+    let link_acceptor = LinkAcceptor::builder().build();
+    let (accept_result, attach_result) = tokio::join!(
+        link_acceptor.accept(listener_session),
+        Sender::attach(client_session, "test-sender", "test-queue"),
+    );
+
+    let sender = attach_result.expect("sender attach failed");
+    let receiver = match accept_result.expect("link accept failed") {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+    (sender, receiver)
+}
+
+/// A payload larger than a single frame must be split across multiple
+/// transfer frames at the frame-size boundary, not the max-message-size
+/// boundary, and must round trip byte-identically. Payload sizes straddle
+/// the frame boundary (frame * 2, frame * 2 + 1, frame * 4, ...) as in
+/// Artemis `AmqpLargeMessageTest::testSendFixedSizedMessages`.
+#[tokio::test]
+async fn payloads_larger_than_frame_size_round_trip() {
+    let (mut server_connection, mut client_connection) =
+        establish_connection_pair(FRAME_SIZE).await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection, 5000).await;
+
+    for size in [
+        2 * FRAME_SIZE,
+        2 * FRAME_SIZE + 1,
+        4 * FRAME_SIZE,
+        8 * FRAME_SIZE + 17,
+        128 * FRAME_SIZE,
+    ] {
+        let (mut sender, mut receiver) =
+            establish_link_pair(&mut listener_session, &mut client_session).await;
+
+        let payload = "x".repeat(size);
+        let send_payload = payload.clone();
+        let send_task = tokio::spawn(async move {
+            let message = Message::from(send_payload);
+            let outcome = sender.send(message).await.unwrap();
+            outcome.accepted_or("Not accepted").unwrap();
+            sender.close().await.unwrap();
+        });
+
+        let received = tokio::time::timeout(Duration::from_secs(10), receiver.recv::<String>())
+            .await
+            .expect("timed out waiting for message")
+            .expect("recv failed");
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(
+            received.body(),
+            &payload,
+            "payload of size {size} round trip failed"
+        );
+        receiver.close().await.unwrap();
+        send_task.await.unwrap();
+    }
+
+    client_session.close().await.unwrap();
+    client_connection.close().await.unwrap();
+}
+
+/// Many multi-frame messages sent back to back with a small session
+/// incoming-window exercise the session window re-advertisement and the
+/// per-transfer accounting: every physical transfer frame must be counted
+/// in the session's `next-outgoing-id` / `remote-incoming-window`.
+#[tokio::test]
+async fn many_multiframe_messages_with_small_window() {
+    const MESSAGE_COUNT: usize = 30;
+    const PAYLOAD_SIZE: usize = 4 * FRAME_SIZE;
+
+    let (mut server_connection, mut client_connection) =
+        establish_connection_pair(FRAME_SIZE).await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection, 8).await;
+
+    let (mut sender, mut receiver) =
+        establish_link_pair(&mut listener_session, &mut client_session).await;
+
+    let payload = "y".repeat(PAYLOAD_SIZE);
+    let send_payload = payload.clone();
+    let send_task = tokio::spawn(async move {
+        for _ in 0..MESSAGE_COUNT {
+            let message = Message::from(send_payload.clone());
+            let outcome = sender.send(message).await.unwrap();
+            outcome.accepted_or("Not accepted").unwrap();
+        }
+        sender.close().await.unwrap();
+    });
+
+    for _ in 0..MESSAGE_COUNT {
+        let received = tokio::time::timeout(Duration::from_secs(10), receiver.recv::<String>())
+            .await
+            .expect("timed out waiting for message")
+            .expect("recv failed");
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), &payload);
+    }
+    receiver.close().await.unwrap();
+    send_task.await.unwrap();
+
+    client_session.close().await.unwrap();
+    client_connection.close().await.unwrap();
+}
+
+/// A message larger than the negotiated max-message-size of the link must be
+/// rejected locally with `SendError::MessageSizeExceeded` before any transfer
+/// frame is sent (mirroring go-amqp's `amqp:link:message-size-exceeded`
+/// behavior), rather than being split across frames.
+#[tokio::test]
+async fn message_larger_than_max_message_size_is_rejected() {
+    let (mut server_connection, mut client_connection) =
+        establish_connection_pair(FRAME_SIZE).await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection, 5000).await;
+
+    let link_acceptor = LinkAcceptor::builder().max_message_size(1000u64).build();
+    let (accept_result, attach_result) = tokio::join!(
+        link_acceptor.accept(&mut listener_session),
+        Sender::attach(&mut client_session, "test-sender", "test-queue"),
+    );
+    let mut sender = attach_result.expect("sender attach failed");
+    let receiver = match accept_result.expect("link accept failed") {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+
+    let message = Message::from("z".repeat(2000));
+    let error = sender.send(message).await.expect_err("expected error");
+    match error {
+        SendError::MessageSizeExceeded(e) => {
+            assert_eq!(e.max_size, 1000);
+            assert!(e.size >= 2000, "encoded size was {}", e.size);
+        }
+        other => panic!("expected MessageSizeExceeded, got {:?}", other),
+    }
+
+    // The sender and receiver closes must run concurrently: each side
+    // processes the other's closing detach as part of its own close handshake.
+    let (sender_close, receiver_close) = tokio::join!(sender.close(), receiver.close());
+    sender_close.unwrap();
+    receiver_close.unwrap();
+    client_session.close().await.unwrap();
+    client_connection.close().await.unwrap();
+}
+
+/// Purpose of this test:
+///
+/// 1. **End-to-end coverage of cross-connection resume.** Resuming a link on
+///    a session of a *different connection* (`detach()` + `resume_on_session`)
+///    exercises the full path: detach handshake, session/outgoing switch,
+///    reattach exchange, and subsequent sends. This path is otherwise
+///    untested.
+/// 2. **Behavioral guard for the max-frame-size refresh.** The link's
+///    `max_frame_size` must be refreshed from the new session when the link
+///    moves to a connection with a different negotiated frame size. Here the
+///    sender moves from a connection with 4096-byte frames to one with
+///    1024-byte frames; the ~3000-byte message can therefore only be sent as
+///    a multi-frame delivery if the refreshed value is in effect. A stale
+///    value would silently fall back to the transport's defensive frame
+///    splitting — the bug class this work eliminates. The split boundary
+///    itself is not publicly observable (there is no public max-frame-size
+///    getter), so this is behavioral; the field refresh itself is covered by
+///    the `switch_session` unit tests.
+/// 3. **Post-resume usability.** A second send on the resumed link confirms
+///    that credit, flow, and settlement keep working after the move.
+#[tokio::test]
+async fn resume_on_new_connection_refreshes_max_frame_size() {
+    // Two connection pairs with different negotiated frame sizes
+    let (mut server_a, mut client_a) = establish_connection_pair(4096).await;
+    let (mut server_b, mut client_b) = establish_connection_pair(1024).await;
+    let (mut listener_a, mut session_a) =
+        establish_session_pair(&mut server_a, &mut client_a, 5000).await;
+    let (mut listener_b, mut session_b) =
+        establish_session_pair(&mut server_b, &mut client_b, 5000).await;
+
+    // Attach the sender on connection A
+    let link_acceptor_a = LinkAcceptor::builder().build();
+    let (accept_a, attach_a) = tokio::join!(
+        link_acceptor_a.accept(&mut listener_a),
+        Sender::attach(&mut session_a, "test-sender", "test-queue"),
+    );
+    let sender = attach_a.expect("sender attach failed");
+    let mut receiver_a = match accept_a.expect("link accept failed") {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+
+    // Drive the acceptor-side receiver so it responds to the sender's
+    // non-closing detach (the receiver's recv loop performs the detach
+    // handshake and then errors with `RemoteDetached`).
+    let recv_a_task = tokio::spawn(async move {
+        let _ = receiver_a.recv::<String>().await;
+    });
+
+    // Accept the resumed link on connection B FIRST: the accept task must run
+    // concurrently with the resume's attach exchange, which waits for the
+    // server's attach reply (keeping the listener session alive by returning
+    // it from the task).
+    let link_acceptor_b = LinkAcceptor::builder().build();
+    let accept_b_task = tokio::spawn(async move {
+        let link = link_acceptor_b.accept(&mut listener_b).await.unwrap();
+        (link, listener_b)
+    });
+
+    // Detach on A and resume the sender on connection B's session
+    let detached = sender.detach().await.unwrap();
+    recv_a_task.await.unwrap();
+    let mut sender = detached.resume_on_session(&session_b).await.unwrap();
+
+    // Keep the listener session alive for the rest of the test (dropping it
+    // would end the server-side session)
+    let (endpoint_b, _listener_b) = accept_b_task.await.unwrap();
+    let mut receiver_b = match endpoint_b {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+
+    // Send the two messages from a spawned task (the send blocks until the
+    // receiver accepts), receiving each on B's acceptor concurrently
+    let payload = "x".repeat(3000);
+    let small_payload = "small".to_string();
+    let send_payload = payload.clone();
+    let send_small_payload = small_payload.clone();
+    let send_task = tokio::spawn(async move {
+        let message = Message::from(send_payload);
+        let outcome = sender.send(message).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        // The resumed link stays usable: a second, smaller send
+        let message = Message::from(send_small_payload);
+        let outcome = sender.send(message).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        sender.close().await.unwrap();
+    });
+
+    let received = receiver_b.recv::<String>().await.unwrap();
+    receiver_b.accept(&received).await.unwrap();
+    assert_eq!(received.body(), &payload);
+
+    let received = receiver_b.recv::<String>().await.unwrap();
+    receiver_b.accept(&received).await.unwrap();
+    assert_eq!(received.body(), &small_payload);
+
+    receiver_b.close().await.unwrap();
+    send_task.await.unwrap();
+
+    session_b.close().await.unwrap();
+    client_b.close().await.unwrap();
+    client_a.close().await.unwrap();
+}

--- a/fe2o3-amqp/tests/link.rs
+++ b/fe2o3-amqp/tests/link.rs
@@ -17,6 +17,47 @@ cfg_not_wasm32! {
 
     mod common;
 
+    /// Round trip a payload through the broker and assert byte equality.
+    ///
+    /// This is modeled on Apache Artemis `AmqpLargeMessageTest`
+    /// (`testSendFixedSizedMessages`/`testSend1MBMessage`), which sends
+    /// payloads spanning multiple frames (the frame size is at most
+    /// 131072 on RabbitMQ and smaller on Artemis/Qpid) and asserts the
+    /// received bytes equal the sent bytes.
+    async fn send_receive_large_content(url: &str, payload: String, detach_on_close: bool) {
+        let mut connection = Connection::open("test-connection", url).await.unwrap();
+        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
+            .await
+            .unwrap();
+        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
+            .await
+            .unwrap();
+
+        let message = Message::from(payload.clone());
+        let outcome = sender.send(message).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+
+        let received = receiver.recv::<String>().await.unwrap();
+        receiver.accept(&received).await.unwrap();
+        assert_eq!(received.body(), &payload);
+
+        if detach_on_close {
+            // rabbitmq only supports non-closing detach
+            sender.detach().await.unwrap();
+            receiver.detach().await.unwrap();
+        } else {
+            sender.close().await.unwrap();
+            receiver.close().await.unwrap();
+        }
+        session.close().await.unwrap();
+        connection.close().await.unwrap();
+    }
+
+    /// Fixed payload sizes that each span multiple frames at the broker's
+    /// default frame size (as in Artemis `testSendFixedSizedMessages`).
+    const LARGE_CONTENT_SIZES: [usize; 4] = [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024];
+
     #[tokio::test]
     async fn activemq_artemis_send_receive() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
@@ -50,27 +91,9 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
 
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
-
-        let message = Message::from("test-message".repeat(100_000));
-        let outcome = sender.send(message).await.unwrap();
-        outcome.accepted_or("Not accepted").unwrap();
-
-        let received = receiver.recv::<String>().await.unwrap();
-        receiver.accept(&received).await.unwrap();
-        assert_eq!(received.body(), &"test-message".repeat(100_000));
-
-        sender.close().await.unwrap();
-        receiver.close().await.unwrap();
-        session.close().await.unwrap();
-        connection.close().await.unwrap();
+        for size in LARGE_CONTENT_SIZES {
+            send_receive_large_content(&url, "a".repeat(size), false).await;
+        }
     }
 
     #[tokio::test]
@@ -106,27 +129,9 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
 
         let url = format!("amqp://admin:admin@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
-
-        let message = Message::from("test-message".repeat(100_000));
-        let outcome = sender.send(message).await.unwrap();
-        outcome.accepted_or("Not accepted").unwrap();
-
-        let received = receiver.recv::<String>().await.unwrap();
-        receiver.accept(&received).await.unwrap();
-        assert_eq!(received.body(), &"test-message".repeat(100_000));
-
-        sender.close().await.unwrap();
-        receiver.close().await.unwrap();
-        session.close().await.unwrap();
-        connection.close().await.unwrap();
+        for size in LARGE_CONTENT_SIZES {
+            send_receive_large_content(&url, "p".repeat(size), false).await;
+        }
     }
 
     #[tokio::test]
@@ -163,27 +168,8 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
 
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
-
-        let message = Message::from("test-message".repeat(100_000));
-        let outcome = sender.send(message).await.unwrap();
-        outcome.accepted_or("Not accepted").unwrap();
-
-        let received = receiver.recv::<String>().await.unwrap();
-        receiver.accept(&received).await.unwrap();
-        assert_eq!(received.body(), &"test-message".repeat(100_000));
-
-        // rabbitmq only supports non-closing detach
-        sender.detach().await.unwrap();
-        receiver.detach().await.unwrap();
-        session.close().await.unwrap();
-        connection.close().await.unwrap();
+        for size in LARGE_CONTENT_SIZES {
+            send_receive_large_content(&url, "r".repeat(size), true).await;
+        }
     }
 }


### PR DESCRIPTION
Large messages were previously split at the link's max-message-size boundary (and not at all when unset, the default), letting the transport encoder split frames after session accounting and silently desyncing the session's transfer-id and window state from the wire. The sender link now splits at the negotiated max-frame-size (directional per AMQP 1.0 §2.7.1), shared from the connection down to the links and refreshed on cross-connection resume, and continuation frames always omit the delivery-id/delivery-tag/message-format/ settled/rcv-settle-mode fields even for two-frame deliveries.

Also add sender- and receiver-side max-message-size enforcement: oversized messages are rejected with amqp:link:message-size-exceeded (SendError / RecvError::MessageSizeExceeded) without detaching the link.

fix: #382 