### PR TITLE
refactor: Handle remote detach in session loop

### DIFF
--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -31,6 +31,21 @@
 7. A send that wins the race against a concurrently arriving remote closing detach now
    fails with the detach outcome instead of consuming link-credit and writing a transfer
    the relay can no longer forward (the detach is polled before the credit).
+8. An in-flight receive or send reports the remote detach outcome (`RemoteClosed` /
+   `RemoteClosedWithError` / `RemoteDetached(WithError)`) when a real detach raced the
+   session or connection stop, instead of the stop reason dominating; the stop reason
+   surfaces through the channel closure and the subsequent operations.
+9. A non-closing remote detach that carries an error now surfaces as
+   `RemoteDetachedWithError` instead of losing the error.
+10. [`Sender::on_detach`] now transitions the link straight to its terminal state (`Closed`
+    / `Detached`, releasing the output handle) — the relay already answered the remote's
+    detach at arrival — so a subsequent `close()` completes cleanly instead of sending a
+    duplicate closing detach or failing with `DetachedByRemote`.
+11. Locally initiated detaches are only sent while the link's bookkeeping still exists: a
+    duplicate closing detach in the double-close race (both sides close concurrently and
+    the relay already answered the remote's detach) is suppressed by the session instead
+    of being sent to the peer and leaking a stale close-pending entry. All outgoing
+    detaches (engine-written and relay replies) now flow through the same outbound path.
 
 ## 0.17.0
 

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -14,6 +14,23 @@
    message-format, settled and rcv-settle-mode fields (previously a two-frame delivery
    could carry a delivery-tag on its last frame, which peers such as Qpid Broker-J
    reject).
+4. Remote-initiated link detach/close frames are now answered by the session relay at
+   arrival time; the link engine no longer writes the response. This fixes a hang when
+   the remote closes a link while the local engine is idle (waiting for link-credit or
+   not awaiting anything), and lets the peer's close handshake complete even when the
+   link endpoint was dropped.
+5. The sender's pending deliveries are now failed with `LinkStateError::RemoteClosed` /
+   `RemoteClosedWithError` when the remote closes the link with them still unsettled,
+   instead of leaving the delivery futures pending until the session tears down.
+6. Dropping a sender or receiver link without a clean close no longer emits a duplicate
+   closing detach when the remote's own detach has already been forwarded to (and
+   answered for) the link. Dropping a sender additionally fails the deliveries that can
+   no longer be settled by the peer (remote closed/detached first, or the session
+   stopped), while deliveries on a still-live link stay pending for the peer's
+   settlement, which the relay keeps applying.
+7. A send that wins the race against a concurrently arriving remote closing detach now
+   fails with the detach outcome instead of consuming link-credit and writing a transfer
+   the relay can no longer forward (the detach is polled before the credit).
 
 ## 0.17.0
 

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -594,7 +594,10 @@ impl endpoint::Session for ListenerSession {
         self.session.on_incoming_disposition(disposition)
     }
 
