### PR TITLE
test: bound integration-test setup operations with a timeout

### DIFF
--- a/fe2o3-amqp/tests/acceptor.rs
+++ b/fe2o3-amqp/tests/acceptor.rs
@@ -16,6 +16,8 @@ use fe2o3_amqp::{
     Session,
 };
 
+mod common;
+
 /// When the connection stops while the listener session is waiting for an
 /// incoming link, `LinkAcceptor::accept` must surface the connection-level
 /// stop reason rather than a fabricated one.
@@ -28,11 +30,10 @@ async fn listener_acceptor_reports_connection_closed() {
         .build();
     let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
 
-    let mut client_connection = Connection::builder()
+    let mut client_connection = common::expect_ok!(Connection::builder()
         .container_id("test-client")
-        .open_with_stream(client_io)
-        .await
-        .expect("client connection failed");
+        .open_with_stream(client_io))
+    .await;
 
     let mut server_connection = connection_task
         .await
@@ -43,11 +44,10 @@ async fn listener_acceptor_reports_connection_closed() {
     // its session; the connection handle stays in scope so the connection
     // stays alive.
     let session_acceptor = SessionAcceptor::new();
-    let (session_result, begin_result) = tokio::join!(
-        session_acceptor.accept(&mut server_connection),
-        Session::begin(&mut client_connection),
-    );
-    let _client_session = begin_result.expect("client session begin failed");
+    let begin_fut = common::expect_ok!(Session::begin(&mut client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(&mut server_connection), begin_fut);
+    let _client_session = begin_result;
     let mut listener_session = session_result.expect("session accept failed");
 
     let link_acceptor = LinkAcceptor::builder().build();
@@ -83,11 +83,10 @@ async fn listener_acceptor_reports_session_ended() {
         .build();
     let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
 
-    let mut client_connection = Connection::builder()
+    let mut client_connection = common::expect_ok!(Connection::builder()
         .container_id("test-client")
-        .open_with_stream(client_io)
-        .await
-        .expect("client connection failed");
+        .open_with_stream(client_io))
+    .await;
 
     let mut server_connection = connection_task
         .await
@@ -98,11 +97,10 @@ async fn listener_acceptor_reports_session_ended() {
     // its session; the connection handle stays in scope so the connection
     // stays alive.
     let session_acceptor = SessionAcceptor::new();
-    let (session_result, begin_result) = tokio::join!(
-        session_acceptor.accept(&mut server_connection),
-        Session::begin(&mut client_connection),
-    );
-    let client_session = begin_result.expect("client session begin failed");
+    let begin_fut = common::expect_ok!(Session::begin(&mut client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(&mut server_connection), begin_fut);
+    let client_session = begin_result;
     let mut listener_session = session_result.expect("session accept failed");
 
     let link_acceptor = LinkAcceptor::builder().build();

--- a/fe2o3-amqp/tests/broker_connection_compat.rs
+++ b/fe2o3-amqp/tests/broker_connection_compat.rs
@@ -18,7 +18,7 @@ cfg_not_wasm32! {
     async fn activemq_artemis_connection() {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 
@@ -26,7 +26,7 @@ cfg_not_wasm32! {
     async fn activemq_artemis_sasl_plain_connection() {
         let (_node, port) = common::setup_activemq_artemis(Some("artemis"), Some("artemis")).await;
         let url = format!("amqp://artemis:artemis@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 
@@ -36,7 +36,7 @@ cfg_not_wasm32! {
         // `admin`/`admin` user. Anonymous access is not enabled.
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
         let url = format!("amqp://admin:admin@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 
@@ -44,7 +44,7 @@ cfg_not_wasm32! {
     async fn qpid_broker_j_sasl_plain_connection() {
         let (_node, port) = common::setup_qpid_broker_j(Some("admin"), Some("admin")).await;
         let url = format!("amqp://admin:admin@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 
@@ -52,7 +52,7 @@ cfg_not_wasm32! {
     async fn rabbitmq_amqp10_connection() {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 
@@ -60,7 +60,7 @@ cfg_not_wasm32! {
     async fn rabbitmq_amqp10_sasl_plain_connection() {
         let (_node, port) = common::setup_rabbitmq_amqp10(Some("guest"), Some("guest")).await;
         let url = format!("amqp://guest:guest@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
         connection.close().await.unwrap();
     }
 }

--- a/fe2o3-amqp/tests/clean_teardown.rs
+++ b/fe2o3-amqp/tests/clean_teardown.rs
@@ -15,6 +15,8 @@ use fe2o3_amqp::{
     types::definitions::{self, AmqpError},
 };
 
+mod common;
+
 fn test_error() -> definitions::Error {
     definitions::Error::new(
         AmqpError::InternalError,
@@ -34,11 +36,10 @@ async fn establish_connection_pair() -> (
         .build();
     let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
 
-    let client_connection = Connection::builder()
+    let client_connection = common::expect_ok!(Connection::builder()
         .container_id("test-client")
-        .open_with_stream(client_io)
-        .await
-        .expect("client connection failed");
+        .open_with_stream(client_io))
+    .await;
 
     let server_connection = connection_task
         .await
@@ -53,11 +54,10 @@ async fn establish_session_pair(
     client_connection: &mut ConnectionHandle<()>,
 ) -> SessionHandle<()> {
     let session_acceptor = SessionAcceptor::new();
-    let (session_result, begin_result) = tokio::join!(
-        session_acceptor.accept(server_connection),
-        Session::begin(client_connection),
-    );
-    let client_session = begin_result.expect("client session begin failed");
+    let begin_fut = common::expect_ok!(Session::begin(client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(server_connection), begin_fut);
+    let client_session = begin_result;
     session_result.expect("session accept failed");
     client_session
 }

--- a/fe2o3-amqp/tests/common.rs
+++ b/fe2o3-amqp/tests/common.rs
@@ -77,17 +77,22 @@ pub async fn setup_rabbitmq_amqp10(
     username: Option<&str>,
     password: Option<&str>,
 ) -> (ContainerAsync<GenericImage>, u16) {
+    // Wait for RabbitMQ to finish booting before connecting: the AMQP 1.0
+    // plugin accepts TCP connections while the broker is still starting up,
+    // and the client has no handshake timeout, so connecting too early hangs
+    // the test until the CI job timeout.
+    let wait_for = WaitFor::message_on_either_std("Server startup complete");
     let image = match (username, password) {
         (Some(username), Some(password)) => {
             GenericImage::new("docker.io/minghuaw/rabbitmq-amqp1.0", "latest")
                 .with_exposed_port(5672.tcp())
-                .with_wait_for(WaitFor::seconds(10))
+                .with_wait_for(wait_for)
                 .with_env_var("RABBITMQ_DEFAULT_USER", username)
                 .with_env_var("RABBITMQ_DEFAULT_PASS", password)
         }
         _ => GenericImage::new("docker.io/minghuaw/rabbitmq-amqp1.0", "latest")
             .with_exposed_port(5672.tcp())
-            .with_wait_for(WaitFor::seconds(10))
+            .with_wait_for(wait_for)
             .into(),
     };
     let node = image.start().await.unwrap();

--- a/fe2o3-amqp/tests/common/mod.rs
+++ b/fe2o3-amqp/tests/common/mod.rs
@@ -6,6 +6,29 @@ use testcontainers::{
     ContainerAsync, GenericImage, ImageExt,
 };
 
+/// Runs `fut` under a 60s timeout, panicking with the expression text on
+/// timeout or with the error on failure. Bounds the AMQP setup operations
+/// (connection open, session begin, link attach) in integration tests: a
+/// broker that accepts TCP but stalls the handshake would otherwise hang the
+/// test until the CI job timeout.
+///
+/// Expands to a future so that it can also be joined concurrently with the
+/// acceptor-side operation (e.g. `tokio::join!`).
+macro_rules! expect_ok {
+    ($fut:expr) => {
+        async {
+            let what = stringify!($fut);
+            tokio::time::timeout(std::time::Duration::from_secs(60), $fut)
+                .await
+                .unwrap_or_else(|_| panic!("AMQP operation timed out after 60s: {what}"))
+                .unwrap()
+        }
+    };
+}
+
+pub(crate) use expect_ok;
+
+#[allow(dead_code)] // not used by all test binaries
 pub async fn setup_activemq_artemis(
     username: Option<&str>,
     password: Option<&str>,
@@ -29,6 +52,7 @@ pub async fn setup_activemq_artemis(
     (node, port)
 }
 
+#[allow(dead_code)] // not used by all test binaries
 pub async fn setup_qpid_broker_j(
     username: Option<&str>,
     password: Option<&str>,

--- a/fe2o3-amqp/tests/large_message_split.rs
+++ b/fe2o3-amqp/tests/large_message_split.rs
@@ -28,6 +28,8 @@ use fe2o3_amqp::{
     Sender,
 };
 
+mod common;
+
 const FRAME_SIZE: usize = 1024;
 
 async fn establish_connection_pair(
@@ -44,12 +46,11 @@ async fn establish_connection_pair(
         .build();
     let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
 
-    let client_connection = Connection::builder()
+    let client_connection = common::expect_ok!(Connection::builder()
         .container_id("test-client")
         .max_frame_size(frame_size as u32)
-        .open_with_stream(client_io)
-        .await
-        .expect("client connection failed");
+        .open_with_stream(client_io))
+    .await;
 
     let server_connection = connection_task
         .await
@@ -67,13 +68,12 @@ async fn establish_session_pair(
     let session_acceptor = SessionAcceptor::builder()
         .incoming_window(session_incoming_window)
         .build();
-    let (session_result, begin_result) = tokio::join!(
-        session_acceptor.accept(server_connection),
-        Session::builder()
-            .incoming_window(session_incoming_window)
-            .begin(client_connection),
-    );
-    let client_session = begin_result.expect("client session begin failed");
+    let begin_fut = common::expect_ok!(Session::builder()
+        .incoming_window(session_incoming_window)
+        .begin(client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(server_connection), begin_fut);
+    let client_session = begin_result;
     let listener_session = session_result.expect("session accept failed");
     (listener_session, client_session)
 }
@@ -85,12 +85,12 @@ async fn establish_link_pair(
     client_session: &mut SessionHandle<()>,
 ) -> (Sender, fe2o3_amqp::Receiver) {
     let link_acceptor = LinkAcceptor::builder().build();
-    let (accept_result, attach_result) = tokio::join!(
-        link_acceptor.accept(listener_session),
-        Sender::attach(client_session, "test-sender", "test-queue"),
-    );
+    let attach_fut =
+        common::expect_ok!(Sender::attach(client_session, "test-sender", "test-queue"));
+    let (accept_result, attach_result) =
+        tokio::join!(link_acceptor.accept(listener_session), attach_fut);
 
-    let sender = attach_result.expect("sender attach failed");
+    let sender = attach_result;
     let receiver = match accept_result.expect("link accept failed") {
         LinkEndpoint::Receiver(receiver) => receiver,
         other => panic!("expected receiver endpoint, got {:?}", other),
@@ -202,11 +202,14 @@ async fn message_larger_than_max_message_size_is_rejected() {
         establish_session_pair(&mut server_connection, &mut client_connection, 5000).await;
 
     let link_acceptor = LinkAcceptor::builder().max_message_size(1000u64).build();
-    let (accept_result, attach_result) = tokio::join!(
-        link_acceptor.accept(&mut listener_session),
-        Sender::attach(&mut client_session, "test-sender", "test-queue"),
-    );
-    let mut sender = attach_result.expect("sender attach failed");
+    let attach_fut = common::expect_ok!(Sender::attach(
+        &mut client_session,
+        "test-sender",
+        "test-queue"
+    ));
+    let (accept_result, attach_result) =
+        tokio::join!(link_acceptor.accept(&mut listener_session), attach_fut);
+    let mut sender = attach_result;
     let receiver = match accept_result.expect("link accept failed") {
         LinkEndpoint::Receiver(receiver) => receiver,
         other => panic!("expected receiver endpoint, got {:?}", other),
@@ -263,11 +266,10 @@ async fn resume_on_new_connection_refreshes_max_frame_size() {
 
     // Attach the sender on connection A
     let link_acceptor_a = LinkAcceptor::builder().build();
-    let (accept_a, attach_a) = tokio::join!(
-        link_acceptor_a.accept(&mut listener_a),
-        Sender::attach(&mut session_a, "test-sender", "test-queue"),
-    );
-    let sender = attach_a.expect("sender attach failed");
+    let attach_a_fut =
+        common::expect_ok!(Sender::attach(&mut session_a, "test-sender", "test-queue"));
+    let (accept_a, attach_a) = tokio::join!(link_acceptor_a.accept(&mut listener_a), attach_a_fut);
+    let sender = attach_a;
     let mut receiver_a = match accept_a.expect("link accept failed") {
         LinkEndpoint::Receiver(receiver) => receiver,
         other => panic!("expected receiver endpoint, got {:?}", other),
@@ -293,7 +295,7 @@ async fn resume_on_new_connection_refreshes_max_frame_size() {
     // Detach on A and resume the sender on connection B's session
     let detached = sender.detach().await.unwrap();
     recv_a_task.await.unwrap();
-    let mut sender = detached.resume_on_session(&session_b).await.unwrap();
+    let mut sender = common::expect_ok!(detached.resume_on_session(&session_b)).await;
 
     // Keep the listener session alive for the rest of the test (dropping it
     // would end the server-side session)

--- a/fe2o3-amqp/tests/link.rs
+++ b/fe2o3-amqp/tests/link.rs
@@ -25,14 +25,10 @@ cfg_not_wasm32! {
     /// 131072 on RabbitMQ and smaller on Artemis/Qpid) and asserts the
     /// received bytes equal the sent bytes.
     async fn send_receive_large_content(url: &str, payload: String, detach_on_close: bool) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
         let message = Message::from(payload.clone());
         let outcome = sender.send(message).await.unwrap();
@@ -63,14 +59,10 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_activemq_artemis(None, None).await;
 
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
         let message = Message::from("test-message");
         let outcome = sender.send(message).await.unwrap();
@@ -101,14 +93,10 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_qpid_broker_j(None, None).await;
 
         let url = format!("amqp://admin:admin@localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
         let message = Message::from("test-message");
         let outcome = sender.send(message).await.unwrap();
@@ -139,14 +127,10 @@ cfg_not_wasm32! {
         let (_node, port) = common::setup_rabbitmq_amqp10(None, None).await;
 
         let url = format!("amqp://localhost:{}", port);
-        let mut connection = Connection::open("test-connection", &url[..]).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", &url[..])).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
         let message = Message::from("test-message");
         let outcome = sender.send(message).await.unwrap();

--- a/fe2o3-amqp/tests/link_stop_reason.rs
+++ b/fe2o3-amqp/tests/link_stop_reason.rs
@@ -22,6 +22,8 @@ use fe2o3_amqp::{
     Receiver, Sendable, Sender,
 };
 
+mod common;
+
 fn test_error() -> definitions::Error {
     definitions::Error::new(
         AmqpError::InternalError,
@@ -38,11 +40,10 @@ async fn establish_connection_pair() -> (ListenerConnectionHandle, ConnectionHan
         .build();
     let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
 
-    let client_connection = Connection::builder()
+    let client_connection = common::expect_ok!(Connection::builder()
         .container_id("test-client")
-        .open_with_stream(client_io)
-        .await
-        .expect("client connection failed");
+        .open_with_stream(client_io))
+    .await;
 
     let server_connection = connection_task
         .await
@@ -59,11 +60,10 @@ async fn establish_session_pair(
     client_connection: &mut ConnectionHandle<()>,
 ) -> (SessionHandle<()>, ListenerSessionHandle) {
     let session_acceptor = SessionAcceptor::new();
-    let (session_result, begin_result) = tokio::join!(
-        session_acceptor.accept(server_connection),
-        Session::begin(client_connection),
-    );
-    let client_session = begin_result.expect("client session begin failed");
+    let begin_fut = common::expect_ok!(Session::begin(client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(server_connection), begin_fut);
+    let client_session = begin_result;
     let listener_session = session_result.expect("session accept failed");
     (client_session, listener_session)
 }
@@ -75,16 +75,15 @@ async fn attach_sender(
     name: &str,
 ) -> Sender {
     let link_acceptor = LinkAcceptor::new();
-    let (link_result, attach_result) = tokio::join!(
-        link_acceptor.accept(listener_session),
-        Sender::builder()
-            .name(name)
-            .source(Source::builder().build())
-            .target(Target::builder().build())
-            .attach(client_session),
-    );
+    let attach_fut = common::expect_ok!(Sender::builder()
+        .name(name)
+        .source(Source::builder().build())
+        .target(Target::builder().build())
+        .attach(client_session));
+    let (link_result, attach_result) =
+        tokio::join!(link_acceptor.accept(listener_session), attach_fut);
     let _server_receiver = link_result.expect("link accept failed");
-    attach_result.expect("sender attach failed")
+    attach_result
 }
 
 /// Attach a client receiver link, with the listener accepting it concurrently.
@@ -94,16 +93,15 @@ async fn attach_receiver(
     name: &str,
 ) -> Receiver {
     let link_acceptor = LinkAcceptor::new();
-    let (link_result, attach_result) = tokio::join!(
-        link_acceptor.accept(listener_session),
-        Receiver::builder()
-            .name(name)
-            .source(Source::builder().build())
-            .target(Target::builder().build())
-            .attach(client_session),
-    );
+    let attach_fut = common::expect_ok!(Receiver::builder()
+        .name(name)
+        .source(Source::builder().build())
+        .target(Target::builder().build())
+        .attach(client_session));
+    let (link_result, attach_result) =
+        tokio::join!(link_acceptor.accept(listener_session), attach_fut);
     let _server_sender = link_result.expect("link accept failed");
-    attach_result.expect("receiver attach failed")
+    attach_result
 }
 
 /// Sends until the teardown has propagated and the send surfaces the expected

--- a/fe2o3-amqp/tests/transaction.rs
+++ b/fe2o3-amqp/tests/transaction.rs
@@ -97,17 +97,11 @@ cfg_not_wasm32! {
     }
 
     async fn transaction_posting_commit(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
         post_commit_and_verify(txn, &mut sender, &mut receiver).await;
@@ -120,18 +114,12 @@ cfg_not_wasm32! {
     }
 
     async fn owned_transaction_posting_commit(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue")
-            .await
-            .unwrap();
-        let mut receiver = Receiver::attach(&mut session, "test-receiver", "test-queue")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue")).await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller", None)).await;
         post_commit_and_verify(txn, &mut sender, &mut receiver).await;
 
         sender.close().await.unwrap();
@@ -162,18 +150,12 @@ cfg_not_wasm32! {
     }
 
     async fn transaction_discharge(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-discharge")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-discharge")).await;
         let mut receiver =
-            Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")
-                .await
-                .unwrap();
+            common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")).await;
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
         discharge_and_verify(txn, &mut sender, &mut receiver).await;
@@ -186,19 +168,13 @@ cfg_not_wasm32! {
     }
 
     async fn owned_transaction_discharge(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-discharge")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-discharge")).await;
         let mut receiver =
-            Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")
-                .await
-                .unwrap();
+            common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue-discharge")).await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller", None)).await;
         discharge_and_verify(txn, &mut sender, &mut receiver).await;
 
         sender.close().await.unwrap();
@@ -250,22 +226,16 @@ cfg_not_wasm32! {
     }
 
     async fn posting_variants(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
         let mut sender =
-            Sender::attach(&mut session, "test-sender", "test-queue-variants")
-                .await
-                .unwrap();
-        let mut receiver = Receiver::attach(
+            common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-variants")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(
             &mut session,
             "test-receiver",
             "test-queue-variants",
-        )
-        .await
-        .unwrap();
+        )).await;
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
         post_variants_and_verify(txn, &mut sender, &mut receiver).await;
@@ -278,23 +248,17 @@ cfg_not_wasm32! {
     }
 
     async fn owned_posting_variants(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
         let mut sender =
-            Sender::attach(&mut session, "test-sender", "test-queue-variants")
-                .await
-                .unwrap();
-        let mut receiver = Receiver::attach(
+            common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-variants")).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(
             &mut session,
             "test-receiver",
             "test-queue-variants",
-        )
-        .await
-        .unwrap();
+        )).await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller", None)).await;
         post_variants_and_verify(txn, &mut sender, &mut receiver).await;
 
         sender.close().await.unwrap();
@@ -324,18 +288,12 @@ cfg_not_wasm32! {
     }
 
     async fn transaction_rollback(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-rollback")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-rollback")).await;
         let mut receiver =
-            Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")
-                .await
-                .unwrap();
+            common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")).await;
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
         rollback_and_verify(txn, &mut sender, &mut receiver).await;
@@ -352,25 +310,17 @@ cfg_not_wasm32! {
     }
 
     async fn owned_transaction_rollback(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let mut sender = Sender::attach(&mut session, "test-sender", "test-queue-rollback")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let mut sender = common::expect_ok!(Sender::attach(&mut session, "test-sender", "test-queue-rollback")).await;
         let mut receiver =
-            Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")
-                .await
-                .unwrap();
+            common::expect_ok!(Receiver::attach(&mut session, "test-receiver", "test-queue-rollback")).await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)).await;
         rollback_and_verify(txn, &mut sender, &mut receiver).await;
 
         // A subsequent transaction on its own control link still works
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)).await;
         post_commit_and_verify(txn, &mut sender, &mut receiver).await;
 
         sender.close().await.unwrap();
@@ -524,20 +474,16 @@ cfg_not_wasm32! {
     {
         let queue = format!("test-queue-ret-{}", body);
 
-        let mut seed_sender = Sender::attach(
+        let mut seed_sender = common::expect_ok!(Sender::attach(
             session,
             format!("test-seed-sender-{}", body),
             &queue,
-        )
-        .await
-        .unwrap();
-        let mut receiver = Receiver::attach(
+        )).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(
             session,
             format!("test-receiver-{}", body),
             &queue,
-        )
-        .await
-        .unwrap();
+        )).await;
         seed_sender.send(Message::from(body)).await.unwrap();
 
         match body {
@@ -569,11 +515,9 @@ cfg_not_wasm32! {
     }
 
     async fn qpid_retirement(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
 
         for &body in RETIREMENT_BODIES.iter() {
             let txn = Transaction::declare(&controller, None).await.unwrap();
@@ -586,17 +530,15 @@ cfg_not_wasm32! {
     }
 
     async fn qpid_owned_retirement(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
 
         for (index, &body) in RETIREMENT_BODIES.iter().enumerate() {
-            let txn = OwnedTransaction::declare(
+            let txn = common::expect_ok!(OwnedTransaction::declare(
                 &mut session,
                 format!("test-owned-controller-{}", index),
                 None,
-            )
-            .await
-            .unwrap();
+            )).await;
             qpid_retire_case(body, txn, &mut session).await;
         }
 
@@ -629,20 +571,16 @@ cfg_not_wasm32! {
     {
         let queue = format!("test-queue-ret-{}", body);
 
-        let mut seed_sender = Sender::attach(
+        let mut seed_sender = common::expect_ok!(Sender::attach(
             session,
             format!("test-seed-sender-{}", body),
             &queue,
-        )
-        .await
-        .unwrap();
-        let mut receiver = Receiver::attach(
+        )).await;
+        let mut receiver = common::expect_ok!(Receiver::attach(
             session,
             format!("test-receiver-{}", body),
             &queue,
-        )
-        .await
-        .unwrap();
+        )).await;
         seed_sender.send(Message::from(body)).await.unwrap();
 
         match body {
@@ -662,11 +600,9 @@ cfg_not_wasm32! {
     }
 
     async fn artemis_retirement(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
 
         for &body in RETIREMENT_BODIES.iter() {
             let txn = Transaction::declare(&controller, None).await.unwrap();
@@ -679,17 +615,15 @@ cfg_not_wasm32! {
     }
 
     async fn artemis_owned_retirement(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
 
         for (index, &body) in RETIREMENT_BODIES.iter().enumerate() {
-            let txn = OwnedTransaction::declare(
+            let txn = common::expect_ok!(OwnedTransaction::declare(
                 &mut session,
                 format!("test-owned-controller-{}", index),
                 None,
-            )
-            .await
-            .unwrap();
+            )).await;
             artemis_retire_case(body, txn, &mut session).await;
         }
 
@@ -748,19 +682,13 @@ cfg_not_wasm32! {
         <T as TransactionDischarge>::Error: From<FlowError> + Debug,
         <T as TransactionRetirement>::RetireError: Debug,
     {
-        let mut seed_sender = Sender::attach(session, "test-seed-sender", queue)
-            .await
-            .unwrap();
+        let mut seed_sender = common::expect_ok!(Sender::attach(session, "test-seed-sender", queue)).await;
         seed_sender.send(Message::from(body)).await.unwrap();
-        let mut receiver = Receiver::attach(session, "test-receiver", queue)
-            .await
-            .unwrap();
+        let mut receiver = common::expect_ok!(Receiver::attach(session, "test-receiver", queue)).await;
 
         acquire_commit_and_verify(txn, &mut receiver, body).await;
 
-        let mut verify_receiver = Receiver::attach(session, "test-verify-receiver", queue)
-            .await
-            .unwrap();
+        let mut verify_receiver = common::expect_ok!(Receiver::attach(session, "test-verify-receiver", queue)).await;
         let result = timeout(
             Duration::from_secs(3),
             verify_receiver.recv::<String>(),
@@ -784,19 +712,13 @@ cfg_not_wasm32! {
         <T as TransactionDischarge>::Error: From<FlowError> + Debug,
         <T as TransactionRetirement>::RetireError: Debug,
     {
-        let mut seed_sender = Sender::attach(session, "test-seed-sender", queue)
-            .await
-            .unwrap();
+        let mut seed_sender = common::expect_ok!(Sender::attach(session, "test-seed-sender", queue)).await;
         seed_sender.send(Message::from(body)).await.unwrap();
-        let mut receiver = Receiver::attach(session, "test-receiver", queue)
-            .await
-            .unwrap();
+        let mut receiver = common::expect_ok!(Receiver::attach(session, "test-receiver", queue)).await;
 
         acquire_rollback_and_verify(txn, &mut receiver, body).await;
 
-        let mut verify_receiver = Receiver::attach(session, "test-verify-receiver", queue)
-            .await
-            .unwrap();
+        let mut verify_receiver = common::expect_ok!(Receiver::attach(session, "test-verify-receiver", queue)).await;
         let delivery = recv_string(&mut verify_receiver).await;
         assert_eq!(delivery.body(), body);
         verify_receiver.accept(&delivery).await.unwrap();
@@ -806,11 +728,9 @@ cfg_not_wasm32! {
     }
 
     async fn acquisition(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
-        let controller = Controller::attach(&mut session, "test-controller")
-            .await
-            .unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
+        let controller = common::expect_ok!(Controller::attach(&mut session, "test-controller")).await;
 
         let txn = Transaction::declare(&controller, None).await.unwrap();
         acquire_commit_case(txn, &mut session, "test-queue-acquire", "acquire-commit").await;
@@ -830,17 +750,13 @@ cfg_not_wasm32! {
     }
 
     async fn owned_acquisition(url: &str) {
-        let mut connection = Connection::open("test-connection", url).await.unwrap();
-        let mut session = Session::begin(&mut connection).await.unwrap();
+        let mut connection = common::expect_ok!(Connection::open("test-connection", url)).await;
+        let mut session = common::expect_ok!(Session::begin(&mut connection)).await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller-0", None)).await;
         acquire_commit_case(txn, &mut session, "test-queue-acquire", "acquire-commit").await;
 
-        let txn = OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)
-            .await
-            .unwrap();
+        let txn = common::expect_ok!(OwnedTransaction::declare(&mut session, "test-owned-controller-1", None)).await;
         acquire_rollback_case(
             txn,
             &mut session,


### PR DESCRIPTION
## What

A broker that accepts TCP but stalls the AMQP handshake (e.g. RabbitMQ while it is still booting) hangs the integration tests' setup operations until the CI job timeout. This PR:

1. **Waits for RabbitMQ to actually finish booting** before connecting (`WaitFor::message_on_either_std("Server startup complete")` instead of a fixed 10s).
2. **Bounds every AMQP setup operation** — connection open, session begin, and link attach (including `Controller::attach`, `OwnedTransaction::declare`, and link resume) — with a 60s `tokio::time::timeout` via a new `common::expect_ok!` macro. On timeout it panics with the exact expression text, e.g.:

   ```
   AMQP operation timed out after 60s: Connection::open("test-connection", "amqp://localhost:5672")
   ```

   The macro expands to a future so it can still be joined concurrently with the acceptor-side operation at the `tokio::join!` sites.

## Details

- `tests/common.rs` moved to `tests/common/mod.rs` so it is not auto-compiled as its own test binary.
- ~100 call sites across all 7 integration test binaries are wrapped.
- The 4 RabbitMQ tests fail fast on arm64 dev machines (the image is amd64-only and the Erlang BEAM segfaults under qemu emulation); they run natively on amd64 CI.