### PR TITLE
chore: bump all crates to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ exclude = [
 
 [workspace.dependencies]
 # Local deps
-fe2o3-amqp = { path = "fe2o3-amqp", version = "0.17" }
-fe2o3-amqp-cbs = { path = "fe2o3-amqp-cbs", version = "0.17" }
-fe2o3-amqp-ext = { path = "fe2o3-amqp-ext", version = "0.17" }
-fe2o3-amqp-management = { path = "fe2o3-amqp-management", version = "0.17" }
-fe2o3-amqp-types = { path = "fe2o3-amqp-types", version = "0.17" }
-fe2o3-amqp-ws = { path = "fe2o3-amqp-ws", version = "0.17" }
+fe2o3-amqp = { path = "fe2o3-amqp", version = "0.18" }
+fe2o3-amqp-cbs = { path = "fe2o3-amqp-cbs", version = "0.18" }
+fe2o3-amqp-ext = { path = "fe2o3-amqp-ext", version = "0.18" }
+fe2o3-amqp-management = { path = "fe2o3-amqp-management", version = "0.18" }
+fe2o3-amqp-types = { path = "fe2o3-amqp-types", version = "0.18" }
+fe2o3-amqp-ws = { path = "fe2o3-amqp-ws", version = "0.18" }
 serde_amqp_derive = { path = "serde_amqp_derive", version = "0.3.2" }
-serde_amqp = { path = "serde_amqp", version = "0.17" }
+serde_amqp = { path = "serde_amqp", version = "0.18" }
 
 # External deps
 bytes = "1"

--- a/fe2o3-amqp-cbs/Cargo.toml
+++ b/fe2o3-amqp-cbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-cbs"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 CBS extension"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-cbs/Changelog.md
+++ b/fe2o3-amqp-cbs/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Bumped version to "0.17.0" to track `fe2o3-amqp` 0.17.0. This crate has no

--- a/fe2o3-amqp-ext/Cargo.toml
+++ b/fe2o3-amqp-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ext"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Extension types to fe2o3-amqp"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-ext/Changelog.md
+++ b/fe2o3-amqp-ext/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Bumped version to "0.17.0" to match other `fe2o3-amqp` crates, so that a

--- a/fe2o3-amqp-management/Cargo.toml
+++ b/fe2o3-amqp-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-management"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "An experimental impl of AMQP 1.0 management extension"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-management/Changelog.md
+++ b/fe2o3-amqp-management/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Bumped version to "0.17.0" to track `fe2o3-amqp` 0.17.0. This crate has no

--- a/fe2o3-amqp-types/Cargo.toml
+++ b/fe2o3-amqp-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-types"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Implementation of AMQP1.0 data types"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-types/Changelog.md
+++ b/fe2o3-amqp-types/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Derived `PartialEq` and `Eq` on the performatives (`Open`, `Begin`, `Attach`,

--- a/fe2o3-amqp-ws/Cargo.toml
+++ b/fe2o3-amqp-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp-ws"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "WebSocket binding stream for AMQP1.0"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp-ws/Changelog.md
+++ b/fe2o3-amqp-ws/Changelog.md
@@ -1,5 +1,10 @@
 # fe2o3-amqp-ws
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Updated `tungstenite` and `tokio-tungstenite` from `0.26` to `0.30`.

--- a/fe2o3-amqp/Cargo.toml
+++ b/fe2o3-amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe2o3-amqp"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "An implementation of AMQP1.0 protocol based on serde and tokio"
 license = "MIT/Apache-2.0"

--- a/fe2o3-amqp/Changelog.md
+++ b/fe2o3-amqp/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.18.0
 
 1. **Breaking**: `SendError` and `RecvError` gain a `MessageSizeExceeded` variant: the
    sender rejects oversized messages locally, and the receiver rejects deliveries

--- a/serde_amqp/Cargo.toml
+++ b/serde_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "A serde implementation of AMQP1.0 protocol."
 license = "MIT/Apache-2.0"

--- a/serde_amqp/Changelog.md
+++ b/serde_amqp/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.18.0
+
+1. Bumped the version to "0.18.0" to match the updated `fe2o3-amqp`. This crate has no
+   change.
+
 ## 0.17.0
 
 1. Bumped version to "0.17.0" to match other `fe2o3-amqp` crates, so that a

--- a/serde_amqp_derive/Cargo.toml
+++ b/serde_amqp_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_amqp_derive"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Custom derive macros for serde_amqp"
 license = "MIT/Apache-2.0"

--- a/serde_amqp_derive/Changelog.md
+++ b/serde_amqp_derive/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+1. Updated `convert_case` to `0.12`
+
 ## 0.3.2
 
 1. Updated `convert_case` to `0.11`


### PR DESCRIPTION
Bump fe2o3-amqp, fe2o3-amqp-types, fe2o3-amqp-ext, fe2o3-amqp-cbs, fe2o3-amqp-management, fe2o3-amqp-ws and serde_amqp to 0.18.0, matching the breaking changes in fe2o3-amqp (MessageSizeExceeded enforcement and the max-frame-size split). Crates without source changes since 0.17.0 get a changelog note; fe2o3-amqp's Unreleased section becomes the 0.18.0 release notes.

Also bump serde_amqp_derive 0.3.3 for the merged dependabot convert_case 0.12 update (its workspace version requirement is left unchanged).