-    async fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::Error> {
+    async fn on_incoming_detach(
+        &mut self,
+        detach: Detach,
+    ) -> Result<Option<SessionFrame>, Self::Error> {
         self.session.on_incoming_detach(detach).await
     }
 

--- a/fe2o3-amqp/src/acceptor/session.rs
+++ b/fe2o3-amqp/src/acceptor/session.rs
@@ -475,7 +475,7 @@ impl endpoint::Session for ListenerSession {
         Ok(output_handle)
     }
 
-    fn deallocate_link(&mut self, output_handle: OutputHandle) {
+    fn deallocate_link(&mut self, output_handle: OutputHandle) -> bool {
         self.session.deallocate_link(output_handle)
     }
 
@@ -597,7 +597,7 @@ impl endpoint::Session for ListenerSession {
     async fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> Result<Option<SessionFrame>, Self::Error> {
+    ) -> Result<Option<Detach>, Self::Error> {
         self.session.on_incoming_detach(detach).await
     }
 
@@ -655,8 +655,8 @@ impl endpoint::Session for ListenerSession {
         self.session.on_outgoing_disposition(disposition)
     }
 
-    fn on_outgoing_detach(&mut self, detach: Detach) -> SessionFrame {
-        self.session.on_outgoing_detach(detach)
+    fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame> {
+        self.session.on_outgoing_detach(detach, expects_echo)
     }
 }
 

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -26,15 +26,14 @@ use super::{OutputHandle, Settlement};
 pub(crate) trait LinkDetach {
     type DetachError: Send;
 
-    /// Handle a detach frame that is the response to the engine's *own*
-    /// outgoing detach/close (the echo) during an engine-driven handshake
-    /// (`close`, `detach`, or the attach-error paths). The relay does not
-    /// respond to such frames; the engine consumes the echo and completes
-    /// the state transition here.
+    /// Handle a detach the peer sends in reply to a detach/close this link
+    /// sent itself (from `close()`, `detach()`, or the attach-error paths).
     ///
-    /// This is NOT the method for a detach the engine must answer itself
-    /// (the relay already answered any remote-initiated detach at arrival);
-    /// see [`LinkDetach::apply_remote_detach_outcome`] for that.
+    /// The relay forwards such a reply without answering it; the link's own
+    /// close/detach procedure consumes the frame and completes here. A
+    /// detach the peer sends on its own is answered by the relay already,
+    /// so the engine handles it with [`Self::apply_remote_detach_outcome`]
+    /// instead.
     fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::DetachError>;
 
     async fn send_detach(
@@ -44,29 +43,16 @@ pub(crate) trait LinkDetach {
         error: Option<Error>,
     ) -> Result<(), Self::DetachError>;
 
-    /// Apply the outcome of a remote detach/close whose response detach has
-    /// already been sent (by the relay), or that the engine will never send
-    /// (a detach frame drained by a drop path).
+    /// Record that the peer detached or closed the link when this link does
+    /// not need to reply: the peer acted on its own and the session relay
+    /// already sent the reply, or the link is being dropped. Nothing is
+    /// sent.
     ///
-    /// This method writes nothing to the wire. It must only be called when
-    /// the peer's detach has already been answered — for remote-initiated
-    /// detaches the relay sends the response at arrival time, and a drop
-    /// path drains frames whose response likewise already went out. Calling
-    /// it when the engine still owes the response would leave the peer's
-    /// close/detach handshake hanging.
-    ///
-    /// The link transitions **directly to the terminal state** — `Closed`
-    /// for a closing detach, `Detached` otherwise — and releases the output
-    /// handle. It never passes through the intermediate `CloseReceived` /
-    /// `DetachReceived` states: those record that the engine must reply with
-    /// a detach of its own, which is the engine-driven handshake's job (see
-    /// [`LinkDetach::on_incoming_detach`]), not this method's. The engine's
-    /// mid-handshake states `CloseSent` (closing detach) and `DetachSent`
-    /// (non-closing detach) are accepted so a drop-path drain can apply an
-    /// echo whose engine handshake never ran.
-    ///
-    /// The remote's error (if any) is reported as `RemoteClosedWithError` /
-    /// `RemoteDetachedWithError`.
+    /// The link becomes `Closed` or `Detached` and its output handle is
+    /// released, without the `CloseReceived` / `DetachReceived` states that
+    /// the engine uses while it still owes the peer a reply (see
+    /// [`Self::on_incoming_detach`]). An error on the detach is reported as
+    /// `RemoteClosedWithError` / `RemoteDetachedWithError`.
     fn apply_remote_detach_outcome(&mut self, detach: Detach) -> Result<(), Self::DetachError>;
 }
 

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -26,6 +26,15 @@ use super::{OutputHandle, Settlement};
 pub(crate) trait LinkDetach {
     type DetachError: Send;
 
+    /// Handle a detach frame that is the response to the engine's *own*
+    /// outgoing detach/close (the echo) during an engine-driven handshake
+    /// (`close`, `detach`, or the attach-error paths). The relay does not
+    /// respond to such frames; the engine consumes the echo and completes
+    /// the state transition here.
+    ///
+    /// This is NOT the method for a detach the engine must answer itself
+    /// (the relay already answered any remote-initiated detach at arrival);
+    /// see [`LinkDetach::apply_remote_detach_outcome`] for that.
     fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::DetachError>;
 
     async fn send_detach(
@@ -36,13 +45,28 @@ pub(crate) trait LinkDetach {
     ) -> Result<(), Self::DetachError>;
 
     /// Apply the outcome of a remote detach/close whose response detach has
-    /// already been sent (by the relay).
+    /// already been sent (by the relay), or that the engine will never send
+    /// (a detach frame drained by a drop path).
     ///
-    /// The link transitions straight to the terminal state that processing the
-    /// detach in the engine used to produce (`send_detach` followed by
-    /// `on_incoming_detach`), without writing anything to the wire: a closing
-    /// detach leaves the link `Closed` and a non-closing one leaves it
-    /// `Detached`; the output handle is released in both cases.
+    /// This method writes nothing to the wire. It must only be called when
+    /// the peer's detach has already been answered — for remote-initiated
+    /// detaches the relay sends the response at arrival time, and a drop
+    /// path drains frames whose response likewise already went out. Calling
+    /// it when the engine still owes the response would leave the peer's
+    /// close/detach handshake hanging.
+    ///
+    /// The link transitions **directly to the terminal state** — `Closed`
+    /// for a closing detach, `Detached` otherwise — and releases the output
+    /// handle. It never passes through the intermediate `CloseReceived` /
+    /// `DetachReceived` states: those record that the engine must reply with
+    /// a detach of its own, which is the engine-driven handshake's job (see
+    /// [`LinkDetach::on_incoming_detach`]), not this method's. The engine's
+    /// mid-handshake states `CloseSent` (closing detach) and `DetachSent`
+    /// (non-closing detach) are accepted so a drop-path drain can apply an
+    /// echo whose engine handshake never ran.
+    ///
+    /// The remote's error (if any) is reported as `RemoteClosedWithError` /
+    /// `RemoteDetachedWithError`.
     fn apply_remote_detach_outcome(&mut self, detach: Detach) -> Result<(), Self::DetachError>;
 }
 

--- a/fe2o3-amqp/src/endpoint/link.rs
+++ b/fe2o3-amqp/src/endpoint/link.rs
@@ -34,6 +34,16 @@ pub(crate) trait LinkDetach {
         closed: bool,
         error: Option<Error>,
     ) -> Result<(), Self::DetachError>;
+
+    /// Apply the outcome of a remote detach/close whose response detach has
+    /// already been sent (by the relay).
+    ///
+    /// The link transitions straight to the terminal state that processing the
+    /// detach in the engine used to produce (`send_detach` followed by
+    /// `on_incoming_detach`), without writing anything to the wire: a closing
+    /// detach leaves the link `Closed` and a non-closing one leaves it
+    /// `Detached`; the output handle is released in both cases.
+    fn apply_remote_detach_outcome(&mut self, detach: Detach) -> Result<(), Self::DetachError>;
 }
 
 pub(crate) trait LinkAttach {

--- a/fe2o3-amqp/src/endpoint/mod.rs
+++ b/fe2o3-amqp/src/endpoint/mod.rs
@@ -27,6 +27,8 @@ use fe2o3_amqp_types::{
 };
 use tokio::sync::oneshot;
 
+use crate::link::LinkStateError;
+
 mod connection;
 pub(crate) use self::connection::*;
 
@@ -147,6 +149,6 @@ pub(crate) enum Settlement {
     Settled(DeliveryTag),
     Unsettled {
         delivery_tag: DeliveryTag,
-        outcome: oneshot::Receiver<Option<DeliveryState>>,
+        outcome: oneshot::Receiver<Result<Option<DeliveryState>, LinkStateError>>,
     },
 }

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -99,10 +99,10 @@ pub(crate) trait Session {
         disposition: Disposition,
     ) -> Result<Option<Vec<Disposition>>, Self::Error>;
 
-    /// Handle an incoming detach, returning the response detach for the peer
-    /// (the relay's reply to a remote-initiated detach) when one is owed. The
-    /// response is not sent here: the engine routes it through
-    /// [`Session::on_outgoing_detach`] with `expects_echo = false`.
+    /// Handle an incoming detach. Returns the detach to send back when the
+    /// peer detached the link on its own, or `None` when it only answers a
+    /// detach the link sent itself. The reply is not sent here; the engine
+    /// sends it through [`Session::on_outgoing_detach`].
     fn on_incoming_detach(
         &mut self,
         detach: Detach,
@@ -145,15 +145,15 @@ pub(crate) trait Session {
         disposition: Disposition,
     ) -> Result<SessionFrame, Self::Error>;
 
-    /// Send a detach frame out, releasing the link's bookkeeping, and record
-    /// whether the peer's response detach is expected.
+    /// Send a detach frame out and release the link's bookkeeping.
     ///
-    /// `expects_echo` is true for a locally initiated detach (engine-written
-    /// close/detach/drop/attach-error): the output handle is recorded so an
-    /// incoming detach on the link can be recognized as the peer's echo. It
-    /// is false for the relay's reply to a remote-initiated detach, for which
-    /// the peer sends nothing back. Returns `None` when a locally initiated
-    /// detach is a duplicate (the link's bookkeeping is already gone because
-    /// the relay answered the remote's detach first); nothing is sent then.
+    /// Set `expects_echo` when the link sent the detach itself and is
+    /// waiting for the peer's answer: the output handle is recorded so that
+    /// answer can be recognized. Leave it unset when this detach answers a
+    /// detach the peer sent itself.
+    ///
+    /// Returns `None` when the link was already closed towards the peer:
+    /// both sides closed at the same time, the relay already answered the
+    /// peer's detach, and this detach would only repeat that answer.
     fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame>;
 }

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -57,7 +57,9 @@ pub(crate) trait Session {
         input_handle: InputHandle,
     ) -> Result<OutputHandle, Self::AllocError>;
 
-    fn deallocate_link(&mut self, output_handle: OutputHandle);
+    /// Release the link's bookkeeping (name and output handle). Returns
+    /// whether the bookkeeping was still present.
+    fn deallocate_link(&mut self, output_handle: OutputHandle) -> bool;
 
     fn on_incoming_begin(
         &mut self,
@@ -97,12 +99,14 @@ pub(crate) trait Session {
         disposition: Disposition,
     ) -> Result<Option<Vec<Disposition>>, Self::Error>;
 
-    /// Handle an incoming detach, returning the response detach frame to send
-    /// to the peer (e.g. the relay's reply to a remote-initiated detach).
+    /// Handle an incoming detach, returning the response detach for the peer
+    /// (the relay's reply to a remote-initiated detach) when one is owed. The
+    /// response is not sent here: the engine routes it through
+    /// [`Session::on_outgoing_detach`] with `expects_echo = false`.
     fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> impl Future<Output = Result<Option<SessionFrame>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<Detach>, Self::Error>> + Send;
 
     fn on_incoming_end(&mut self, channel: IncomingChannel, end: End)
         -> Result<(), Self::EndError>;
@@ -141,5 +145,15 @@ pub(crate) trait Session {
         disposition: Disposition,
     ) -> Result<SessionFrame, Self::Error>;
 
-    fn on_outgoing_detach(&mut self, detach: Detach) -> SessionFrame;
+    /// Send a detach frame out, releasing the link's bookkeeping, and record
+    /// whether the peer's response detach is expected.
+    ///
+    /// `expects_echo` is true for a locally initiated detach (engine-written
+    /// close/detach/drop/attach-error): the output handle is recorded so an
+    /// incoming detach on the link can be recognized as the peer's echo. It
+    /// is false for the relay's reply to a remote-initiated detach, for which
+    /// the peer sends nothing back. Returns `None` when a locally initiated
+    /// detach is a duplicate (the link's bookkeeping is already gone because
+    /// the relay answered the remote's detach first); nothing is sent then.
+    fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame>;
 }

--- a/fe2o3-amqp/src/endpoint/session.rs
+++ b/fe2o3-amqp/src/endpoint/session.rs
@@ -97,10 +97,12 @@ pub(crate) trait Session {
         disposition: Disposition,
     ) -> Result<Option<Vec<Disposition>>, Self::Error>;
 
+    /// Handle an incoming detach, returning the response detach frame to send
+    /// to the peer (e.g. the relay's reply to a remote-initiated detach).
     fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<SessionFrame>, Self::Error>> + Send;
 
     fn on_incoming_end(&mut self, channel: IncomingChannel, end: End)
         -> Result<(), Self::EndError>;

--- a/fe2o3-amqp/src/link/delivery.rs
+++ b/fe2o3-amqp/src/link/delivery.rs
@@ -303,7 +303,7 @@ pub(crate) struct UnsettledMessage {
     pub(crate) payload: Payload,
     pub(crate) state: Option<DeliveryState>,
     pub(crate) message_format: u32,
-    pub(crate) sender: oneshot::Sender<Option<DeliveryState>>,
+    pub(crate) sender: oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>,
 }
 
 impl UnsettledMessage {
@@ -311,7 +311,7 @@ impl UnsettledMessage {
         payload: Payload,
         state: Option<DeliveryState>,
         message_format: u32,
-        sender: oneshot::Sender<Option<DeliveryState>>,
+        sender: oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>,
     ) -> Self {
         Self {
             payload,
@@ -321,15 +321,25 @@ impl UnsettledMessage {
         }
     }
 
-    pub fn settle(self) -> Result<(), Option<DeliveryState>> {
-        self.sender.send(self.state)
+    pub fn settle(self) -> Result<(), Result<Option<DeliveryState>, LinkStateError>> {
+        self.sender.send(Ok(self.state))
     }
 
     pub fn settle_with_state(
         self,
         state: Option<DeliveryState>,
-    ) -> Result<(), Option<DeliveryState>> {
-        self.sender.send(state)
+    ) -> Result<(), Result<Option<DeliveryState>, LinkStateError>> {
+        self.sender.send(Ok(state))
+    }
+
+    /// Fail the pending settlement with a link-state error (e.g. the remote
+    /// closed the link while the delivery was still unsettled).
+    #[allow(dead_code)] // used by the relay's unsettled-map drain
+    pub fn fail(
+        self,
+        error: LinkStateError,
+    ) -> Result<(), Result<Option<DeliveryState>, LinkStateError>> {
+        self.sender.send(Err(error))
     }
 }
 
@@ -397,8 +407,9 @@ pub trait FromDeliveryState {
     fn from_delivery_state(state: DeliveryState) -> Self;
 }
 
-/// This trait defines how to interprete `tokio::sync::oneshot::error::RecvError`
-/// and a session-stop reason when the settlement channel dies
+/// This trait defines how to interprete `tokio::sync::oneshot::error::RecvError`,
+/// a session-stop reason, and a delivered link-state error when the settlement
+/// channel dies or is failed
 ///
 /// This is public for compatibility with rust versions <= 1.58.0
 pub trait FromDeliveryFailure {
@@ -407,6 +418,10 @@ pub trait FromDeliveryFailure {
 
     /// how to interprete a "the session (or its connection) stopped" failure
     fn from_session_stop_reason(reason: SessionStopReason) -> Self;
+
+    /// how to interprete a link-state error delivered through the settlement
+    /// channel (e.g. the remote closed the link while the delivery was pending)
+    fn from_link_state_error(error: LinkStateError) -> Self;
 }
 
 impl FromDeliveryFailure for SendResult {
@@ -418,6 +433,10 @@ impl FromDeliveryFailure for SendResult {
 
     fn from_session_stop_reason(reason: SessionStopReason) -> Self {
         Err(LinkStateError::SessionStopped(reason).into())
+    }
+
+    fn from_link_state_error(error: LinkStateError) -> Self {
+        Err(error.into())
     }
 }
 
@@ -476,8 +495,12 @@ where
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(result) => {
                         match result {
-                            Ok(Some(state)) => Poll::Ready(O::from_delivery_state(state)),
-                            Ok(None) => Poll::Ready(O::from_none()),
+                            Ok(Ok(Some(state))) => Poll::Ready(O::from_delivery_state(state)),
+                            Ok(Ok(None)) => Poll::Ready(O::from_none()),
+                            // A link-state error was delivered through the
+                            // channel (e.g. the remote closed the link while
+                            // the delivery was still pending)
+                            Ok(Err(error)) => Poll::Ready(O::from_link_state_error(error)),
                             Err(err) => {
                                 // If the sender is dropped, there is likely issues with the connection
                                 // or the session, and thus the error should propagate to the user.
@@ -612,6 +635,59 @@ mod tests {
 
         match fut.await {
             Err(SendError::LinkStateError(LinkStateError::IllegalState)) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_send_result_from_link_state_error() {
+        let result = <SendResult as FromDeliveryFailure>::from_link_state_error(
+            LinkStateError::RemoteClosed,
+        );
+        match result {
+            Err(SendError::LinkStateError(LinkStateError::RemoteClosed)) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
+
+        let error = definitions::Error::new(
+            definitions::ConnectionError::ConnectionForced,
+            Some("remote closed".to_string()),
+            None,
+        );
+        let result = <SendResult as FromDeliveryFailure>::from_link_state_error(
+            LinkStateError::RemoteClosedWithError(error.clone()),
+        );
+        match result {
+            Err(SendError::LinkStateError(LinkStateError::RemoteClosedWithError(actual))) => {
+                assert_eq!(actual, error);
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delivery_fut_link_state_error_delivered() {
+        use crate::endpoint::Settlement;
+        use tokio::sync::oneshot;
+
+        let (tx, rx) = oneshot::channel();
+        let settlement = Settlement::Unsettled {
+            delivery_tag: DeliveryTag::from(b"tag".to_vec()),
+            outcome: rx,
+        };
+        let fut = DeliveryFut::new(settlement, Arc::new(OnceLock::new()));
+
+        let error = definitions::Error::new(
+            definitions::ConnectionError::ConnectionForced,
+            Some("remote closed".to_string()),
+            None,
+        );
+        let _ = tx.send(Err(LinkStateError::RemoteClosedWithError(error.clone())));
+
+        match fut.await {
+            Err(SendError::LinkStateError(LinkStateError::RemoteClosedWithError(actual))) => {
+                assert_eq!(actual, error);
+            }
             other => panic!("unexpected result: {:?}", other),
         }
     }

--- a/fe2o3-amqp/src/link/delivery.rs
+++ b/fe2o3-amqp/src/link/delivery.rs
@@ -334,7 +334,6 @@ impl UnsettledMessage {
 
     /// Fail the pending settlement with a link-state error (e.g. the remote
     /// closed the link while the delivery was still unsettled).
-    #[allow(dead_code)] // used by the relay's unsettled-map drain
     pub fn fail(
         self,
         error: LinkStateError,

--- a/fe2o3-amqp/src/link/error.rs
+++ b/fe2o3-amqp/src/link/error.rs
@@ -453,7 +453,7 @@ impl<'a> TryFrom<&'a SenderAttachError> for definitions::Error {
 }
 
 /// Errors associated with link state
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum LinkStateError {
     /// ILlegal link state
     #[error("Illegal local state")]

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -514,6 +514,42 @@ where
             None => Err(DetachError::IllegalState),
         }
     }
+
+    fn apply_remote_detach_outcome(&mut self, detach: Detach) -> Result<(), Self::DetachError> {
+        match detach.closed {
+            true => match self.local_state {
+                LinkState::Attached
+                | LinkState::AttachSent
+                | LinkState::AttachReceived
+                | LinkState::IncompleteAttachExchanged
+                | LinkState::IncompleteAttachSent
+                | LinkState::IncompleteAttachReceived
+                | LinkState::CloseSent => {
+                    self.local_state = LinkState::Closed;
+                    let _ = self.output_handle.take();
+                    match detach.error {
+                        Some(error) => Err(DetachError::RemoteClosedWithError(error)),
+                        None => Ok(()),
+                    }
+                }
+                _ => Err(DetachError::IllegalState),
+            },
+            false => match self.local_state {
+                LinkState::Attached
+                | LinkState::AttachSent
+                | LinkState::AttachReceived
+                | LinkState::IncompleteAttachExchanged
+                | LinkState::IncompleteAttachSent
+                | LinkState::IncompleteAttachReceived
+                | LinkState::DetachSent => {
+                    self.local_state = LinkState::Detached;
+                    let _ = self.output_handle.take();
+                    Ok(())
+                }
+                _ => Err(DetachError::IllegalState),
+            },
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -801,20 +837,72 @@ impl LinkRelay<OutputHandle> {
         }
     }
 
-    /// This is cancel safe because it only .await on sending over `tokio::mpsc::Sender`
-    pub async fn on_incoming_detach(
+    /// Handle an incoming detach from the peer.
+    ///
+    /// The raw detach is always forwarded into the link engine's channel
+    /// (ignoring a forward failure, which only happens when the link endpoint
+    /// was dropped). If the detach is remote-initiated (`remote_initiated`),
+    /// the relay also sends the response detach (returned as `Some`) so the
+    /// peer's close handshake completes promptly, and for a closing detach on
+    /// a sender link, fails the pending unsettled deliveries. If the detach is
+    /// the response to our own detach/close, nothing is returned and the
+    /// engine's local handshake consumes the forwarded frame.
+    ///
+    /// This is cancel safe because it only `.await`s on sending over
+    /// `tokio::mpsc::Sender`.
+    pub(crate) async fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> Result<(), Box<mpsc::error::SendError<LinkFrame>>> {
+        remote_initiated: bool,
+    ) -> Option<Detach> {
+        let frame = LinkFrame::Detach(detach.clone());
         match self {
-            LinkRelay::Sender { tx, .. } => {
-                tx.send(LinkFrame::Detach(detach)).await.map_err(Box::new)?;
+            LinkRelay::Sender {
+                tx,
+                output_handle,
+                unsettled,
+                ..
+            } => {
+                // A send failure means the link endpoint was dropped; the
+                // response (if any) must still go out.
+                let _ = tx.send(frame).await;
+                if !remote_initiated {
+                    return None;
+                }
+
+                if detach.closed {
+                    if let Some(entries) = unsettled.write().take() {
+                        for (_, entry) in entries {
+                            let error = match detach.error.clone() {
+                                Some(error) => LinkStateError::RemoteClosedWithError(error),
+                                None => LinkStateError::RemoteClosed,
+                            };
+                            let _ = entry.fail(error);
+                        }
+                    }
+                }
+
+                Some(Detach {
+                    handle: output_handle.clone().into(),
+                    closed: detach.closed,
+                    error: detach.error.clone(),
+                })
             }
-            LinkRelay::Receiver { tx, .. } => {
-                tx.send(LinkFrame::Detach(detach)).await.map_err(Box::new)?;
+            LinkRelay::Receiver {
+                tx, output_handle, ..
+            } => {
+                let _ = tx.send(frame).await;
+                if !remote_initiated {
+                    return None;
+                }
+
+                Some(Detach {
+                    handle: output_handle.clone().into(),
+                    closed: detach.closed,
+                    error: detach.error.clone(),
+                })
             }
         }
-        Ok(())
     }
 }
 

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -865,21 +865,22 @@ impl LinkRelay<OutputHandle> {
             } => {
                 // A send failure means the link endpoint was dropped; the
                 // response (if any) must still go out.
-                let _ = tx.send(frame).await;
+                let forward_result = tx.send(frame).await;
+
                 if !remote_initiated {
+                    // The detach is the response to our own detach/close. The
+                    // link endpoint's local handshake consumes the forwarded
+                    // frame — unless the endpoint was dropped, in which case
+                    // the forward fails and nothing else would fail the
+                    // deliveries that are still pending on the closed link.
+                    if forward_result.is_err() && detach.closed {
+                        fail_pending_unsettled(unsettled, &detach);
+                    }
                     return None;
                 }
 
                 if detach.closed {
-                    if let Some(entries) = unsettled.write().take() {
-                        for (_, entry) in entries {
-                            let error = match detach.error.clone() {
-                                Some(error) => LinkStateError::RemoteClosedWithError(error),
-                                None => LinkStateError::RemoteClosed,
-                            };
-                            let _ = entry.fail(error);
-                        }
-                    }
+                    fail_pending_unsettled(unsettled, &detach);
                 }
 
                 Some(Detach {
@@ -902,6 +903,22 @@ impl LinkRelay<OutputHandle> {
                     error: detach.error.clone(),
                 })
             }
+        }
+    }
+}
+
+/// Fail the pending unsettled deliveries of a sender link.
+///
+/// The entries are `take()`n out of the shared map so the drain is exclusive:
+/// the link endpoint's drop path and the relay cannot fail an entry twice.
+fn fail_pending_unsettled(unsettled: &ArcSenderUnsettledMap, detach: &Detach) {
+    if let Some(entries) = unsettled.write().take() {
+        for (_, entry) in entries {
+            let error = match detach.error.clone() {
+                Some(error) => LinkStateError::RemoteClosedWithError(error),
+                None => LinkStateError::RemoteClosed,
+            };
+            let _ = entry.fail(error);
         }
     }
 }

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -407,15 +407,6 @@ where
 {
     type DetachError = DetachError;
 
-    /// Handle a detach frame that is the response to the engine's *own*
-    /// outgoing detach/close (the echo). The relay does not respond to such
-    /// frames — the engine's detach handshake (`close`/`detach`/attach-error
-    /// paths) consumes them and completes the state transition here.
-    ///
-    /// This is NOT the method for a detach the engine must answer itself (the
-    /// relay already answered any remote-initiated detach at arrival); see
-    /// [`endpoint::LinkDetach::apply_remote_detach_outcome`] for that.
-    /// Closing or not isn't taken care of here but outside.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::DetachError> {
         #[cfg(feature = "tracing")]
@@ -850,19 +841,16 @@ impl LinkRelay<OutputHandle> {
         }
     }
 
-    /// Handle an incoming detach from the peer.
+    /// Forward an incoming detach into the link engine's channel. A failure
+    /// to send only means the link endpoint was dropped.
     ///
-    /// The raw detach is always forwarded into the link engine's channel
-    /// (ignoring a forward failure, which only happens when the link endpoint
-    /// was dropped). If the detach is remote-initiated (`remote_initiated`),
-    /// the relay also sends the response detach (returned as `Some`) so the
-    /// peer's close handshake completes promptly, and for a closing detach on
-    /// a sender link, fails the pending unsettled deliveries. If the detach is
-    /// the response to our own detach/close, nothing is returned and the
-    /// engine's local handshake consumes the forwarded frame.
+    /// If the peer detached the link on its own, also returns the reply
+    /// detach for the session to send back, and fails the still-pending
+    /// deliveries when the detach closes the link. If the detach instead
+    /// answers one the link sent itself, returns `None`: the engine's own
+    /// close/detach procedure is waiting for it.
     ///
-    /// This is cancel safe because it only `.await`s on sending over
-    /// `tokio::mpsc::Sender`.
+    /// Cancel safe: only `.await`s on sending over `tokio::mpsc::Sender`.
     pub(crate) async fn on_incoming_detach(
         &mut self,
         detach: Detach,
@@ -920,10 +908,10 @@ impl LinkRelay<OutputHandle> {
     }
 }
 
-/// Fail the pending unsettled deliveries of a sender link.
+/// Fail the pending deliveries of a sender link.
 ///
-/// The entries are `take()`n out of the shared map so the drain is exclusive:
-/// the link endpoint's drop path and the relay cannot fail an entry twice.
+/// The entries are removed from the shared map before failing, so the link's
+/// drop path and the relay cannot fail the same delivery twice.
 fn fail_pending_unsettled(unsettled: &ArcSenderUnsettledMap, detach: &Detach) {
     if let Some(entries) = unsettled.write().take() {
         for (_, entry) in entries {

--- a/fe2o3-amqp/src/link/mod.rs
+++ b/fe2o3-amqp/src/link/mod.rs
@@ -407,7 +407,15 @@ where
 {
     type DetachError = DetachError;
 
-    /// Closing or not isn't taken care of here but outside
+    /// Handle a detach frame that is the response to the engine's *own*
+    /// outgoing detach/close (the echo). The relay does not respond to such
+    /// frames — the engine's detach handshake (`close`/`detach`/attach-error
+    /// paths) consumes them and completes the state transition here.
+    ///
+    /// This is NOT the method for a detach the engine must answer itself (the
+    /// relay already answered any remote-initiated detach at arrival); see
+    /// [`endpoint::LinkDetach::apply_remote_detach_outcome`] for that.
+    /// Closing or not isn't taken care of here but outside.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::DetachError> {
         #[cfg(feature = "tracing")]
@@ -515,6 +523,8 @@ where
         }
     }
 
+    /// See [`endpoint::LinkDetach::apply_remote_detach_outcome`] for the
+    /// documented contract of this method.
     fn apply_remote_detach_outcome(&mut self, detach: Detach) -> Result<(), Self::DetachError> {
         match detach.closed {
             true => match self.local_state {
@@ -544,7 +554,10 @@ where
                 | LinkState::DetachSent => {
                     self.local_state = LinkState::Detached;
                     let _ = self.output_handle.take();
-                    Ok(())
+                    match detach.error {
+                        Some(error) => Err(DetachError::RemoteDetachedWithError(error)),
+                        None => Ok(()),
+                    }
                 }
                 _ => Err(DetachError::IllegalState),
             },

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -836,6 +836,23 @@ pub(crate) struct ReceiverInner<L: endpoint::ReceiverLink> {
 
 impl<L: endpoint::ReceiverLink> Drop for ReceiverInner<L> {
     fn drop(&mut self) {
+        // A remote detach/close may already have been forwarded into the
+        // engine's channel by the relay (the relay replies to the peer on its
+        // own, without the engine). Apply the terminal outcome here so the
+        // link state is not left stale, and suppress the closing detach this
+        // drop would otherwise send: replying a second time to the remote's
+        // detach would be a duplicate.
+        while let Ok(frame) = self.incoming.try_recv() {
+            if let LinkFrame::Detach(detach) = frame {
+                // Applying the terminal outcome also releases the output
+                // handle, which suppresses the closing detach below.
+                let _ = self.link.apply_remote_detach_outcome(detach);
+            }
+            // Any other frame (e.g. a partially received transfer or an attach
+            // response left behind by an interrupted reattach) is superseded
+            // by the drop.
+        }
+
         if let Some(handle) = self.link.output_handle_mut().take() {
             let detach = Detach {
                 handle: handle.into(),

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -1017,11 +1017,19 @@ where
         };
 
         match frame {
+            // The response detach is handled by the relay; only the local
+            // outcome is applied here.
             LinkFrame::Detach(detach) => {
+                // If the session (or its connection) has already stopped, the
+                // stop reason dominates over a link-level detach frame.
+                if let Some(reason) = self.link().session_stop_reason().get() {
+                    return Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
+                        reason.clone(),
+                    )));
+                }
                 let closed = detach.closed;
-                self.link.send_detach(&self.outgoing, closed, None).await?; // cancel safe
                 self.link
-                    .on_incoming_detach(detach)
+                    .apply_remote_detach_outcome(detach)
                     .map_err(Into::into)
                     .and_then(|_| match closed {
                         true => Err(LinkStateError::RemoteClosed.into()),

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -845,7 +845,14 @@ impl<L: endpoint::ReceiverLink> Drop for ReceiverInner<L> {
         while let Ok(frame) = self.incoming.try_recv() {
             if let LinkFrame::Detach(detach) = frame {
                 remote_detach_received = true;
-                let _ = self.link.apply_remote_detach_outcome(detach);
+                // If the state change fails, ignore it: the engine is being
+                // dropped anyway.
+                if self.link.apply_remote_detach_outcome(detach).is_err() {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!("failed to apply remote detach outcome on receiver drop");
+                    #[cfg(feature = "log")]
+                    log::debug!("failed to apply remote detach outcome on receiver drop");
+                }
             }
             // Any other frame (e.g. a partially received transfer or an attach
             // response left behind by an interrupted reattach) is superseded

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -1040,15 +1040,12 @@ where
 
         match frame {
             // The response detach is handled by the relay; only the local
-            // outcome is applied here.
+            // outcome is applied here. A detach frame that reached the
+            // engine is a real link event and is reported as such even when
+            // the session (or its connection) is also stopping: the stop
+            // reason surfaces through the channel closure (the `None` case
+            // above) and the other link operations.
             LinkFrame::Detach(detach) => {
-                // If the session (or its connection) has already stopped, the
-                // stop reason dominates over a link-level detach frame.
-                if let Some(reason) = self.link().session_stop_reason().get() {
-                    return Err(RecvError::LinkStateError(LinkStateError::SessionStopped(
-                        reason.clone(),
-                    )));
-                }
                 let closed = detach.closed;
                 self.link
                     .apply_remote_detach_outcome(detach)

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -839,13 +839,16 @@ impl<L: endpoint::ReceiverLink> Drop for ReceiverInner<L> {
         // A remote detach/close may already have been forwarded into the
         // engine's channel by the relay (the relay replies to the peer on its
         // own, without the engine). Apply the terminal outcome here so the
-        // link state is not left stale, and suppress the closing detach this
-        // drop would otherwise send: replying a second time to the remote's
-        // detach would be a duplicate.
+        // link state is not left stale. Once any detach frame has been
+        // drained, the detach/close exchange with the peer is complete (the
+        // relay answered a remote-initiated detach at arrival; an echo
+        // answers the engine's own detach), so the closing detach this drop
+        // would otherwise send must be suppressed: replying a second time
+        // would be a duplicate.
+        let mut remote_detach_received = false;
         while let Ok(frame) = self.incoming.try_recv() {
             if let LinkFrame::Detach(detach) = frame {
-                // Applying the terminal outcome also releases the output
-                // handle, which suppresses the closing detach below.
+                remote_detach_received = true;
                 let _ = self.link.apply_remote_detach_outcome(detach);
             }
             // Any other frame (e.g. a partially received transfer or an attach
@@ -853,27 +856,29 @@ impl<L: endpoint::ReceiverLink> Drop for ReceiverInner<L> {
             // by the drop.
         }
 
-        if let Some(handle) = self.link.output_handle_mut().take() {
-            let detach = Detach {
-                handle: handle.into(),
-                closed: true,
-                error: None,
-            };
-            if let Err(_error) = self.outgoing.try_send(LinkFrame::Detach(detach)) {
-                #[cfg(any(feature = "log", feature = "tracing"))]
-                {
-                    let reason = match &_error {
-                        tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            "control channel is full"
-                        }
-                        tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                            "control channel is closed"
-                        }
-                    };
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(reason, "Failed to enqueue Detach frame on receiver drop");
-                    #[cfg(feature = "log")]
-                    log::warn!("Failed to enqueue Detach frame on receiver drop: {reason}");
+        if !remote_detach_received {
+            if let Some(handle) = self.link.output_handle_mut().take() {
+                let detach = Detach {
+                    handle: handle.into(),
+                    closed: true,
+                    error: None,
+                };
+                if let Err(_error) = self.outgoing.try_send(LinkFrame::Detach(detach)) {
+                    #[cfg(any(feature = "log", feature = "tracing"))]
+                    {
+                        let reason = match &_error {
+                            tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                                "control channel is full"
+                            }
+                            tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                                "control channel is closed"
+                            }
+                        };
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(reason, "Failed to enqueue Detach frame on receiver drop");
+                        #[cfg(feature = "log")]
+                        log::warn!("Failed to enqueue Detach frame on receiver drop: {reason}");
+                    }
                 }
             }
         }

--- a/fe2o3-amqp/src/link/receiver.rs
+++ b/fe2o3-amqp/src/link/receiver.rs
@@ -836,15 +836,11 @@ pub(crate) struct ReceiverInner<L: endpoint::ReceiverLink> {
 
 impl<L: endpoint::ReceiverLink> Drop for ReceiverInner<L> {
     fn drop(&mut self) {
-        // A remote detach/close may already have been forwarded into the
-        // engine's channel by the relay (the relay replies to the peer on its
-        // own, without the engine). Apply the terminal outcome here so the
-        // link state is not left stale. Once any detach frame has been
-        // drained, the detach/close exchange with the peer is complete (the
-        // relay answered a remote-initiated detach at arrival; an echo
-        // answers the engine's own detach), so the closing detach this drop
-        // would otherwise send must be suppressed: replying a second time
-        // would be a duplicate.
+        // A detach the relay already answered may be waiting in the engine's
+        // channel. Apply it so the link state matches the detach; and once
+        // any detach was drained, the peer has already ended the link, so
+        // the closing detach this drop would otherwise send would be a
+        // duplicate.
         let mut remote_detach_received = false;
         while let Ok(frame) = self.incoming.try_recv() {
             if let LinkFrame::Detach(detach) = frame {
@@ -1039,12 +1035,10 @@ where
         };
 
         match frame {
-            // The response detach is handled by the relay; only the local
-            // outcome is applied here. A detach frame that reached the
-            // engine is a real link event and is reported as such even when
-            // the session (or its connection) is also stopping: the stop
-            // reason surfaces through the channel closure (the `None` case
-            // above) and the other link operations.
+            // The relay already sent the reply to this peer detach; the link
+            // records the outcome here. Reported as-is even when the session
+            // is stopping: a stop without a detach shows up as the channel
+            // closing (`None` above).
             LinkFrame::Detach(detach) => {
                 let closed = detach.closed;
                 self.link

--- a/fe2o3-amqp/src/link/resumption.rs
+++ b/fe2o3-amqp/src/link/resumption.rs
@@ -6,12 +6,12 @@ use tokio::sync::oneshot;
 
 use crate::Payload;
 
-use super::{delivery::UnsettledMessage, receiver_link::is_section_header};
+use super::{delivery::UnsettledMessage, error::LinkStateError, receiver_link::is_section_header};
 
 pub(crate) enum ResumingDelivery {
     Abort {
         message_format: MessageFormat,
-        sender: Option<oneshot::Sender<Option<DeliveryState>>>,
+        sender: Option<oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>>,
     },
     Resend(UnsettledMessage),
     Resume(UnsettledMessage),
@@ -19,7 +19,7 @@ pub(crate) enum ResumingDelivery {
         payload: Payload,
         local_state: DeliveryState,
         message_format: MessageFormat,
-        sender: oneshot::Sender<Option<DeliveryState>>,
+        sender: oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>,
     },
 }
 

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -492,7 +492,10 @@ impl Sender {
 /// This is so that the transaction controller can re-use
 /// the sender
 #[derive(Debug)]
-pub(crate) struct SenderInner<L: endpoint::SenderLink> {
+pub(crate) struct SenderInner<L>
+where
+    L: endpoint::SenderLink + LinkExt<Unsettled = ArcSenderUnsettledMap>,
+{
     // The SenderLink manages the state
     pub(crate) link: L,
     pub(crate) buffer_size: usize,
@@ -505,29 +508,88 @@ pub(crate) struct SenderInner<L: endpoint::SenderLink> {
     pub(crate) incoming: mpsc::Receiver<LinkFrame>,
 }
 
-impl<L: endpoint::SenderLink> Drop for SenderInner<L> {
+impl<L> Drop for SenderInner<L>
+where
+    L: endpoint::SenderLink + LinkExt<Unsettled = ArcSenderUnsettledMap>,
+{
     fn drop(&mut self) {
+        // A remote detach/close may already have been forwarded into the
+        // engine's channel by the relay (the relay replies to the peer on its
+        // own, without the engine). Apply the terminal outcome here so the
+        // link state is not left stale, and suppress the closing detach this
+        // drop would otherwise send: replying a second time to the remote's
+        // detach would be a duplicate.
+        let mut detach_error: Option<LinkStateError> = None;
+        while let Ok(frame) = self.incoming.try_recv() {
+            if let LinkFrame::Detach(detach) = frame {
+                let closed = detach.closed;
+                let error = detach.error.clone();
+                // Applying the terminal outcome also releases the output
+                // handle, which suppresses the closing detach below.
+                if self.link.apply_remote_detach_outcome(detach).is_ok() {
+                    detach_error = Some(match (closed, error) {
+                        (true, Some(error)) => LinkStateError::RemoteClosedWithError(error),
+                        (true, None) => LinkStateError::RemoteClosed,
+                        (false, Some(error)) => LinkStateError::RemoteDetachedWithError(error),
+                        (false, None) => LinkStateError::RemoteDetached,
+                    });
+                }
+            }
+            // Any other frame (e.g. an attach response left behind by an
+            // interrupted reattach) is superseded by the drop.
+        }
+
+        // Whether the peer can still be reached with a closing detach
+        let mut detach_sent = false;
         if let Some(handle) = self.link.output_handle_mut().take() {
             let detach = Detach {
                 handle: handle.into(),
                 closed: true,
                 error: None,
             };
-            if let Err(_error) = self.outgoing.try_send(LinkFrame::Detach(detach)) {
-                #[cfg(any(feature = "log", feature = "tracing"))]
-                {
-                    let reason = match &_error {
-                        tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            "control channel is full"
-                        }
-                        tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                            "control channel is closed"
-                        }
-                    };
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(reason, "Failed to enqueue Detach frame on sender drop");
-                    #[cfg(feature = "log")]
-                    log::warn!("Failed to enqueue Detach frame on sender drop: {reason}");
+            match self.outgoing.try_send(LinkFrame::Detach(detach)) {
+                Ok(()) => detach_sent = true,
+                Err(_error) => {
+                    #[cfg(any(feature = "log", feature = "tracing"))]
+                    {
+                        let reason = match &_error {
+                            tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                                "control channel is full"
+                            }
+                            tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                                "control channel is closed"
+                            }
+                        };
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(reason, "Failed to enqueue Detach frame on sender drop");
+                        #[cfg(feature = "log")]
+                        log::warn!("Failed to enqueue Detach frame on sender drop: {reason}");
+                    }
+                }
+            }
+        }
+
+        // Fail the outstanding deliveries that can no longer be settled by the
+        // peer: the remote closed/detached the link first (the relay may have
+        // already failed them; `take()` makes the drain exclusive), or the
+        // session (or its connection) stopped so the closing detach could not
+        // even be enqueued. Deliveries that are still pending on a live link
+        // are left alone: the relay keeps settling them from the peer's
+        // dispositions.
+        let error = detach_error.or_else(|| {
+            if detach_sent {
+                None
+            } else {
+                match self.link.session_stop_reason().get() {
+                    Some(reason) => Some(LinkStateError::SessionStopped(reason.clone())),
+                    None => Some(LinkStateError::IllegalState), // defensive: no stop reason recorded; failure is link-local
+                }
+            }
+        });
+        if let Some(error) = error {
+            if let Some(entries) = self.link.unsettled().write().take() {
+                for (_, entry) in entries {
+                    let _ = entry.fail(error.clone());
                 }
             }
         }

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -469,11 +469,16 @@ impl Sender {
     }
 
     /// Returns when the remote peer detach/close the link
+    ///
+    /// The relay has already answered a remote-initiated detach at arrival,
+    /// so the link transitions directly to its terminal state (`Closed` /
+    /// `Detached`, releasing the output handle); a subsequent `close()`
+    /// completes without writing another detach.
     pub async fn on_detach(&mut self) -> DetachError {
         match recv_remote_detach(&mut self.inner).await {
             Ok(detach) => {
                 let closed = detach.closed;
-                match self.inner.link.on_incoming_detach(detach) {
+                match self.inner.link.apply_remote_detach_outcome(detach) {
                     Ok(_) => {
                         if closed {
                             DetachError::ClosedByRemote

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -799,7 +799,7 @@ impl SenderInner<SenderLink<Target>> {
         &mut self,
         delivery_tag: DeliveryTag,
         message_format: MessageFormat,
-        sender: Option<oneshot::Sender<Option<DeliveryState>>>,
+        sender: Option<oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>>,
     ) -> Result<(), SendError> {
         let handle = self
             .link
@@ -834,7 +834,7 @@ impl SenderInner<SenderLink<Target>> {
         match settled {
             true => {
                 if let Some(sender) = sender {
-                    let _ = sender.send(None);
+                    let _ = sender.send(Ok(None));
                 }
             }
             false => {
@@ -910,7 +910,7 @@ impl SenderInner<SenderLink<Target>> {
         message_format: MessageFormat,
         state: DeliveryState,
         payload: Payload,
-        sender: oneshot::Sender<Option<DeliveryState>>,
+        sender: oneshot::Sender<Result<Option<DeliveryState>, LinkStateError>>,
     ) -> Result<(), SendError> {
         let handle = self
             .link
@@ -943,7 +943,7 @@ impl SenderInner<SenderLink<Target>> {
 
         match settled {
             true => {
-                let _ = sender.send(None);
+                let _ = sender.send(Ok(None));
             }
             false => {
                 let unsettled = UnsettledMessage::new(payload, None, message_format, sender);

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -959,10 +959,7 @@ impl SenderInner<SenderLink<Target>> {
 
     async fn resend(&mut self, unsettled_message: UnsettledMessage) -> Result<(), SendError> {
         let detached_fut = self.incoming.recv();
-        let tag = self
-            .link
-            .get_delivery_tag_or_detached(&self.outgoing, detached_fut)
-            .await?;
+        let tag = self.link.get_delivery_tag_or_detached(detached_fut).await?;
         let new_delivery_tag = DeliveryTag::from(tag);
         let transfer = self.link.generate_non_resuming_transfer_performative(
             new_delivery_tag.clone(),

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -470,10 +470,9 @@ impl Sender {
 
     /// Returns when the remote peer detach/close the link
     ///
-    /// The relay has already answered a remote-initiated detach at arrival,
-    /// so the link transitions directly to its terminal state (`Closed` /
-    /// `Detached`, releasing the output handle); a subsequent `close()`
-    /// completes without writing another detach.
+    /// The peer's detach has already been answered when this returns, so the
+    /// link is left `Closed` or `Detached` (its output handle is released),
+    /// and a later `close()` finishes without sending another detach.
     pub async fn on_detach(&mut self) -> DetachError {
         match recv_remote_detach(&mut self.inner).await {
             Ok(detach) => {
@@ -518,15 +517,11 @@ where
     L: endpoint::SenderLink + LinkExt<Unsettled = ArcSenderUnsettledMap>,
 {
     fn drop(&mut self) {
-        // A remote detach/close may already have been forwarded into the
-        // engine's channel by the relay (the relay replies to the peer on its
-        // own, without the engine). Apply the terminal outcome here so the
-        // link state is not left stale. Once any detach frame has been
-        // drained, the detach/close exchange with the peer is complete (the
-        // relay answered a remote-initiated detach at arrival; an echo
-        // answers the engine's own detach), so the closing detach this drop
-        // would otherwise send must be suppressed: replying a second time
-        // would be a duplicate.
+        // A detach the relay already answered may be waiting in the engine's
+        // channel. Apply it so the link state matches the detach; and once
+        // any detach was drained, the peer has already ended the link, so
+        // the closing detach this drop would otherwise send would be a
+        // duplicate.
         let mut remote_detach_received = false;
         let mut detach_error: Option<LinkStateError> = None;
         while let Ok(frame) = self.incoming.try_recv() {
@@ -534,9 +529,9 @@ where
                 remote_detach_received = true;
                 let closed = detach.closed;
                 let error = detach.error.clone();
-                // The state transition may fail on a stale state, but the
-                // engine is being dropped either way; only the wire event
-                // decides the fate of the pending deliveries below.
+                // If the state change fails, ignore it: the engine is being
+                // dropped anyway, and the deliveries below are failed from
+                // the detach itself.
                 if self.link.apply_remote_detach_outcome(detach).is_err() {
                     #[cfg(feature = "tracing")]
                     tracing::debug!("failed to apply remote detach outcome on sender drop");
@@ -586,13 +581,12 @@ where
             }
         }
 
-        // Fail the outstanding deliveries that can no longer be settled by the
-        // peer: the remote closed/detached the link first (the relay may have
-        // already failed them; `take()` makes the drain exclusive), or the
-        // session (or its connection) stopped so the closing detach could not
-        // even be enqueued. Deliveries that are still pending on a live link
-        // are left alone: the relay keeps settling them from the peer's
-        // dispositions.
+        // Fail the deliveries that can no longer be settled: the peer closed
+        // or detached the link without settling them (the entries are
+        // removed first, so each is failed once, even if the relay already
+        // failed it), or the session stopped so the closing detach could not
+        // be sent. Deliveries on a still-open link stay pending: the relay
+        // settles them as the peer's dispositions arrive.
         let error = detach_error.or_else(|| {
             if detach_sent {
                 None

--- a/fe2o3-amqp/src/link/sender.rs
+++ b/fe2o3-amqp/src/link/sender.rs
@@ -516,24 +516,34 @@ where
         // A remote detach/close may already have been forwarded into the
         // engine's channel by the relay (the relay replies to the peer on its
         // own, without the engine). Apply the terminal outcome here so the
-        // link state is not left stale, and suppress the closing detach this
-        // drop would otherwise send: replying a second time to the remote's
-        // detach would be a duplicate.
+        // link state is not left stale. Once any detach frame has been
+        // drained, the detach/close exchange with the peer is complete (the
+        // relay answered a remote-initiated detach at arrival; an echo
+        // answers the engine's own detach), so the closing detach this drop
+        // would otherwise send must be suppressed: replying a second time
+        // would be a duplicate.
+        let mut remote_detach_received = false;
         let mut detach_error: Option<LinkStateError> = None;
         while let Ok(frame) = self.incoming.try_recv() {
             if let LinkFrame::Detach(detach) = frame {
+                remote_detach_received = true;
                 let closed = detach.closed;
                 let error = detach.error.clone();
-                // Applying the terminal outcome also releases the output
-                // handle, which suppresses the closing detach below.
-                if self.link.apply_remote_detach_outcome(detach).is_ok() {
-                    detach_error = Some(match (closed, error) {
-                        (true, Some(error)) => LinkStateError::RemoteClosedWithError(error),
-                        (true, None) => LinkStateError::RemoteClosed,
-                        (false, Some(error)) => LinkStateError::RemoteDetachedWithError(error),
-                        (false, None) => LinkStateError::RemoteDetached,
-                    });
+                // The state transition may fail on a stale state, but the
+                // engine is being dropped either way; only the wire event
+                // decides the fate of the pending deliveries below.
+                if self.link.apply_remote_detach_outcome(detach).is_err() {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!("failed to apply remote detach outcome on sender drop");
+                    #[cfg(feature = "log")]
+                    log::debug!("failed to apply remote detach outcome on sender drop");
                 }
+                detach_error = Some(match (closed, error) {
+                    (true, Some(error)) => LinkStateError::RemoteClosedWithError(error),
+                    (true, None) => LinkStateError::RemoteClosed,
+                    (false, Some(error)) => LinkStateError::RemoteDetachedWithError(error),
+                    (false, None) => LinkStateError::RemoteDetached,
+                });
             }
             // Any other frame (e.g. an attach response left behind by an
             // interrupted reattach) is superseded by the drop.
@@ -541,29 +551,31 @@ where
 
         // Whether the peer can still be reached with a closing detach
         let mut detach_sent = false;
-        if let Some(handle) = self.link.output_handle_mut().take() {
-            let detach = Detach {
-                handle: handle.into(),
-                closed: true,
-                error: None,
-            };
-            match self.outgoing.try_send(LinkFrame::Detach(detach)) {
-                Ok(()) => detach_sent = true,
-                Err(_error) => {
-                    #[cfg(any(feature = "log", feature = "tracing"))]
-                    {
-                        let reason = match &_error {
-                            tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                                "control channel is full"
-                            }
-                            tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                                "control channel is closed"
-                            }
-                        };
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(reason, "Failed to enqueue Detach frame on sender drop");
-                        #[cfg(feature = "log")]
-                        log::warn!("Failed to enqueue Detach frame on sender drop: {reason}");
+        if !remote_detach_received {
+            if let Some(handle) = self.link.output_handle_mut().take() {
+                let detach = Detach {
+                    handle: handle.into(),
+                    closed: true,
+                    error: None,
+                };
+                match self.outgoing.try_send(LinkFrame::Detach(detach)) {
+                    Ok(()) => detach_sent = true,
+                    Err(_error) => {
+                        #[cfg(any(feature = "log", feature = "tracing"))]
+                        {
+                            let reason = match &_error {
+                                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                                    "control channel is full"
+                                }
+                                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                                    "control channel is closed"
+                                }
+                            };
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(reason, "Failed to enqueue Detach frame on sender drop");
+                            #[cfg(feature = "log")]
+                            log::warn!("Failed to enqueue Detach frame on sender drop: {reason}");
+                        }
                     }
                 }
             }

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -155,15 +155,11 @@ where
             biased;
             frame = detached => { // cancel safe
                 match frame {
-                    // If remote has detached the link. The response detach is
-                    // handled by the relay; only the local outcome is applied
-                    // here.
+                    // The relay already sent the reply to this peer detach;
+                    // the link records the outcome here. Reported as-is even
+                    // when the session is stopping: a stop without a detach
+                    // shows up as the channel closing (`None` below).
                     Some(LinkFrame::Detach(detach)) => {
-                        // A detach frame that reached the engine is a real
-                        // link event and is reported as such even when the
-                        // session (or its connection) is also stopping: the
-                        // stop reason surfaces through the channel closure
-                        // (the `None` case below) and the other operations.
                         let closed = detach.closed;
                         let result = self.apply_remote_detach_outcome(detach);
 

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -146,16 +146,13 @@ where
     {
         use crate::util::Consume;
 
+        // The detach branch is polled first so that a remote detach that has
+        // already arrived is observed before a concurrently granted link-credit
+        // is consumed. Otherwise a send could race the remote closing the link,
+        // consuming credit and writing a transfer the relay can no longer
+        // forward.
         tokio::select! {
-            tag = self.flow_state.consume(1) => {
-                // link-credit is defined as
-                // "The current maximum number of messages that can be handled
-                // at the receiver endpoint of the link"
-
-                // Draining should already set the link credit to 0, causing
-                // sender to wait for new link credit
-                Ok(tag)
-            },
+            biased;
             frame = detached => { // cancel safe
                 match frame {
                     // If remote has detached the link. The response detach is
@@ -195,6 +192,15 @@ where
                         }
                     }
                 }
+            },
+            tag = self.flow_state.consume(1) => {
+                // link-credit is defined as
+                // "The current maximum number of messages that can be handled
+                // at the receiver endpoint of the link"
+
+                // Draining should already set the link credit to 0, causing
+                // sender to wait for new link credit
+                Ok(tag)
             }
         }
     }

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -139,7 +139,6 @@ where
 
     pub(crate) async fn get_delivery_tag_or_detached<Fut>(
         &mut self,
-        writer: &mpsc::Sender<LinkFrame>,
         detached: Fut,
     ) -> Result<[u8; 4], LinkStateError>
     where
@@ -159,13 +158,18 @@ where
             },
             frame = detached => { // cancel safe
                 match frame {
-                    // If remote has detached the link
+                    // If remote has detached the link. The response detach is
+                    // handled by the relay; only the local outcome is applied
+                    // here.
                     Some(LinkFrame::Detach(detach)) => {
-                        // FIXME: if the sender is not trying to send anything, this is
-                        // probably not responsive enough
+                        // If the session (or its connection) has already
+                        // stopped, the stop reason dominates over a link-level
+                        // detach frame.
+                        if let Some(reason) = self.session_stop_reason.get() {
+                            return Err(LinkStateError::SessionStopped(reason.clone()));
+                        }
                         let closed = detach.closed;
-                        self.send_detach(writer, closed, None).await?;
-                        let result = self.on_incoming_detach(detach);
+                        let result = self.apply_remote_detach_outcome(detach);
 
                         match (result, closed) {
                             (Ok(_), true) => Err(LinkStateError::RemoteClosed),
@@ -267,7 +271,7 @@ where
     where
         Fut: Future<Output = Option<LinkFrame>> + Send,
     {
-        let tag = self.get_delivery_tag_or_detached(writer, detached).await?;
+        let tag = self.get_delivery_tag_or_detached(detached).await?;
         // Delivery count is incremented when consuming credit
         let delivery_tag = DeliveryTag::from(tag);
 

--- a/fe2o3-amqp/src/link/sender_link.rs
+++ b/fe2o3-amqp/src/link/sender_link.rs
@@ -159,12 +159,11 @@ where
                     // handled by the relay; only the local outcome is applied
                     // here.
                     Some(LinkFrame::Detach(detach)) => {
-                        // If the session (or its connection) has already
-                        // stopped, the stop reason dominates over a link-level
-                        // detach frame.
-                        if let Some(reason) = self.session_stop_reason.get() {
-                            return Err(LinkStateError::SessionStopped(reason.clone()));
-                        }
+                        // A detach frame that reached the engine is a real
+                        // link event and is reported as such even when the
+                        // session (or its connection) is also stopping: the
+                        // stop reason surfaces through the channel closure
+                        // (the `None` case below) and the other operations.
                         let closed = detach.closed;
                         let result = self.apply_remote_detach_outcome(detach);
 

--- a/fe2o3-amqp/src/session/builder.rs
+++ b/fe2o3-amqp/src/session/builder.rs
@@ -1,6 +1,6 @@
 //! Session builder
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, OnceLock};
 
 use fe2o3_amqp_types::definitions::{Fields, Handle, TransferNumber};
@@ -125,6 +125,7 @@ cfg_transaction! {
                     link_name_by_output_handle: Slab::new(),
                     link_by_name: HashMap::new(),
                     link_by_input_handle: HashMap::new(),
+                    close_pending: HashSet::new(),
                     delivery_tag_by_id: HashMap::new(),
                 };
 
@@ -174,6 +175,7 @@ impl Builder {
             link_name_by_output_handle: Slab::new(),
             link_by_name: HashMap::new(),
             link_by_input_handle: HashMap::new(),
+            close_pending: HashSet::new(),
             delivery_tag_by_id: HashMap::new(),
         }
     }

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -243,14 +243,18 @@ where
                 }
             }
             SessionFrameBody::Detach(detach) => {
-                // A remote-initiated detach is answered by the relay: the
-                // returned frame is the response detach to send to the peer.
-                if let Some(frame) = self.session.on_incoming_detach(detach).await? {
-                    self.outgoing.send(frame).await.map_err(|_| {
-                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
-                            self.session.connection_stop_reason(),
-                        ))
-                    })?;
+                // A remote-initiated detach is answered by the relay. The
+                // response flows out through the same outbound path as a
+                // locally initiated detach, without expecting a further echo
+                // from the peer.
+                if let Some(detach) = self.session.on_incoming_detach(detach).await? {
+                    if let Some(frame) = self.session.on_outgoing_detach(detach, false) {
+                        self.outgoing.send(frame).await.map_err(|_| {
+                            SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                                self.session.connection_stop_reason(),
+                            ))
+                        })?;
+                    }
                 }
             }
             SessionFrameBody::End(end) => {
@@ -432,9 +436,10 @@ where
                 .on_outgoing_disposition(disposition)
                 .map(SessionOutgoingItem::SingleFrame)
                 .map(Some)?,
-            LinkFrame::Detach(detach) => Some(SessionOutgoingItem::SingleFrame(
-                self.session.on_outgoing_detach(detach),
-            )),
+            LinkFrame::Detach(detach) => self
+                .session
+                .on_outgoing_detach(detach, true)
+                .map(SessionOutgoingItem::SingleFrame),
 
             #[cfg(feature = "transaction")]
             LinkFrame::Acquisition(_) => {

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -243,10 +243,9 @@ where
                 }
             }
             SessionFrameBody::Detach(detach) => {
-                // A remote-initiated detach is answered by the relay. The
-                // response flows out through the same outbound path as a
-                // locally initiated detach, without expecting a further echo
-                // from the peer.
+                // If the peer detached the link on its own, the relay has a
+                // reply to send back. The reply goes out through the same
+                // path as any other detach, and no answer is expected for it.
                 if let Some(detach) = self.session.on_incoming_detach(detach).await? {
                     if let Some(frame) = self.session.on_outgoing_detach(detach, false) {
                         self.outgoing.send(frame).await.map_err(|_| {

--- a/fe2o3-amqp/src/session/engine.rs
+++ b/fe2o3-amqp/src/session/engine.rs
@@ -243,7 +243,15 @@ where
                 }
             }
             SessionFrameBody::Detach(detach) => {
-                self.session.on_incoming_detach(detach).await?;
+                // A remote-initiated detach is answered by the relay: the
+                // returned frame is the response detach to send to the peer.
+                if let Some(frame) = self.session.on_incoming_detach(detach).await? {
+                    self.outgoing.send(frame).await.map_err(|_| {
+                        SessionInnerError::ConnectionStopped(connection_stop_reason_or_closed(
+                            self.session.connection_stop_reason(),
+                        ))
+                    })?;
+                }
             }
             SessionFrameBody::End(end) => {
                 let end_error = end.error.clone();

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -365,8 +365,8 @@ pub struct Session {
     pub(crate) link_name_by_output_handle: Slab<String>,
     pub(crate) link_by_name: HashMap<String, Option<LinkRelay<OutputHandle>>>,
     pub(crate) link_by_input_handle: HashMap<InputHandle, LinkRelay<OutputHandle>>,
-    // Output handles of links with an in-flight locally initiated
-    // detach/close, awaiting the peer's response detach
+    // Output handles of links whose own detach/close has been sent and is
+    // still awaiting the peer's answer
     pub(crate) close_pending: HashSet<OutputHandle>,
     // Maps from DeliveryId to link.DeliveryCount
     pub(crate) delivery_tag_by_id: HashMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
@@ -901,27 +901,26 @@ impl endpoint::Session for Session {
                     LinkRelay::Sender { output_handle, .. }
                     | LinkRelay::Receiver { output_handle, .. } => output_handle.clone(),
                 };
-                // An incoming detach is the response to our own detach/close iff
-                // we have an in-flight locally initiated detach on the link.
+                // If the link is in `close_pending`, this detach answers the
+                // one the link sent itself; otherwise the peer detached the
+                // link on its own.
                 let remote_initiated = !self.close_pending.remove(&output_handle);
 
-                // The relay forwards the raw detach into the link engine and,
-                // for a remote-initiated detach, returns the response detach to
-                // send to the peer. The response flows out through
-                // `on_outgoing_detach` (with `expects_echo = false`), which
-                // releases the link bookkeeping.
+                // Forward the detach into the link engine. If the peer
+                // detached the link on its own, the relay returns the reply
+                // detach; it is sent out via `on_outgoing_detach` (see the
+                // trait doc), which releases the link bookkeeping.
                 let response = link.on_incoming_detach(detach, remote_initiated).await;
 
                 Ok(response)
             }
             None => {
-                // The link is no longer registered. This can happen when both
-                // sides close the link concurrently and our response to the
-                // remote's first detach has already removed the link, yet the
-                // remote still processes the detach we sent for our own
-                // locally initiated close and echoes a detach back. The second
-                // detach is for a handle that is already gone, so it is
-                // dropped rather than tearing down the session.
+                // The link is no longer registered: both sides closed it at
+                // the same time, our reply to the peer's first detach removed
+                // it, and the peer then answered the detach we sent for our
+                // own close. That second detach is for a handle that no
+                // longer exists, so it is dropped instead of ending the
+                // session.
                 #[cfg(feature = "tracing")]
                 tracing::trace!(frame = ?detach, "incoming detach for an unattached handle is ignored");
                 #[cfg(feature = "log")]
@@ -1155,32 +1154,19 @@ impl endpoint::Session for Session {
         Ok(frame)
     }
 
-    /// The single outbound path for detach frames.
-    ///
-    /// The link bookkeeping (name and output handle) is released here for
-    /// both a locally initiated detach and the relay's reply to a
-    /// remote-initiated detach.
-    ///
-    /// `expects_echo` marks a locally initiated detach (engine-written
-    /// close/detach/drop/attach-error): the peer's response detach is
-    /// expected, so the output handle is recorded in `close_pending` to
-    /// recognize the echo. The relay's reply passes `false` — the peer sends
-    /// nothing back, and recording an entry it could never remove would let a
-    /// later detach on a recycled handle be misclassified as our own echo,
-    /// silencing the relay on a genuine peer close.
-    ///
-    /// Returns `None` (nothing is sent) when a locally initiated detach is a
-    /// duplicate: the bookkeeping is already gone because the relay answered
-    /// the remote's detach first, in which case the engine's own handshake
-    /// completes locally on the forwarded remote detach.
+    /// The single outbound path for detach frames (see the trait doc).
     fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame> {
         let deallocated = self.deallocate_link(detach.handle.clone().into());
         if expects_echo {
+            // Only a detach the link sent itself will be answered by the
+            // peer. An entry for any other detach would stay stale and could
+            // make a later detach on a reused handle look like it is waiting
+            // for an answer.
             if !deallocated {
-                // A duplicate locally initiated detach: the relay already
-                // answered the remote-initiated detach for this link, so the
-                // engine's own close/detach handshake completes locally on the
-                // forwarded detach and nothing more is sent to the peer.
+                // Both sides closed at the same time: the relay already sent
+                // the closing detach for this link, so this one would only
+                // repeat it. The engine's own close/detach still completes —
+                // it consumes the peer's detach that the relay forwarded.
                 #[cfg(feature = "tracing")]
                 tracing::debug!("Suppressing duplicate locally initiated detach");
                 #[cfg(feature = "log")]

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -680,13 +680,18 @@ impl endpoint::Session for Session {
         }
     }
 
-    /// This should only deallocate the output handle
-    fn deallocate_link(&mut self, output_handle: OutputHandle) {
+    /// This should only deallocate the output handle. Returns whether the
+    /// link's bookkeeping was still present (i.e. the detach is the first for
+    /// the link rather than a duplicate).
+    fn deallocate_link(&mut self, output_handle: OutputHandle) -> bool {
         if let Some(name) = self
             .link_name_by_output_handle
             .try_remove(output_handle.0 as usize)
         {
             let _ = self.link_by_name.remove(&name);
+            true
+        } else {
+            false
         }
     }
 
@@ -881,10 +886,7 @@ impl endpoint::Session for Session {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn on_incoming_detach(
-        &mut self,
-        detach: Detach,
-    ) -> Result<Option<SessionFrame>, Self::Error> {
+    async fn on_incoming_detach(&mut self, detach: Detach) -> Result<Option<Detach>, Self::Error> {
         #[cfg(feature = "tracing")]
         tracing::trace!(frame = ?detach);
         #[cfg(feature = "log")]
@@ -904,19 +906,13 @@ impl endpoint::Session for Session {
                 let remote_initiated = !self.close_pending.remove(&output_handle);
 
                 // The relay forwards the raw detach into the link engine and,
-                // for a remote-initiated detach, returns the response frame to
-                // send to the peer.
+                // for a remote-initiated detach, returns the response detach to
+                // send to the peer. The response flows out through
+                // `on_outgoing_detach` (with `expects_echo = false`), which
+                // releases the link bookkeeping.
                 let response = link.on_incoming_detach(detach, remote_initiated).await;
 
-                if remote_initiated {
-                    // The relay's response detach bypasses `on_outgoing_detach`,
-                    // so the link bookkeeping is deallocated here.
-                    self.deallocate_link(output_handle);
-                }
-
-                Ok(response.map(|detach| {
-                    SessionFrame::new(self.outgoing_channel, SessionFrameBody::Detach(detach))
-                }))
+                Ok(response)
             }
             None => {
                 // The link is no longer registered. This can happen when both
@@ -1159,14 +1155,42 @@ impl endpoint::Session for Session {
         Ok(frame)
     }
 
-    fn on_outgoing_detach(&mut self, detach: Detach) -> SessionFrame {
-        // Our own outgoing detach: record the link as awaiting the peer's
-        // response detach, so an incoming detach on it can be recognized as
-        // such rather than a remote-initiated one.
-        self.close_pending.insert(detach.handle.clone().into());
-        self.deallocate_link(detach.handle.clone().into());
+    /// The single outbound path for detach frames.
+    ///
+    /// The link bookkeeping (name and output handle) is released here for
+    /// both a locally initiated detach and the relay's reply to a
+    /// remote-initiated detach.
+    ///
+    /// `expects_echo` marks a locally initiated detach (engine-written
+    /// close/detach/drop/attach-error): the peer's response detach is
+    /// expected, so the output handle is recorded in `close_pending` to
+    /// recognize the echo. The relay's reply passes `false` — the peer sends
+    /// nothing back, and recording an entry it could never remove would let a
+    /// later detach on a recycled handle be misclassified as our own echo,
+    /// silencing the relay on a genuine peer close.
+    ///
+    /// Returns `None` (nothing is sent) when a locally initiated detach is a
+    /// duplicate: the bookkeeping is already gone because the relay answered
+    /// the remote's detach first, in which case the engine's own handshake
+    /// completes locally on the forwarded remote detach.
+    fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame> {
+        let deallocated = self.deallocate_link(detach.handle.clone().into());
+        if expects_echo {
+            if !deallocated {
+                // A duplicate locally initiated detach: the relay already
+                // answered the remote-initiated detach for this link, so the
+                // engine's own close/detach handshake completes locally on the
+                // forwarded detach and nothing more is sent to the peer.
+                #[cfg(feature = "tracing")]
+                tracing::debug!("Suppressing duplicate locally initiated detach");
+                #[cfg(feature = "log")]
+                log::debug!("Suppressing duplicate locally initiated detach");
+                return None;
+            }
+            self.close_pending.insert(detach.handle.clone().into());
+        }
         let body = SessionFrameBody::Detach(detach);
-        SessionFrame::new(self.outgoing_channel, body)
+        Some(SessionFrame::new(self.outgoing_channel, body))
     }
 }
 

--- a/fe2o3-amqp/src/session/mod.rs
+++ b/fe2o3-amqp/src/session/mod.rs
@@ -1,7 +1,7 @@
 //! Implements AMQP1.0 Session
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, OnceLock},
 };
 
@@ -365,6 +365,9 @@ pub struct Session {
     pub(crate) link_name_by_output_handle: Slab<String>,
     pub(crate) link_by_name: HashMap<String, Option<LinkRelay<OutputHandle>>>,
     pub(crate) link_by_input_handle: HashMap<InputHandle, LinkRelay<OutputHandle>>,
+    // Output handles of links with an in-flight locally initiated
+    // detach/close, awaiting the peer's response detach
+    pub(crate) close_pending: HashSet<OutputHandle>,
     // Maps from DeliveryId to link.DeliveryCount
     pub(crate) delivery_tag_by_id: HashMap<(Role, DeliveryNumber), (InputHandle, DeliveryTag)>, // Role must be the remote peer's role
 }
@@ -878,7 +881,10 @@ impl endpoint::Session for Session {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::Error> {
+    async fn on_incoming_detach(
+        &mut self,
+        detach: Detach,
+    ) -> Result<Option<SessionFrame>, Self::Error> {
         #[cfg(feature = "tracing")]
         tracing::trace!(frame = ?detach);
         #[cfg(feature = "log")]
@@ -889,19 +895,46 @@ impl endpoint::Session for Session {
             .remove(&InputHandle::from(detach.handle.clone()))
         {
             Some(mut link) => {
-                // The link endpoint may already have been dropped without an explicit
-                // close handshake (e.g. a `Sender`/`Receiver` that was simply dropped).
-                // In that case the frame cannot be forwarded and the detach reply is
-                // discarded; this must not tear down the session.
-                if let Err(_error) = link.on_incoming_detach(detach).await {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!(error = ?_error);
-                    #[cfg(feature = "log")]
-                    log::error!("error = {:?}", _error);
+                let output_handle = match &link {
+                    LinkRelay::Sender { output_handle, .. }
+                    | LinkRelay::Receiver { output_handle, .. } => output_handle.clone(),
+                };
+                // An incoming detach is the response to our own detach/close iff
+                // we have an in-flight locally initiated detach on the link.
+                let remote_initiated = !self.close_pending.remove(&output_handle);
+
+                // The relay forwards the raw detach into the link engine and,
+                // for a remote-initiated detach, returns the response frame to
+                // send to the peer.
+                let response = link.on_incoming_detach(detach, remote_initiated).await;
+
+                if remote_initiated {
+                    // The relay's response detach bypasses `on_outgoing_detach`,
+                    // so the link bookkeeping is deallocated here.
+                    self.deallocate_link(output_handle);
                 }
-                Ok(())
+
+                Ok(response.map(|detach| {
+                    SessionFrame::new(self.outgoing_channel, SessionFrameBody::Detach(detach))
+                }))
             }
-            None => Err(SessionInnerError::UnattachedHandle),
+            None => {
+                // The link is no longer registered. This can happen when both
+                // sides close the link concurrently and our response to the
+                // remote's first detach has already removed the link, yet the
+                // remote still processes the detach we sent for our own
+                // locally initiated close and echoes a detach back. The second
+                // detach is for a handle that is already gone, so it is
+                // dropped rather than tearing down the session.
+                #[cfg(feature = "tracing")]
+                tracing::trace!(frame = ?detach, "incoming detach for an unattached handle is ignored");
+                #[cfg(feature = "log")]
+                log::trace!(
+                    "incoming detach for an unattached handle is ignored: {:?}",
+                    detach
+                );
+                Ok(None)
+            }
         }
     }
 
@@ -1127,6 +1160,10 @@ impl endpoint::Session for Session {
     }
 
     fn on_outgoing_detach(&mut self, detach: Detach) -> SessionFrame {
+        // Our own outgoing detach: record the link as awaiting the peer's
+        // response detach, so an incoming detach on it can be recognized as
+        // such rather than a remote-initiated one.
+        self.close_pending.insert(detach.handle.clone().into());
         self.deallocate_link(detach.handle.clone().into());
         let body = SessionFrameBody::Detach(detach);
         SessionFrame::new(self.outgoing_channel, body)

--- a/fe2o3-amqp/src/transaction/controller.rs
+++ b/fe2o3-amqp/src/transaction/controller.rs
@@ -48,7 +48,7 @@ pub struct Controller {
 async fn send_on_control_link<T>(
     sender: &mut SenderInner<ControlLink>,
     sendable: Sendable<T>,
-) -> Result<oneshot::Receiver<Option<DeliveryState>>, link::SendError>
+) -> Result<oneshot::Receiver<Result<Option<DeliveryState>, LinkStateError>>, link::SendError>
 where
     T: SerializableBody,
 {
@@ -79,13 +79,15 @@ pub(crate) async fn declare_on_link(
     // the outcome of the declare from the receiver
     let sendable = Sendable::builder().message(message).settled(false).build();
 
-    send_on_control_link(inner, sendable)
+    let outcome = send_on_control_link(inner, sendable)
         .await?
         .await
         .map_err(|_| match inner.link.session_stop_reason.get() {
             Some(reason) => LinkStateError::SessionStopped(reason.clone()),
             None => LinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
-        })?
+        })?;
+    let outcome = outcome?;
+    outcome
         .ok_or(ControllerSendError::NonTerminalDeliveryState)?
         .declared_or_else(|state| {
             if let DeliveryState::Rejected(rejected) = state {
@@ -110,13 +112,15 @@ pub(crate) async fn discharge_on_link(
     let message = Message::builder().value(discharge).build();
     let sendable = Sendable::builder().message(message).settled(false).build();
 
-    send_on_control_link(inner, sendable)
+    let outcome = send_on_control_link(inner, sendable)
         .await?
         .await
         .map_err(|_| match inner.link.session_stop_reason.get() {
             Some(reason) => LinkStateError::SessionStopped(reason.clone()),
             None => LinkStateError::IllegalState, // defensive: no stop reason recorded; failure is link-local
-        })?
+        })?;
+    let outcome = outcome?;
+    outcome
         .ok_or(ControllerSendError::NonTerminalDeliveryState)?
         .accepted_or_else(|state| {
             if let DeliveryState::Rejected(rejected) = state {

--- a/fe2o3-amqp/src/transaction/error.rs
+++ b/fe2o3-amqp/src/transaction/error.rs
@@ -302,4 +302,40 @@ impl FromDeliveryFailure for PostResult {
     fn from_session_stop_reason(reason: SessionStopReason) -> Self {
         Err(PostError::LinkStateError(LinkStateError::SessionStopped(reason)))
     }
+
+    fn from_link_state_error(error: LinkStateError) -> Self {
+        Err(PostError::LinkStateError(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fe2o3_amqp_types::definitions;
+
+    use super::{FromDeliveryFailure, LinkStateError, PostError, PostResult};
+
+    #[test]
+    fn test_post_result_from_link_state_error() {
+        let result =
+            <PostResult as FromDeliveryFailure>::from_link_state_error(LinkStateError::RemoteClosed);
+        match result {
+            Err(PostError::LinkStateError(LinkStateError::RemoteClosed)) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
+
+        let error = definitions::Error::new(
+            definitions::ConnectionError::ConnectionForced,
+            Some("remote closed".to_string()),
+            None,
+        );
+        let result = <PostResult as FromDeliveryFailure>::from_link_state_error(
+            LinkStateError::RemoteClosedWithError(error.clone()),
+        );
+        match result {
+            Err(PostError::LinkStateError(LinkStateError::RemoteClosedWithError(actual))) => {
+                assert_eq!(actual, error);
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
 }

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -766,11 +766,11 @@ pub(crate) fn rollback_on_drop(
                     // A link-state error was delivered through the channel
                     // (e.g. the remote closed the control link): the discharge
                     // outcome will not arrive, so give up waiting.
-                    Ok(Err(error)) => {
+                    Ok(Err(_error)) => {
                         #[cfg(feature = "tracing")]
-                        tracing::error!(error = ?error);
+                        tracing::error!(error = ?_error);
                         #[cfg(feature = "log")]
-                        log::error!("error = {:?}", error);
+                        log::error!("error = {:?}", _error);
                         return;
                     }
                     Err(_error) => {

--- a/fe2o3-amqp/src/transaction/mod.rs
+++ b/fe2o3-amqp/src/transaction/mod.rs
@@ -748,7 +748,7 @@ pub(crate) fn rollback_on_drop(
                 counter += 1;
 
                 match rx.try_recv() {
-                    Ok(Some(state)) => match state {
+                    Ok(Ok(Some(state))) => match state {
                         DeliveryState::Accepted(_) => break,
                         _ => {
                             #[cfg(feature = "tracing")]
@@ -758,10 +758,20 @@ pub(crate) fn rollback_on_drop(
                             break;
                         }
                     },
-                    Ok(None) => {
+                    Ok(Ok(None)) => {
                         std::thread::sleep(std::time::Duration::from_millis(
                             (10 * counter + 1) as u64,
                         ));
+                    }
+                    // A link-state error was delivered through the channel
+                    // (e.g. the remote closed the control link): the discharge
+                    // outcome will not arrive, so give up waiting.
+                    Ok(Err(error)) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!(error = ?error);
+                        #[cfg(feature = "log")]
+                        log::error!("error = {:?}", error);
+                        return;
                     }
                     Err(_error) => {
                         #[cfg(feature = "tracing")]

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -352,7 +352,10 @@ where
         }
     }
 
-    async fn on_incoming_detach(&mut self, detach: Detach) -> Result<(), Self::Error> {
+    async fn on_incoming_detach(
+        &mut self,
+        detach: Detach,
+    ) -> Result<Option<SessionFrame>, Self::Error> {
         self.session.on_incoming_detach(detach).await
     }
 

--- a/fe2o3-amqp/src/transaction/session.rs
+++ b/fe2o3-amqp/src/transaction/session.rs
@@ -273,7 +273,7 @@ where
             .allocate_incoming_link(link_name, link_relay, input_handle)
     }
 
-    fn deallocate_link(&mut self, output_handle: OutputHandle) {
+    fn deallocate_link(&mut self, output_handle: OutputHandle) -> bool {
         self.session.deallocate_link(output_handle)
     }
 
@@ -355,7 +355,7 @@ where
     async fn on_incoming_detach(
         &mut self,
         detach: Detach,
-    ) -> Result<Option<SessionFrame>, Self::Error> {
+    ) -> Result<Option<Detach>, Self::Error> {
         self.session.on_incoming_detach(detach).await
     }
 
@@ -413,7 +413,7 @@ where
         self.session.on_outgoing_disposition(disposition)
     }
 
-    fn on_outgoing_detach(&mut self, detach: Detach) -> SessionFrame {
-        self.session.on_outgoing_detach(detach)
+    fn on_outgoing_detach(&mut self, detach: Detach, expects_echo: bool) -> Option<SessionFrame> {
+        self.session.on_outgoing_detach(detach, expects_echo)
     }
 }

--- a/fe2o3-amqp/tests/link_stop_reason.rs
+++ b/fe2o3-amqp/tests/link_stop_reason.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 use fe2o3_amqp::{
     acceptor::{
-        ConnectionAcceptor, LinkAcceptor, ListenerConnectionHandle, ListenerSessionHandle,
-        SessionAcceptor,
+        ConnectionAcceptor, LinkAcceptor, LinkEndpoint, ListenerConnectionHandle,
+        ListenerSessionHandle, SessionAcceptor,
     },
     connection::{Connection, ConnectionHandle, ConnectionStopReason},
     link::{LinkStateError, RecvError, SendError, SenderAttachError, SessionStopReason},
@@ -69,11 +69,17 @@ async fn establish_session_pair(
 }
 
 /// Attach a client sender link, with the listener accepting it concurrently.
+///
+/// The listener-side receiver is returned so the test controls when that end
+/// of the link is torn down: dropping it before the teardown under test would
+/// race a closing detach ahead of the session/connection stop, and the link
+/// operation would then report the detach outcome (the detach was the event
+/// that actually ended the link) instead of the stop reason.
 async fn attach_sender(
     client_session: &mut SessionHandle<()>,
     listener_session: &mut ListenerSessionHandle,
     name: &str,
-) -> Sender {
+) -> (Sender, Receiver) {
     let link_acceptor = LinkAcceptor::new();
     let attach_fut = common::expect_ok!(Sender::builder()
         .name(name)
@@ -82,16 +88,22 @@ async fn attach_sender(
         .attach(client_session));
     let (link_result, attach_result) =
         tokio::join!(link_acceptor.accept(listener_session), attach_fut);
-    let _server_receiver = link_result.expect("link accept failed");
-    attach_result
+    let server_receiver = match link_result.expect("link accept failed") {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+    (attach_result, server_receiver)
 }
 
 /// Attach a client receiver link, with the listener accepting it concurrently.
+///
+/// The listener-side sender is returned so the test controls when that end of
+/// the link is torn down (see [`attach_sender`]).
 async fn attach_receiver(
     client_session: &mut SessionHandle<()>,
     listener_session: &mut ListenerSessionHandle,
     name: &str,
-) -> Receiver {
+) -> (Receiver, Sender) {
     let link_acceptor = LinkAcceptor::new();
     let attach_fut = common::expect_ok!(Receiver::builder()
         .name(name)
@@ -100,8 +112,11 @@ async fn attach_receiver(
         .attach(client_session));
     let (link_result, attach_result) =
         tokio::join!(link_acceptor.accept(listener_session), attach_fut);
-    let _server_sender = link_result.expect("link accept failed");
-    attach_result
+    let server_sender = match link_result.expect("link accept failed") {
+        LinkEndpoint::Sender(sender) => sender,
+        other => panic!("expected sender endpoint, got {:?}", other),
+    };
+    (attach_result, server_sender)
 }
 
 /// Sends until the teardown has propagated and the send surfaces the expected
@@ -141,7 +156,8 @@ async fn link_send_surfaces_connection_closed() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     drop(client_connection);
 
@@ -159,7 +175,8 @@ async fn link_send_surfaces_session_ended() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     drop(client_session);
 
@@ -173,7 +190,7 @@ async fn link_recv_surfaces_connection_closed() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut receiver =
+    let (mut receiver, _listener_sender) =
         attach_receiver(&mut client_session, &mut listener_session, "receiver-1").await;
 
     drop(server_connection);
@@ -197,7 +214,7 @@ async fn link_recv_surfaces_session_ended() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut receiver =
+    let (mut receiver, _listener_sender) =
         attach_receiver(&mut client_session, &mut listener_session, "receiver-1").await;
 
     drop(listener_session);
@@ -250,7 +267,8 @@ async fn link_send_surfaces_local_end_with_error() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     let error = test_error();
     client_session
@@ -268,7 +286,8 @@ async fn link_send_surfaces_remote_end_with_error() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     let error = test_error();
     listener_session
@@ -285,7 +304,8 @@ async fn link_send_surfaces_remote_end() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     drop(listener_session);
 
@@ -300,7 +320,8 @@ async fn link_send_surfaces_local_close_with_error() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     let error = test_error();
     client_connection
@@ -322,7 +343,8 @@ async fn link_send_surfaces_remote_close_with_error() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut client_session, mut listener_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let mut sender = attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
+    let (mut sender, _listener_receiver) =
+        attach_sender(&mut client_session, &mut listener_session, "sender-1").await;
 
     let error = test_error();
     server_connection

--- a/fe2o3-amqp/tests/relay_remote_detach.rs
+++ b/fe2o3-amqp/tests/relay_remote_detach.rs
@@ -94,12 +94,8 @@ async fn pending_delivery_failed_by_close_echo_after_sender_dropped_without_clos
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut listener_session, mut client_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let (mut sender, _receiver) = establish_link_pair(
-        &mut listener_session,
-        &mut client_session,
-        "sender-drop-1",
-    )
-    .await;
+    let (mut sender, _receiver) =
+        establish_link_pair(&mut listener_session, &mut client_session, "sender-drop-1").await;
 
     let delivery = sender
         .send_batchable(Sendable::builder().message("hello").build())
@@ -120,10 +116,7 @@ async fn pending_delivery_failed_by_close_echo_after_sender_dropped_without_clos
     }
 
     // The session is still healthy: it must end cleanly.
-    client_session
-        .end()
-        .await
-        .expect("session end failed");
+    client_session.end().await.expect("session end failed");
     client_connection.close().await.expect("close failed");
 }
 
@@ -137,12 +130,8 @@ async fn remote_link_close_fails_pending_delivery_and_session_survives() {
     let (mut server_connection, mut client_connection) = establish_connection_pair().await;
     let (mut listener_session, mut client_session) =
         establish_session_pair(&mut server_connection, &mut client_connection).await;
-    let (mut sender, receiver) = establish_link_pair(
-        &mut listener_session,
-        &mut client_session,
-        "remote-close-1",
-    )
-    .await;
+    let (mut sender, receiver) =
+        establish_link_pair(&mut listener_session, &mut client_session, "remote-close-1").await;
 
     let delivery = sender
         .send_batchable(Sendable::builder().message("hello").build())
@@ -167,12 +156,8 @@ async fn remote_link_close_fails_pending_delivery_and_session_survives() {
     drop(sender);
 
     // The sessions must still be healthy: a fresh link pair round trips.
-    let (mut sender2, mut receiver2) = establish_link_pair(
-        &mut listener_session,
-        &mut client_session,
-        "remote-close-2",
-    )
-    .await;
+    let (mut sender2, mut receiver2) =
+        establish_link_pair(&mut listener_session, &mut client_session, "remote-close-2").await;
 
     let message = Message::from("still-alive");
     let send_task = tokio::spawn(async move {

--- a/fe2o3-amqp/tests/relay_remote_detach.rs
+++ b/fe2o3-amqp/tests/relay_remote_detach.rs
@@ -5,8 +5,10 @@
 //!   (the link engine never writes a response), and the relay fails the
 //!   deliveries that are still pending on the link;
 //! - dropping a sender link without a clean close leaves its pending
-//!   deliveries unresolved (they are still settled by the peer's dispositions
-//!   through the relay) unless the delivery can no longer be settled.
+//!   deliveries to the peer's settlement, and the peer's close response fails
+//!   the stranded ones when the engine is gone;
+//! - `Sender::on_detach` observes a remote close in the terminal state, so a
+//!   subsequent `close()` is clean.
 //!
 //! These run over an in-memory `tokio::io::duplex` stream, so no broker or
 //! network is required.
@@ -20,7 +22,7 @@ use fe2o3_amqp::{
         ConnectionAcceptor, LinkAcceptor, LinkEndpoint, ListenerSessionHandle, SessionAcceptor,
     },
     connection::{Connection, ConnectionHandle},
-    link::{LinkStateError, SendError},
+    link::{DetachError, LinkStateError, SendError},
     session::{Session, SessionHandle},
     types::messaging::Message,
     Sendable, Sender,
@@ -158,6 +160,59 @@ async fn remote_link_close_fails_pending_delivery_and_session_survives() {
     // The sessions must still be healthy: a fresh link pair round trips.
     let (mut sender2, mut receiver2) =
         establish_link_pair(&mut listener_session, &mut client_session, "remote-close-2").await;
+
+    let message = Message::from("still-alive");
+    let send_task = tokio::spawn(async move {
+        let outcome = sender2.send(message).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        sender2.close().await.unwrap();
+    });
+
+    let received = tokio::time::timeout(Duration::from_secs(10), receiver2.recv::<String>())
+        .await
+        .expect("timed out waiting for message")
+        .expect("recv failed");
+    receiver2.accept(&received).await.unwrap();
+    assert_eq!(received.body(), "still-alive");
+    receiver2.close().await.unwrap();
+    send_task.await.unwrap();
+
+    client_session.close().await.unwrap();
+    client_connection.close().await.unwrap();
+}
+
+/// `Sender::on_detach` waits for the remote to end the link. The relay has
+/// already answered the remote's closing detach at arrival, so `on_detach`
+/// transitions the link straight to its terminal state and a subsequent
+/// `close()` completes without sending a duplicate closing detach.
+#[tokio::test]
+async fn on_detach_returns_after_remote_close_and_close_is_clean() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let (mut sender, receiver) =
+        establish_link_pair(&mut listener_session, &mut client_session, "on-detach-1").await;
+
+    let close_task = tokio::spawn(async move {
+        receiver.close().await.expect("receiver close failed");
+    });
+
+    let detached = tokio::time::timeout(Duration::from_secs(10), sender.on_detach())
+        .await
+        .expect("on_detach timed out");
+    match detached {
+        DetachError::ClosedByRemote => {}
+        other => panic!("expected ClosedByRemote, got {:?}", other),
+    }
+    close_task.await.unwrap();
+
+    // The link is already in its terminal state, so close() completes cleanly
+    // without writing another detach.
+    sender.close().await.expect("sender close failed");
+
+    // The sessions must still be healthy: a fresh link pair round trips.
+    let (mut sender2, mut receiver2) =
+        establish_link_pair(&mut listener_session, &mut client_session, "on-detach-2").await;
 
     let message = Message::from("still-alive");
     let send_task = tokio::spawn(async move {

--- a/fe2o3-amqp/tests/relay_remote_detach.rs
+++ b/fe2o3-amqp/tests/relay_remote_detach.rs
@@ -1,0 +1,195 @@
+//! Tests of the relay-handled remote link detach/close semantics and of the
+//! link drop (Drop edge) behavior:
+//!
+//! - a remote closing detach is answered by the session relay at arrival time
+//!   (the link engine never writes a response), and the relay fails the
+//!   deliveries that are still pending on the link;
+//! - dropping a sender link without a clean close leaves its pending
+//!   deliveries unresolved (they are still settled by the peer's dispositions
+//!   through the relay) unless the delivery can no longer be settled.
+//!
+//! These run over an in-memory `tokio::io::duplex` stream, so no broker or
+//! network is required.
+
+#![cfg(feature = "acceptor")]
+
+use std::time::Duration;
+
+use fe2o3_amqp::{
+    acceptor::{
+        ConnectionAcceptor, LinkAcceptor, LinkEndpoint, ListenerSessionHandle, SessionAcceptor,
+    },
+    connection::{Connection, ConnectionHandle},
+    link::{LinkStateError, SendError},
+    session::{Session, SessionHandle},
+    types::messaging::Message,
+    Sendable, Sender,
+};
+
+mod common;
+
+async fn establish_connection_pair() -> (
+    fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    ConnectionHandle<()>,
+) {
+    let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+    let acceptor = ConnectionAcceptor::builder()
+        .container_id("test-listener")
+        .build();
+    let connection_task = tokio::spawn(async move { acceptor.accept(server_io).await });
+
+    let client_connection = common::expect_ok!(Connection::builder()
+        .container_id("test-client")
+        .open_with_stream(client_io))
+    .await;
+
+    let server_connection = connection_task
+        .await
+        .expect("connection accept task panicked")
+        .expect("connection accept failed");
+
+    (server_connection, client_connection)
+}
+
+async fn establish_session_pair(
+    server_connection: &mut fe2o3_amqp::acceptor::ListenerConnectionHandle,
+    client_connection: &mut ConnectionHandle<()>,
+) -> (ListenerSessionHandle, SessionHandle<()>) {
+    let session_acceptor = SessionAcceptor::new();
+    let begin_fut = common::expect_ok!(Session::begin(client_connection));
+    let (session_result, begin_result) =
+        tokio::join!(session_acceptor.accept(server_connection), begin_fut);
+    let client_session = begin_result;
+    let listener_session = session_result.expect("session accept failed");
+    (listener_session, client_session)
+}
+
+/// Attach the client sender concurrently with the acceptor accepting the
+/// incoming link, returning both ends.
+async fn establish_link_pair(
+    listener_session: &mut ListenerSessionHandle,
+    client_session: &mut SessionHandle<()>,
+    name: &str,
+) -> (Sender, fe2o3_amqp::Receiver) {
+    let link_acceptor = LinkAcceptor::builder().build();
+    let attach_fut = common::expect_ok!(Sender::attach(client_session, name, "test-queue"));
+    let (accept_result, attach_result) =
+        tokio::join!(link_acceptor.accept(listener_session), attach_fut);
+
+    let sender = attach_result;
+    let receiver = match accept_result.expect("link accept failed") {
+        LinkEndpoint::Receiver(receiver) => receiver,
+        other => panic!("expected receiver endpoint, got {:?}", other),
+    };
+    (sender, receiver)
+}
+
+/// Dropping a sender link without a clean close must not, by itself, fail the
+/// deliveries that are still pending on it. Once the peer's close response
+/// (echo) comes back and finds the link engine gone, the relay fails the
+/// stranded delivery instead of leaving it pending until the teardown.
+#[tokio::test]
+async fn pending_delivery_failed_by_close_echo_after_sender_dropped_without_close() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let (mut sender, _receiver) = establish_link_pair(
+        &mut listener_session,
+        &mut client_session,
+        "sender-drop-1",
+    )
+    .await;
+
+    let delivery = sender
+        .send_batchable(Sendable::builder().message("hello").build())
+        .await
+        .expect("send failed");
+    drop(sender);
+
+    // The drop itself does not touch the pending delivery; the peer's echo of
+    // the drop's closing detach fails it (the engine is gone, so only the
+    // relay can fail it).
+    let result = tokio::time::timeout(Duration::from_secs(10), delivery)
+        .await
+        .expect("delivery did not resolve after the close echo")
+        .expect_err("stranded delivery must fail on the close echo");
+    match result {
+        SendError::LinkStateError(LinkStateError::RemoteClosed) => {}
+        other => panic!("expected RemoteClosed, got {:?}", other),
+    }
+
+    // The session is still healthy: it must end cleanly.
+    client_session
+        .end()
+        .await
+        .expect("session end failed");
+    client_connection.close().await.expect("close failed");
+}
+
+/// A remote-initiated closing detach must fail the deliveries that are still
+/// pending on the link with `RemoteClosed`, even when the link engine never
+/// processes the detach (it is answered by the relay). Dropping the sender
+/// afterwards must not disturb the sessions: a fresh link pair on the same
+/// sessions still works.
+#[tokio::test]
+async fn remote_link_close_fails_pending_delivery_and_session_survives() {
+    let (mut server_connection, mut client_connection) = establish_connection_pair().await;
+    let (mut listener_session, mut client_session) =
+        establish_session_pair(&mut server_connection, &mut client_connection).await;
+    let (mut sender, receiver) = establish_link_pair(
+        &mut listener_session,
+        &mut client_session,
+        "remote-close-1",
+    )
+    .await;
+
+    let delivery = sender
+        .send_batchable(Sendable::builder().message("hello").build())
+        .await
+        .expect("send failed");
+
+    // The remote closes the link while the delivery is still unsettled.
+    receiver.close().await.expect("receiver close failed");
+
+    // The relay fails the pending delivery when answering the closing detach.
+    let result = tokio::time::timeout(Duration::from_secs(10), delivery)
+        .await
+        .expect("delivery did not resolve")
+        .expect_err("pending delivery must fail on remote close");
+    match result {
+        SendError::LinkStateError(LinkStateError::RemoteClosed) => {}
+        other => panic!("expected RemoteClosed, got {:?}", other),
+    }
+
+    // Dropping the sender now must not send a duplicate closing detach or
+    // otherwise disturb the sessions.
+    drop(sender);
+
+    // The sessions must still be healthy: a fresh link pair round trips.
+    let (mut sender2, mut receiver2) = establish_link_pair(
+        &mut listener_session,
+        &mut client_session,
+        "remote-close-2",
+    )
+    .await;
+
+    let message = Message::from("still-alive");
+    let send_task = tokio::spawn(async move {
+        let outcome = sender2.send(message).await.unwrap();
+        outcome.accepted_or("Not accepted").unwrap();
+        sender2.close().await.unwrap();
+    });
+
+    let received = tokio::time::timeout(Duration::from_secs(10), receiver2.recv::<String>())
+        .await
+        .expect("timed out waiting for message")
+        .expect("recv failed");
+    receiver2.accept(&received).await.unwrap();
+    assert_eq!(received.body(), "still-alive");
+    receiver2.close().await.unwrap();
+    send_task.await.unwrap();
+
+    client_session.close().await.unwrap();
+    client_connection.close().await.unwrap();
+}


### PR DESCRIPTION
Remote-initiated detach/close is now answered by the session relay at arrival; link engines never write a response detach. Fixes the peer's close handshake stalling when the engine is idle or the link was already dropped.